### PR TITLE
fix(webapp): keep CDP base64Encoded for playwright-cli response-body

### DIFF
--- a/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
+++ b/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
@@ -279,7 +279,7 @@ playwright-cli request --tab=<id> <index> [--filename=path]                   # 
 playwright-cli request-headers --tab=<id> <index>                             # Request headers only
 playwright-cli request-body --tab=<id> <index>                                # Request body only
 playwright-cli response-headers --tab=<id> <index>                            # Response headers only
-playwright-cli response-body --tab=<id> <index> [--filename=path]             # Response body (saves binary to file)
+playwright-cli response-body --tab=<id> <index> [--filename=path]             # Response body (--filename saves the exact bytes)
 playwright-cli network-state-set --tab=<id> <online|offline>                  # Toggle network state
 playwright-cli route --tab=<id> <pattern> [--status=N] [--body=text] [--content-type=type] [--header=name:value]
 playwright-cli route-list --tab=<id>                                          # List active routes

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/network-requests.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/network-requests.ts
@@ -104,6 +104,7 @@ function ensureCapturing(
       status: null,
       responseHeaders: null,
       responseBody: null,
+      responseBodyBase64: false,
       mimeType: null,
       isStatic: isStaticResource(null, url),
       timestamp: Date.now(),
@@ -148,6 +149,9 @@ function ensureCapturing(
         const r = result as NetworkGetResponseBodyResult | undefined;
         if (!r) return;
         entry.responseBody = r.body ?? null;
+        // Chrome tells us how the body is encoded; keep the flag instead of
+        // guessing from MIME later (matches `cdp/har-recorder.ts`).
+        entry.responseBodyBase64 = r.base64Encoded === true;
       })
       .catch(() => {
         // Body may not be available for all resource types — ignore
@@ -163,6 +167,56 @@ function ensureCapturing(
     transport.off('Network.responseReceived', onResponse);
     transport.off('Network.loadingFinished', onLoadingFinished);
   });
+}
+
+/** Decoded response-body bytes, or the reason the body cannot be decoded. */
+type DecodedBody = { bytes: Uint8Array } | { error: string };
+
+/**
+ * Index of the first unpaired surrogate in `s`, or -1 when the string is
+ * well-formed. `TextEncoder` silently turns those into U+FFFD, which is the
+ * one substitution a saved file must never get.
+ */
+function findLoneSurrogate(s: string): number {
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code < 0xd800 || code > 0xdfff) continue;
+    if (code >= 0xdc00) return i; // trailing surrogate with no lead
+    const next = s.charCodeAt(i + 1);
+    if (Number.isNaN(next) || next < 0xdc00 || next > 0xdfff) return i;
+    i++; // well-formed pair — skip its low half
+  }
+  return -1;
+}
+
+/**
+ * Turn a captured CDP body into the exact bytes Chrome received.
+ *
+ * `Network.getResponseBody` reports its own encoding via `base64Encoded`, so
+ * that flag — never the MIME type — decides how the body is read. A base64
+ * JPEG labelled `text/plain` is still base64; a UTF-8 JSON document labelled
+ * `application/octet-stream` is still text. Anything that cannot be decoded
+ * faithfully is an error, not a best-effort write.
+ */
+function decodeResponseBody(body: string, base64Encoded: boolean): DecodedBody {
+  if (base64Encoded) {
+    let binary: string;
+    try {
+      binary = atob(body);
+    } catch {
+      return { error: 'response body is flagged base64 but is not valid base64' };
+    }
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i) & 0xff;
+    return { bytes };
+  }
+  const lone = findLoneSurrogate(body);
+  if (lone >= 0) {
+    return {
+      error: `response body has an unpaired surrogate at index ${lone} and cannot be saved without substituting U+FFFD`,
+    };
+  }
+  return { bytes: new TextEncoder().encode(body) };
 }
 
 /** Look up an entry by 1-based display index. */
@@ -272,7 +326,10 @@ export const requestHandler: PlaywrightHandler = async ({
   if (entry.responseBody !== null) {
     const body = entry.responseBody;
     const preview = body.length > 4096 ? body.slice(0, 4096) + '\n... (truncated)' : body;
-    parts.push('', `Response Body:\n${preview}`);
+    // Say so when the preview is base64 — `response-body --filename` is what
+    // turns it back into bytes.
+    const label = entry.responseBodyBase64 ? 'Response Body (base64)' : 'Response Body';
+    parts.push('', `${label}:\n${preview}`);
   }
 
   const output = parts.join('\n') + '\n';
@@ -445,6 +502,17 @@ export const responseBodyHandler: PlaywrightHandler = async ({
 
   const filename = flags['filename'];
 
+  const decoded = decodeResponseBody(entry.responseBody, entry.responseBodyBase64);
+  if ('error' in decoded) {
+    return { stdout: '', stderr: `Request ${indexStr}: ${decoded.error}\n`, exitCode: 1 };
+  }
+
+  if (filename) {
+    await fs.writeFile(filename, decoded.bytes);
+    return { stdout: `Saved to ${filename}\n`, stderr: '', exitCode: 0 };
+  }
+
+  // MIME only picks the rendering on stdout — it never touched the bytes above.
   const isBinary =
     entry.mimeType !== null &&
     !entry.mimeType.startsWith('text/') &&
@@ -452,34 +520,13 @@ export const responseBodyHandler: PlaywrightHandler = async ({
     !entry.mimeType.includes('javascript') &&
     !entry.mimeType.includes('xml');
 
-  if (filename) {
-    if (isBinary) {
-      try {
-        const binary = atob(entry.responseBody);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) {
-          bytes[i] = binary.charCodeAt(i);
-        }
-        await fs.writeFile(filename, bytes);
-      } catch {
-        await fs.writeFile(filename, entry.responseBody);
-      }
-    } else {
-      await fs.writeFile(filename, entry.responseBody);
-    }
-    return { stdout: `Saved to ${filename}\n`, stderr: '', exitCode: 0 };
-  }
-
   if (isBinary) {
-    try {
-      const byteLength = atob(entry.responseBody).length;
-      return { stdout: `[binary body, ${byteLength} bytes]\n`, stderr: '', exitCode: 0 };
-    } catch {
-      // Fall through and show raw
-    }
+    return { stdout: `[binary body, ${decoded.bytes.length} bytes]\n`, stderr: '', exitCode: 0 };
   }
 
-  const body = entry.responseBody;
+  const body = entry.responseBodyBase64
+    ? new TextDecoder().decode(decoded.bytes)
+    : entry.responseBody;
   const preview = body.length > 4096 ? body.slice(0, 4096) + '\n... (truncated)' : body;
   return { stdout: preview + '\n', stderr: '', exitCode: 0 };
 };

--- a/packages/webapp/src/shell/supplemental-commands/playwright/help.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/help.ts
@@ -152,7 +152,8 @@ Commands:
   response-headers <index> --tab=<id> [--filename=<path>]
                          Show response headers only.
   response-body <index> --tab=<id> [--filename=<path>]
-                         Show response body only. Binary bodies shown as [binary body, N bytes].
+                         Show response body only. Binary bodies shown as [binary body, N bytes];
+                         --filename writes the response bytes exactly as Chrome sent them.
   mousemove <x> <y> --tab=<id> Move mouse to coordinates
   mousedown [button] --tab=<id> Press mouse button (left/right/middle, default: left)
   mouseup [button] --tab=<id>  Release mouse button (left/right/middle, default: left)

--- a/packages/webapp/src/shell/supplemental-commands/playwright/types.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/types.ts
@@ -99,6 +99,11 @@ export interface NetworkEntry {
   status: number | null;
   responseHeaders: Record<string, string> | null;
   responseBody: string | null;
+  /**
+   * Whether `responseBody` is base64 (CDP `Network.getResponseBody.base64Encoded`).
+   * Kept verbatim from the CDP result — MIME type never decides the encoding.
+   */
+  responseBodyBase64: boolean;
   mimeType: string | null;
   isStatic: boolean;
   timestamp: number;

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -5320,7 +5320,13 @@ describe('playwright-cli requests', () => {
     );
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Saved to /tmp/body.txt');
-    expect(fs.writeFile).toHaveBeenCalledWith('/tmp/body.txt', expect.any(String));
+    // Bodies are written as bytes — the CDP `base64Encoded` flag decides how
+    // they are decoded, never the MIME type.
+    expect(fs.writeFile).toHaveBeenCalledWith('/tmp/body.txt', expect.any(Uint8Array));
+    const bodyWrite = (fs.writeFile as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) => call[0] === '/tmp/body.txt'
+    );
+    expect(new TextDecoder().decode(bodyWrite?.[1] as Uint8Array)).toBe('hello world');
   });
 
   it('tab-close removes network subscription', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/network-requests.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/network-requests.test.ts
@@ -32,11 +32,17 @@ function makeEntry(over: Partial<NetworkEntry> = {}): NetworkEntry {
     status: 200,
     responseHeaders: { 'content-type': 'application/json' },
     responseBody: null,
+    responseBodyBase64: false,
     mimeType: 'application/json',
     isStatic: false,
     timestamp: 0,
     ...over,
   };
+}
+
+/** A `writeFile` spy whose recorded arguments stay typed for byte assertions. */
+function mockWriteFile() {
+  return vi.fn(async (_path: string, _data: string | Uint8Array) => undefined);
 }
 
 /** Seed a state that already has captured entries (capture branch skipped). */
@@ -58,7 +64,7 @@ describe('network-requests handlers', () => {
 
   it('captures requests, responses, and bodies through the CDP event pipeline', async () => {
     const transport = createMockTransport((method) =>
-      method === 'Network.getResponseBody' ? { body: 'PAYLOAD' } : {}
+      method === 'Network.getResponseBody' ? { body: 'PAYLOAD', base64Encoded: false } : {}
     );
     const { browser } = createMockBrowser({ transport, sessionId: 'session-1' });
     const state = createPlaywrightState();
@@ -87,6 +93,7 @@ describe('network-requests handlers', () => {
     expect(listed.stdout).toContain('1 POST https://example.com/data → 201');
     const entry = state.networkRequests.get(TAB)![0];
     expect(entry.responseBody).toBe('PAYLOAD');
+    expect(entry.responseBodyBase64).toBe(false);
   });
 
   it('ignores events from a different session', async () => {
@@ -159,7 +166,7 @@ describe('network-requests handlers', () => {
   });
 
   it('request saves to a file when --filename is given', async () => {
-    const writeFile = vi.fn(async () => undefined);
+    const writeFile = mockWriteFile();
     const state = seeded([makeEntry()]);
     const result = await requestHandler(
       createHandlerCtx({
@@ -239,7 +246,13 @@ describe('network-requests handlers', () => {
 
     const binary = await responseBodyHandler(
       createHandlerCtx({
-        state: seeded([makeEntry({ responseBody: btoa('abc'), mimeType: 'image/png' })]),
+        state: seeded([
+          makeEntry({
+            responseBody: btoa('abc'),
+            responseBodyBase64: true,
+            mimeType: 'image/png',
+          }),
+        ]),
         positional: ['1'],
         flags: { tab: TAB },
       })
@@ -248,8 +261,10 @@ describe('network-requests handlers', () => {
   });
 
   it('response-body decodes binary bytes when saving to a file', async () => {
-    const writeFile = vi.fn(async () => undefined);
-    const state = seeded([makeEntry({ responseBody: btoa('abc'), mimeType: 'image/png' })]);
+    const writeFile = mockWriteFile();
+    const state = seeded([
+      makeEntry({ responseBody: btoa('abc'), responseBodyBase64: true, mimeType: 'image/png' }),
+    ]);
     const result = await responseBodyHandler(
       createHandlerCtx({
         state,
@@ -262,6 +277,182 @@ describe('network-requests handlers', () => {
     expect(writeFile).toHaveBeenCalledWith('/img.png', expect.any(Uint8Array));
   });
 
+  it('keeps the CDP base64Encoded flag on capture', async () => {
+    const transport = createMockTransport((method) =>
+      method === 'Network.getResponseBody' ? { body: btoa('abc'), base64Encoded: true } : {}
+    );
+    const { browser } = createMockBrowser({ transport, sessionId: 'session-1' });
+    const state = createPlaywrightState();
+    const ctx = createHandlerCtx({ browser, state, flags: { tab: TAB } });
+    await requestsHandler(ctx);
+
+    await transport.emit('Network.requestWillBeSent', {
+      sessionId: 'session-1',
+      requestId: 'r1',
+      request: { url: 'https://example.com/blob', method: 'GET', headers: {} },
+    });
+    await transport.emit('Network.responseReceived', {
+      sessionId: 'session-1',
+      requestId: 'r1',
+      response: { status: 200, headers: {}, mimeType: 'application/octet-stream' },
+    });
+    await transport.emit('Network.loadingFinished', { sessionId: 'session-1', requestId: 'r1' });
+
+    const entry = state.networkRequests.get(TAB)![0];
+    expect(entry.responseBodyBase64).toBe(true);
+  });
+
+  it('response-body --filename writes base64 bodies byte-for-byte', async () => {
+    // Every byte value, the fixture a UTF-8 hop expands and `atob` cannot fake.
+    const original = new Uint8Array(256).map((_, i) => i);
+    const latin1 = String.fromCharCode(...original);
+    const writeFile = mockWriteFile();
+    const state = seeded([
+      makeEntry({
+        responseBody: btoa(latin1),
+        responseBodyBase64: true,
+        mimeType: 'image/jpeg',
+      }),
+    ]);
+    const result = await responseBodyHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/out.bin' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(result.exitCode).toBe(0);
+    const written = writeFile.mock.calls[0][1] as unknown as Uint8Array;
+    expect(written).toBeInstanceOf(Uint8Array);
+    expect(written.length).toBe(256);
+    expect(Array.from(written)).toEqual(Array.from(original));
+  });
+
+  it('response-body --filename trusts the flag over the MIME type', async () => {
+    // Chrome base64s bodies it cannot decode as text whatever the label says;
+    // the old MIME heuristic wrote the base64 alphabet to the file instead.
+    const writeFile = mockWriteFile();
+    const state = seeded([
+      makeEntry({
+        responseBody: btoa('\x00\x01\x02binary'),
+        responseBodyBase64: true,
+        mimeType: 'text/plain',
+      }),
+    ]);
+    await responseBodyHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/out.bin' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    const written = writeFile.mock.calls[0][1] as unknown as Uint8Array;
+    expect(Array.from(written)).toEqual([
+      0,
+      1,
+      2,
+      ...Array.from(new TextEncoder().encode('binary')),
+    ]);
+  });
+
+  it('response-body --filename writes text bodies as UTF-8 text', async () => {
+    const writeFile = mockWriteFile();
+    const body = '{"hé":"ok 😀"}';
+    const state = seeded([
+      makeEntry({ responseBody: body, responseBodyBase64: false, mimeType: 'application/json' }),
+    ]);
+    await responseBodyHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/out.json' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    const written = writeFile.mock.calls[0][1] as unknown as Uint8Array;
+    expect(new TextDecoder().decode(written)).toBe(body);
+  });
+
+  it('response-body --filename does not base64-decode an unflagged binary-looking body', async () => {
+    // `base64Encoded: false` means Chrome handed us text — the label is not a
+    // licence to run `atob` over it (the old path wrote garbage or the string).
+    const latin1 = String.fromCharCode(...new Uint8Array(256).map((_, i) => i));
+    const writeFile = mockWriteFile();
+    const state = seeded([
+      makeEntry({ responseBody: latin1, responseBodyBase64: false, mimeType: 'image/jpeg' }),
+    ]);
+    const result = await responseBodyHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/out.bin' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(result.exitCode).toBe(0);
+    const written = writeFile.mock.calls[0][1] as unknown as Uint8Array;
+    expect(Array.from(written)).toEqual(Array.from(new TextEncoder().encode(latin1)));
+  });
+
+  it('response-body fails instead of writing U+FFFD for an unpaired surrogate', async () => {
+    const writeFile = mockWriteFile();
+    const state = seeded([
+      makeEntry({
+        responseBody: `head\uD800tail`,
+        responseBodyBase64: false,
+        mimeType: 'text/plain',
+      }),
+    ]);
+    const result = await responseBodyHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/out.txt' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unpaired surrogate');
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('response-body fails when a base64-flagged body is not valid base64', async () => {
+    const writeFile = mockWriteFile();
+    const state = seeded([
+      makeEntry({ responseBody: 'not base64!!', responseBodyBase64: true, mimeType: 'image/png' }),
+    ]);
+    const result = await responseBodyHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/out.png' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('not valid base64');
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('response-body prints a base64 text body as text, not the base64 alphabet', async () => {
+    const result = await responseBodyHandler(
+      createHandlerCtx({
+        state: seeded([
+          makeEntry({
+            responseBody: btoa('hello'),
+            responseBodyBase64: true,
+            mimeType: 'text/plain',
+          }),
+        ]),
+        positional: ['1'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.stdout).toBe('hello\n');
+  });
+
   it('the header/body detail handlers all honor --filename', async () => {
     const cases: Array<[typeof requestHeadersHandler, NetworkEntry]> = [
       [requestHeadersHandler, makeEntry()],
@@ -270,7 +461,7 @@ describe('network-requests handlers', () => {
       [responseBodyHandler, makeEntry({ responseBody: 'text', mimeType: 'text/plain' })],
     ];
     for (const [handler, entry] of cases) {
-      const writeFile = vi.fn(async () => undefined);
+      const writeFile = mockWriteFile();
       const result = await handler(
         createHandlerCtx({
           state: seeded([entry]),


### PR DESCRIPTION
## Summary

`playwright-cli response-body <index> --filename=<path>` threw away CDP's `Network.getResponseBody.base64Encoded` at capture time and re-derived the encoding from the MIME type on save — `atob` when the type "looked binary", otherwise `VirtualFS.writeFile(string)`, which UTF-8-encodes. A captured JPEG/zip/mp4 could be written expanded, and a base64 body labelled `text/plain` was written as the base64 alphabet, both with exit 0. Capture now keeps the flag on the ring-buffer entry (matching `cdp/har-recorder.ts`) and the flag alone decides how the body is decoded; a body that cannot be reconstructed faithfully exits 1 instead of writing a corrupt file.

## Why

Closes #2887 — the download-side sibling of #2878 (upload) and #2883 (`drop --path`). `response-body --filename` is how an agent saves a downloaded mp4/zip/PDF out of a tab, so the failure is silent: exit 0, corrupt file, and the next `ffprobe`/unzip is what breaks.

**Repro** (the four rows of the issue's table)

| CDP `base64Encoded` | MIME | before | now |
|---|---|---|---|
| `true` | binary-looking | `atob` → bytes ✅ | bytes ✅ |
| `true` | `text/plain` / `json` / missing | writes the **base64 alphabet** | bytes ✅ |
| `false` | binary-looking | `atob` throws → writes the string UTF-8-expanded | UTF-8 text bytes ✅ |
| `true`, corrupt payload | any | silently wrote something | exit 1, nothing written |

Expected: `--filename` writes exactly what Chrome received. Actual (before): a 256-byte `0x00..0xFF` body could land as 384 bytes, or as its base64 text.

## Approach / Implementation notes

- `NetworkEntry.responseBodyBase64: boolean` (`playwright/types.ts`) — required, not optional, so the compiler catches any future capture site that forgets it. Seeded `false` on `Network.requestWillBeSent`, set from `r.base64Encoded === true` on the `Network.getResponseBody` result, exactly like `har-recorder.ts`'s `responseBodyBase64`.
- One `decodeResponseBody(body, base64Encoded)` decides the bytes; MIME is consulted only *after* that, to pick `[binary body, N bytes]` vs the text preview on stdout. There is no longer a path where the MIME type changes what lands on disk.
- **Failure over substitution.** `base64Encoded: true` + a payload `atob` rejects → exit 1 (the old code fell back to writing the raw string). `base64Encoded: false` + an unpaired surrogate → exit 1, because `TextEncoder` would silently turn it into U+FFFD. Nothing is written in either case.
- **Encoding for `base64Encoded: false` is UTF-8, not latin1** — the one place I diverged from the issue's suggestions. Chrome sets the flag false only when it hands back *decoded text*, so `charCodeAt & 0xff` would corrupt every legitimate non-ASCII text body (`{"hé":"ok 😀"}` → mojibake) to rescue a case a protocol-conformant peer never produces. A peer that stuffs latin1 bytes into a `base64Encoded: false` body is unrecoverable in-band; the U+FFFD / lone-surrogate guards catch the detectable subset. There is a test pinning the contract either way.
- `request <index>` now labels the inline preview `Response Body (base64):` when the flag is set, so the detail view stops reading like text an agent can copy.

## Cross-cutting impact

- **Floats**: the handler is shell-layer webapp code shared by CLI, extension, Electron and cloud — one code path, no follower shim to mirror. No new imports, no layer crossings (the CDP result type stays a local interface, per the existing note in the file).
- **Other callers of the changed contract**: `NetworkEntry` is constructed in exactly one place (`ensureCapturing`) and read by the six `request*`/`response*` handlers; `har-recorder.ts` has its own entry type and is untouched. #2878's upload work is in `handlers/upload.ts` and is not touched here.
- **Behavior change for text bodies**: `--filename` now hands `writeFile` a `Uint8Array` instead of a `string`. `VirtualFS.writeFile` runs `TextEncoder().encode()` on strings, so the bytes on disk are identical; only the argument type changed (one existing assertion in `playwright-command.test.ts` updated, and it now also checks the round-tripped text).
- **Exit codes**: two new exit-1 paths on `response-body` where the command previously always returned 0. That is the point of the issue, but it is a visible contract change for a script that ignored the body and only checked the exit code.
- **Persisted state / bundle size**: none — the ring buffer is in-memory; webapp worker `+0.7 kB`, well inside the first-load allowance.

## Test plan

- [x] `npm run verify` — all 8 checks pass (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists touched
- [x] `npm run typecheck` — clean (all 9 projects)
- [x] `npm run test` — 20037 passing; see pre-existing failures below
- [x] `npm run test:coverage:webapp` — floors held
- [x] `npm run build`, `npm run build -w @slicc/chrome-extension`, `npm run bundle-size` — first-load OK, extension budgets under limit
- [x] **New behavior covered by unit tests**: `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/handlers/network-requests.test.ts` (23 tests)
  - capture keeps `base64Encoded`
  - `--filename` on a base64 body writes the 256-byte `0x00..0xFF` fixture byte-for-byte
  - a base64 body labelled `text/plain` writes bytes, not the base64 alphabet
  - a text/json body (`{"hé":"ok 😀"}`) round-trips as UTF-8 text
  - the issue's `{ latin1 256-byte string, base64Encoded: false, image/jpeg }` fixture is *not* run through `atob`
  - unpaired surrogate → exit 1, `writeFile` never called
  - `base64Encoded: true` + invalid base64 → exit 1, `writeFile` never called
  - a base64 `text/plain` body prints as text on stdout
- [x] **Mutation-tested**: hard-coding the flag back to `false` (the pre-fix behavior) fails 6 of these tests; restoring the fix makes them pass again.
- [x] N/A — no UI change, no screencast.

**Pre-existing failures** (unrelated to this PR): `packages/dev-tools/tools/check-touched-exemptions.test.mjs > passes when the changed file is NOT on the float-probe debt list` fails locally on a clean tree — the test writes a fake entry into the real `float-probe-baseline.json`, and the gate's own "list must not grow" check then diffs that fake entry against `origin/main` and exits 1. Reproduced by hand with none of this PR's code in the loop; this PR touches no `dev-tools/` or `scoops/` file.

## Documentation

- [x] `packages/vfs-root/workspace/skills/playwright-cli/SKILL.md` — `response-body` line now says `--filename` saves the exact bytes
- [x] `playwright/help.ts` — same, in `--help`
- [ ] No `README.md` / `CLAUDE.md` / `docs/` change needed — no new command, flag, or architecture surface

## Risk & rollback

- Blast radius: the `response-body` subcommand of `playwright-cli`, all floats. Other `playwright-cli` verbs and the HAR recorder are untouched.
- No flags, no persisted state, no migration — revert this PR and the old behavior is back.
- CI cannot catch it: the fixtures are synthetic CDP results. What a reviewer may want to verify by hand is a real tab downloading a JPEG/zip and `cmp`-ing the saved file, since only live Chrome decides when it sets `base64Encoded`.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Shell-command behavior change reflected in `SKILL.md` + `--help`
- [x] Single shared handler — no leader/follower/offscreen fork to keep in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
