### PR TITLE
fix(webapp): stash binaries as bytes, not UTF-8 strings

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -335,6 +335,38 @@ When adding a diff variant, keep the OID comparison ahead of the content read an
 the pathspec test ahead of the walk: the pre-2719 code compared decoded strings
 and pulled all 3,549 tracked blobs out of the packfile on every invocation.
 
+### `git stash` moves bytes, not text
+
+Push and pop/apply are byte paths end to end (#2885). Push reads each dirty
+working-tree file with `{ encoding: 'binary' }`, compares it to the HEAD blob
+byte for byte, and hands the `Uint8Array` straight to `writeBlob`; pop/apply
+reads the stashed blob, the stash base, and the working-tree copy as bytes and
+writes the result back as bytes.
+
+Before that, both halves round-tripped through `readTextFile` (a **non-fatal**
+`TextDecoder`) and `TextEncoder.encode`, so a dirty JPEG, zip, wasm or packfile
+was stashed as U+FFFD and restored as `EF BF BD` — silently, with exit code 0.
+An unmodified binary was fine, because it took the raw-blob path; only dirty
+ones corrupted.
+
+The three-way merge is still available, but only for a path both sides changed
+whose working-tree, base, and stashed versions are **all** lossless UTF-8
+(no NUL, strict decode over the whole file — stricter than `looksLikeText`,
+which samples 4 KB and answers "can a human read this?"). When both sides moved
+a binary, stash does what git does instead of inventing bytes:
+
+```text
+warning: Cannot merge binary files: logo.png (Updated upstream vs Stashed changes)
+CONFLICT (content): Merge conflict in logo.png
+```
+
+Exit code 1, the working-tree copy is left verbatim (no markers spliced into
+it), and the stash entry is kept so the stashed bytes stay recoverable.
+
+`git merge-file` is explicitly a text tool and keeps its text contract; `git
+show` / `diff` / `revert` still decode blobs for display, but never write the
+decoded result back.
+
 ### `git commit -F` reads the message from a file
 
 `-F` / `--file` is the scripted way to supply a multi-paragraph commit message

--- a/packages/webapp/src/git/commands/stash.ts
+++ b/packages/webapp/src/git/commands/stash.ts
@@ -8,6 +8,44 @@ import { threeWayMerge } from '../merge-file-core.js';
 import { diffCommits } from './diff.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
+const EMPTY_BYTES = new Uint8Array(0);
+
+/** Read a working-tree file as raw bytes. Throws (ENOENT/EISDIR) like `readFile`. */
+async function readWorkdirBytes(ctx: GitCommandContext, path: string): Promise<Uint8Array> {
+  return (await ctx.fs.readFile(path, { encoding: 'binary' })) as Uint8Array;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a === b) return true;
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Decode `bytes` only if they survive a `TextDecoder` → `TextEncoder` round
+ * trip unchanged — i.e. only if it is safe to merge them as text and write the
+ * result back. `undefined` means "these are bytes, treat them as bytes".
+ *
+ * Deliberately stricter than `core/file-type.ts`'s `looksLikeText`, which
+ * answers a different question ("can a human read this?") off a 4 KB sample: a
+ * 10 MB tarball whose first 4 KB happen to be ASCII would pass that and then
+ * lose every high byte past the window. Here the whole file must decode as
+ * strict UTF-8 — a single invalid sequence anywhere comes back out as U+FFFD,
+ * and silently substituting bytes is the bug (#2885). NUL is rejected up front
+ * for the same reason git treats it as the binary tell.
+ */
+function decodeMergeableText(bytes: Uint8Array): string | undefined {
+  if (bytes.includes(0x00)) return undefined;
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function stash(
   ctx: GitCommandContext,
   cwd: string,
@@ -134,9 +172,9 @@ async function stashCollectDirty(
   for (const filepath of allTracked) {
     const inHead = headFiles.includes(filepath);
 
-    let workdirContent: string | undefined;
+    let workdirBytes: Uint8Array | undefined;
     try {
-      workdirContent = await ctx.fs.readTextFile(`${cwd}/${filepath}`);
+      workdirBytes = await readWorkdirBytes(ctx, `${cwd}/${filepath}`);
     } catch {
       /* file doesn't exist in workdir */
     }
@@ -149,29 +187,20 @@ async function stashCollectDirty(
         oid: headOid,
         filepath,
       });
-      const headContent = new TextDecoder().decode(blob);
 
-      if (workdirContent === undefined) {
+      if (workdirBytes === undefined) {
         dirtyFiles.push({ file: filepath, inHead: true, existsInWorkdir: false });
-      } else if (workdirContent !== headContent) {
+      } else if (!bytesEqual(workdirBytes, blob)) {
         dirtyFiles.push({ file: filepath, inHead: true, existsInWorkdir: true });
-        const oid = await git.writeBlob({
-          fs: ctx.lfs,
-          dir: cwd,
-          blob: new TextEncoder().encode(workdirContent),
-        });
+        const oid = await git.writeBlob({ fs: ctx.lfs, dir: cwd, blob: workdirBytes });
         indexEntries.push({ filepath, oid });
       } else {
         const blobOid = await git.writeBlob({ fs: ctx.lfs, dir: cwd, blob });
         indexEntries.push({ filepath, oid: blobOid });
       }
-    } else if (workdirContent !== undefined) {
+    } else if (workdirBytes !== undefined) {
       dirtyFiles.push({ file: filepath, inHead: false, existsInWorkdir: true });
-      const oid = await git.writeBlob({
-        fs: ctx.lfs,
-        dir: cwd,
-        blob: new TextEncoder().encode(workdirContent),
-      });
+      const oid = await git.writeBlob({ fs: ctx.lfs, dir: cwd, blob: workdirBytes });
       indexEntries.push({ filepath, oid });
     }
   }
@@ -297,18 +326,15 @@ async function stashRestore(
   // HEAD may have advanced since the stash was created.
   const baseOid = stashCommit.parent[0] ?? headOid;
 
-  const conflicts = await mergeStashTree(ctx, cwd, stashCommit.tree, baseOid);
+  const { conflicts, warnings } = await mergeStashTree(ctx, cwd, stashCommit.tree, baseOid);
 
   if (conflicts.length > 0) {
     // Real git keeps the stash entry on conflict for both pop and apply.
     const stdout = conflicts
       .map((filepath) => `CONFLICT (content): Merge conflict in ${filepath}\n`)
       .join('');
-    return {
-      stdout,
-      stderr: drop ? 'The stash entry is kept in case you need it again.\n' : '',
-      exitCode: 1,
-    };
+    const kept = drop ? 'The stash entry is kept in case you need it again.\n' : '';
+    return { stdout, stderr: warnings.join('') + kept, exitCode: 1 };
   }
 
   if (!drop) {
@@ -336,15 +362,21 @@ async function stashRestore(
 
 /**
  * Restore a stash tree onto the working tree via a per-file three-way merge and
- * return the list of files that conflicted. Cleanly merged files are staged;
- * conflicted files keep their markers in the working tree and are left unstaged.
+ * return the files that conflicted (plus any git-style warnings to print).
+ * Cleanly merged files are staged; conflicted files keep their working-tree
+ * content and are left unstaged.
+ *
+ * Everything below the text merge is byte work (#2885). Only a file whose
+ * three sides are all lossless UTF-8 goes through {@link threeWayMerge}; a
+ * JPEG or a packfile is compared and written as bytes, because decoding it to
+ * merge it is what turned `FF D8` into `EF BF BD`.
  */
 async function mergeStashTree(
   ctx: GitCommandContext,
   cwd: string,
   treeOid: string,
   baseOid: string
-): Promise<string[]> {
+): Promise<{ conflicts: string[]; warnings: string[] }> {
   const stashFiles = new Map<string, Uint8Array>();
 
   const walkTree = async (oid: string, prefix: string): Promise<void> => {
@@ -379,42 +411,37 @@ async function mergeStashTree(
     /* no base */
   }
 
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
   const conflicts: string[] = [];
+  const warnings: string[] = [];
 
-  for (const [filepath, blob] of stashFiles) {
-    const theirs = decoder.decode(blob);
-    const base = baseFileSet.has(filepath) ? await readBaseText(ctx, cwd, baseOid, filepath) : '';
+  for (const [filepath, theirs] of stashFiles) {
+    const base = baseFileSet.has(filepath)
+      ? await readBaseBytes(ctx, cwd, baseOid, filepath)
+      : EMPTY_BYTES;
 
-    let ours: string | undefined;
+    let ours: Uint8Array | undefined;
     try {
-      ours = await ctx.fs.readTextFile(`${cwd}/${filepath}`);
+      ours = await readWorkdirBytes(ctx, `${cwd}/${filepath}`);
     } catch {
       /* no local copy in the working tree */
     }
 
-    let mergedText: string;
-    let conflicted = false;
-    if (ours === undefined || ours === theirs) {
-      mergedText = theirs;
-    } else {
-      const merge = threeWayMerge(ours, base, theirs, {
-        labels: { current: 'Updated upstream', base: 'stash base', other: 'Stashed changes' },
-      });
-      mergedText = merge.content;
-      conflicted = merge.conflicts > 0;
-    }
+    const { merged, conflicted, binary } = resolveStashedFile(ours, base, theirs);
 
     const slashIdx = filepath.lastIndexOf('/');
     if (slashIdx !== -1) {
       await ctx.fs.mkdir(`${cwd}/${filepath.slice(0, slashIdx)}`, { recursive: true });
     }
-    await ctx.fs.writeFile(`${cwd}/${filepath}`, encoder.encode(mergedText));
+    await ctx.fs.writeFile(`${cwd}/${filepath}`, merged);
 
+    if (binary) {
+      warnings.push(
+        `warning: Cannot merge binary files: ${filepath} (Updated upstream vs Stashed changes)\n`
+      );
+    }
     if (conflicted) {
       conflicts.push(filepath);
-    } else if (mergedText !== base) {
+    } else if (!bytesEqual(merged, base)) {
       await git.add({ fs: ctx.lfs, cache: ctx.cache, dir: cwd, filepath });
     }
   }
@@ -432,16 +459,62 @@ async function mergeStashTree(
     }
   }
 
-  return conflicts;
+  return { conflicts, warnings };
 }
 
-/** Read a file's base-commit blob as text, returning '' when it is not present. */
-async function readBaseText(
+/**
+ * Decide the bytes a single stashed path should end up with, given the working
+ * tree (`ours`, absent when the file is gone), the stash base (`base`) and the
+ * stashed blob (`theirs`).
+ *
+ * Byte comparisons decide first, so a binary that only one side touched is
+ * restored or preserved without ever being decoded. Only a path both sides
+ * moved AND whose three versions are all lossless UTF-8 reaches the text merge;
+ * anything else is a binary conflict, which is what git does rather than
+ * inventing bytes (#2885).
+ */
+function resolveStashedFile(
+  ours: Uint8Array | undefined,
+  base: Uint8Array,
+  theirs: Uint8Array
+): { merged: Uint8Array; conflicted: boolean; binary: boolean } {
+  // No local copy, already the stashed bytes, or untouched since the stash
+  // base — the stashed bytes are the answer either way.
+  if (ours === undefined || bytesEqual(ours, theirs) || bytesEqual(ours, base)) {
+    return { merged: theirs, conflicted: false, binary: false };
+  }
+  // The stash never changed this file (push records every tracked path, not
+  // just the dirty ones), so the local edit stands.
+  if (bytesEqual(theirs, base)) {
+    return { merged: ours, conflicted: false, binary: false };
+  }
+
+  const oursText = decodeMergeableText(ours);
+  const baseText = decodeMergeableText(base);
+  const theirsText = decodeMergeableText(theirs);
+  if (oursText === undefined || baseText === undefined || theirsText === undefined) {
+    // Both sides moved and at least one is binary: keep the working-tree copy
+    // and report the conflict instead of merging bytes as prose.
+    return { merged: ours, conflicted: true, binary: true };
+  }
+
+  const merge = threeWayMerge(oursText, baseText, theirsText, {
+    labels: { current: 'Updated upstream', base: 'stash base', other: 'Stashed changes' },
+  });
+  return {
+    merged: new TextEncoder().encode(merge.content),
+    conflicted: merge.conflicts > 0,
+    binary: false,
+  };
+}
+
+/** Read a file's base-commit blob, returning no bytes when it is not present. */
+async function readBaseBytes(
   ctx: GitCommandContext,
   cwd: string,
   baseOid: string,
   filepath: string
-): Promise<string> {
+): Promise<Uint8Array> {
   try {
     const { blob } = await git.readBlob({
       fs: ctx.lfs,
@@ -450,9 +523,9 @@ async function readBaseText(
       oid: baseOid,
       filepath,
     });
-    return new TextDecoder().decode(blob);
+    return blob;
   } catch {
-    return '';
+    return EMPTY_BYTES;
   }
 }
 

--- a/packages/webapp/tests/git/git-stash-binary.test.ts
+++ b/packages/webapp/tests/git/git-stash-binary.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression (#2885): `git stash` push and pop/apply must move working-tree
+ * bytes, not UTF-8 strings.
+ *
+ * Both halves used to hop through `readTextFile` (`TextDecoder` with
+ * `fatal: false`) and `TextEncoder.encode`, so a dirty JPEG / zip / wasm /
+ * packfile was stashed as U+FFFD and restored as `EF BF BD` — with exit code 0
+ * and no warning. Unmodified files took the raw-blob path and survived, which
+ * is why only DIRTY binaries corrupted.
+ *
+ * The fixtures are the same probes the sibling codec bugs used: a 256-byte
+ * 0x00..0xFF ramp and a JPEG SOI (`FF D8 FF 98 00 41 7F 80 FE`, PR #2818). Any
+ * string round-trip anywhere in the path expands or replaces the high bytes and
+ * the byte-equality assertions trip.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import 'fake-indexeddb/auto';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GitCommands } from '../../src/git/git-commands.js';
+
+/** Every byte 0x00-0xFF — NUL, high bytes, and invalid UTF-8 sequences. */
+function allBytes(): Uint8Array {
+  return new Uint8Array(Array.from({ length: 256 }, (_, i) => i));
+}
+
+/** The JPEG SOI probe from PR #2818. */
+const JPEG_SOI = new Uint8Array([0xff, 0xd8, 0xff, 0x98, 0x00, 0x41, 0x7f, 0x80, 0xfe]);
+
+async function readBytes(vfs: VirtualFS, path: string): Promise<Uint8Array> {
+  return (await vfs.readFile(path, { encoding: 'binary' })) as Uint8Array;
+}
+
+describe('git stash binary round-trip (#2885)', () => {
+  let vfs: VirtualFS;
+  let git: GitCommands;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    const testId = dbCounter++;
+    vfs = await VirtualFS.create({ dbName: `git-stash-binary-${testId}`, wipe: true });
+    git = new GitCommands({
+      fs: vfs,
+      authorName: 'Test User',
+      authorEmail: 'test@example.com',
+      globalDbName: `git-stash-binary-global-${testId}`,
+    });
+  });
+
+  /** init + commit `committed` at `bin.dat`, then dirty it with `dirty`. */
+  async function seedDirtyBinary(committed: Uint8Array, dirty: Uint8Array): Promise<void> {
+    await git.execute(['init'], '/project');
+    await vfs.writeFile('/project/bin.dat', committed);
+    await git.execute(['add', 'bin.dat'], '/project');
+    await git.execute(['commit', '-m', 'initial'], '/project');
+    await vfs.writeFile('/project/bin.dat', dirty);
+  }
+
+  it('stash + pop restores a dirty all-bytes file byte for byte', async () => {
+    const committed = new Uint8Array([0x00, 0x01, 0x02]);
+    const dirty = allBytes();
+    await seedDirtyBinary(committed, dirty);
+
+    const push = await git.execute(['stash'], '/project');
+    expect(push.exitCode).toBe(0);
+    // Workdir is back to the committed bytes, unexpanded.
+    expect(Array.from(await readBytes(vfs, '/project/bin.dat'))).toEqual(Array.from(committed));
+
+    const pop = await git.execute(['stash', 'pop'], '/project');
+    expect(pop.exitCode).toBe(0);
+    expect(pop.stdout).toContain('Dropped refs/stash@{0}');
+
+    const restored = await readBytes(vfs, '/project/bin.dat');
+    expect(restored.byteLength).toBe(256);
+    expect(Array.from(restored)).toEqual(Array.from(dirty));
+  });
+
+  it('stash + pop restores a dirty JPEG SOI probe byte for byte', async () => {
+    await seedDirtyBinary(new Uint8Array([0xff, 0xd8, 0xff, 0xd9]), JPEG_SOI);
+
+    expect((await git.execute(['stash'], '/project')).exitCode).toBe(0);
+    expect((await git.execute(['stash', 'pop'], '/project')).exitCode).toBe(0);
+
+    const restored = await readBytes(vfs, '/project/bin.dat');
+    // The bug produced 21 bytes with EF BF BD runs instead of these 9.
+    expect(restored.byteLength).toBe(JPEG_SOI.byteLength);
+    expect(Array.from(restored)).toEqual(Array.from(JPEG_SOI));
+  });
+
+  it('stash + apply restores binary bytes and keeps the entry', async () => {
+    const dirty = allBytes();
+    await seedDirtyBinary(new Uint8Array([0x00]), dirty);
+
+    await git.execute(['stash'], '/project');
+    const apply = await git.execute(['stash', 'apply'], '/project');
+    expect(apply.exitCode).toBe(0);
+    expect(Array.from(await readBytes(vfs, '/project/bin.dat'))).toEqual(Array.from(dirty));
+
+    const list = await git.execute(['stash', 'list'], '/project');
+    expect(list.stdout).toContain('stash@{0}');
+  });
+
+  it('stashes a new (never committed) binary file and pops it back intact', async () => {
+    await git.execute(['init'], '/project');
+    await vfs.writeFile('/project/keep.txt', 'keep');
+    await git.execute(['add', 'keep.txt'], '/project');
+    await git.execute(['commit', '-m', 'initial'], '/project');
+
+    const dirty = allBytes();
+    await vfs.writeFile('/project/new.bin', dirty);
+    await git.execute(['add', 'new.bin'], '/project');
+
+    expect((await git.execute(['stash'], '/project')).exitCode).toBe(0);
+    expect(await vfs.exists('/project/new.bin')).toBe(false);
+
+    expect((await git.execute(['stash', 'pop'], '/project')).exitCode).toBe(0);
+    expect(Array.from(await readBytes(vfs, '/project/new.bin'))).toEqual(Array.from(dirty));
+  });
+
+  it('leaves an unrelated committed binary untouched across a stash round-trip', async () => {
+    const untouched = allBytes();
+    await git.execute(['init'], '/project');
+    await vfs.writeFile('/project/asset.bin', untouched);
+    await vfs.writeFile('/project/file.txt', 'original\n');
+    await git.execute(['add', '.'], '/project');
+    await git.execute(['commit', '-m', 'initial'], '/project');
+
+    // Only the text file is dirty; the binary must not be rewritten as U+FFFD
+    // by the stash tree walk (push records every tracked path, not just dirty).
+    await vfs.writeFile('/project/file.txt', 'modified\n');
+    expect((await git.execute(['stash'], '/project')).exitCode).toBe(0);
+    expect(Array.from(await readBytes(vfs, '/project/asset.bin'))).toEqual(Array.from(untouched));
+
+    expect((await git.execute(['stash', 'pop'], '/project')).exitCode).toBe(0);
+    expect(Array.from(await readBytes(vfs, '/project/asset.bin'))).toEqual(Array.from(untouched));
+    expect(await vfs.readTextFile('/project/file.txt')).toBe('modified\n');
+  });
+
+  it('reports a binary conflict instead of merging bytes as text', async () => {
+    const committed = allBytes();
+    const stashed = new Uint8Array([...allBytes(), 0xde, 0xad]);
+    const local = new Uint8Array([...allBytes(), 0xbe, 0xef]);
+    await seedDirtyBinary(committed, stashed);
+
+    await git.execute(['stash'], '/project');
+
+    // Diverge the working tree from both the base and the stash.
+    await vfs.writeFile('/project/bin.dat', local);
+    const pop = await git.execute(['stash', 'pop'], '/project');
+
+    expect(pop.exitCode).toBe(1);
+    expect(pop.stdout).toContain('CONFLICT (content): Merge conflict in bin.dat');
+    expect(pop.stderr).toContain('warning: Cannot merge binary files: bin.dat');
+
+    // The working-tree copy is preserved verbatim — no markers spliced into it.
+    expect(Array.from(await readBytes(vfs, '/project/bin.dat'))).toEqual(Array.from(local));
+
+    // The entry is kept so the stashed bytes are still recoverable.
+    expect((await git.execute(['stash', 'list'], '/project')).stdout).toContain('stash@{0}');
+  });
+
+  it('still three-way merges disjoint text edits after the byte change', async () => {
+    await git.execute(['init'], '/project');
+    await vfs.writeFile('/project/file.txt', 'A\nB\nC\n');
+    await git.execute(['add', 'file.txt'], '/project');
+    await git.execute(['commit', '-m', 'initial'], '/project');
+
+    await vfs.writeFile('/project/file.txt', 'A\nB\nCHANGED_C\n');
+    await git.execute(['stash'], '/project');
+
+    await vfs.writeFile('/project/file.txt', 'CHANGED_A\nB\nC\n');
+    const pop = await git.execute(['stash', 'pop'], '/project');
+
+    expect(pop.exitCode).toBe(0);
+    expect(await vfs.readTextFile('/project/file.txt')).toBe('CHANGED_A\nB\nCHANGED_C\n');
+  });
+
+  it('preserves a UTF-8 text file with multi-byte characters', async () => {
+    await git.execute(['init'], '/project');
+    await vfs.writeFile('/project/file.txt', 'plain\n');
+    await git.execute(['add', 'file.txt'], '/project');
+    await git.execute(['commit', '-m', 'initial'], '/project');
+
+    const unicode = 'héllo — 🍦 λ\n';
+    await vfs.writeFile('/project/file.txt', unicode);
+    await git.execute(['stash'], '/project');
+    expect((await git.execute(['stash', 'pop'], '/project')).exitCode).toBe(0);
+
+    expect(await vfs.readTextFile('/project/file.txt')).toBe(unicode);
+  });
+});


### PR DESCRIPTION
Fixes #2885

## Summary

`git stash` push and pop/apply round-tripped every dirty working-tree file through `readTextFile` (`VirtualFS.readFile({ encoding: 'utf-8' })`, a **non-fatal** `TextDecoder`) and `TextEncoder.encode`. A dirty JPEG, zip, wasm or packfile was stashed as U+FFFD and restored as `EF BF BD` — with exit code 0 and no warning. Unmodified files took the raw-blob path and survived, so **only dirty binaries** corrupted.

Push and pop/apply are now byte paths end to end: read with `{ encoding: 'binary' }`, compare byte for byte, hand the `Uint8Array` straight to `writeBlob` / `writeFile`. Before, `git stash && git stash pop` handed back an unopenable `.png`; now it hands back the same bytes.

## Why

`git merge-file` is explicitly a text tool. Stash is not — it claims to save the working tree, including the binaries git itself treats as binary.

**Repro** (the issue's codec probe, JPEG SOI from #2818):

```
in  ff d8 ff 98 00 41 7f 80 fe                    (9 bytes)
readTextFile + TextEncoder.encode →
out ef bf bd × 4, 00 41 7f, ef bf bd × 2          (21 bytes)
```

1. Commit a binary, dirty it, `git stash`, `git stash pop`.
2. Expected: the dirty bytes back.
3. Actual: high bytes replaced with `EF BF BD`, exit 0 either way.

Same family as #2878 / #2888 (playwright-cli upload), #2818 (jsh fetch), #1031 (composer zip-as-text): the call that should have been a byte copy went through UTF-8 and reported success.

## Approach / Implementation notes

`packages/webapp/src/git/commands/stash.ts` only.

- **Push** (`stashCollectDirty`): `readWorkdirBytes` (`{ encoding: 'binary' }`) → `bytesEqual` against the HEAD blob → `writeBlob({ blob: workdirBytes })`. No string ever exists.
- **Pop / apply** (`mergeStashTree`): stash blob, stash base (`readBaseBytes`), and the working-tree copy are all `Uint8Array`. The per-file decision moved into `resolveStashedFile(ours, base, theirs)` — pure, no I/O, so it is directly testable and keeps `mergeStashTree`'s complexity flat.
- **Byte comparisons decide first**, so a binary that only one side touched never gets decoded at all:
  1. no local copy, or `ours == theirs`, or `ours == base` → the stashed bytes;
  2. `theirs == base` (push records *every* tracked path, not just the dirty ones) → the local bytes;
  3. otherwise decode all three, and only then merge.
- **`decodeMergeableText`** is deliberately stricter than `core/file-type.ts`'s `looksLikeText`, which answers a different question ("can a human read this?") off a 4 KB sample. A 10 MB tarball whose first 4 KB happen to be ASCII would pass that and then lose every high byte past the window. Here the **whole file** must decode as strict UTF-8 (`fatal: true`), with NUL rejected up front — that is exactly the "does `decode` → `encode` round-trip losslessly?" predicate the write-back needs.
- **Binary conflict fails instead of substituting** (the issue's explicit ask). When both sides moved a path and any side is binary, stash does what git does:

  ```
  warning: Cannot merge binary files: logo.png (Updated upstream vs Stashed changes)
  CONFLICT (content): Merge conflict in logo.png
  ```

  Exit 1, the working-tree copy left **verbatim** (no markers spliced into it), the stash entry kept so the stashed bytes stay recoverable. `mergeStashTree` returns `{ conflicts, warnings }` so `stashRestore` can put the warning on stderr alongside the existing "stash entry is kept" line.

Rejected: gating on `looksLikeText` (samples 4 KB — see above), and clobbering with the stashed bytes on a binary conflict (loses the local edit silently, which is the class of bug being fixed).

## Cross-cutting impact

- **Text behavior is unchanged.** The three-way merge, its conflict markers, the `Updated upstream` / `stash base` / `Stashed changes` labels, exit codes, and the stash-base-not-HEAD merge base all still work — all 30 existing `tests/git/` files (582 tests) pass untouched. The two short-circuits added ahead of the merge are algebraically what `threeWayMerge` already returned for those inputs (`ours == base` → theirs; `theirs == base` → ours), just without decoding.
- **Other callers**: `resolveStashedFile` / `readBaseBytes` / `readWorkdirBytes` / `bytesEqual` / `decodeMergeableText` are module-private to `stash.ts`. `mergeStashTree`'s return shape changed, and its only caller is `stashRestore` in the same file.
- **Floats**: pure `packages/webapp/src/git/` logic over `VirtualFS` — identical in CLI, extension, Electron, Sliccstart, and the kernel worker. No wire protocol, no persisted state, no schema.
- **Explicitly out of scope** (per the issue): `git show` / `diff` / `revert` still `TextDecoder.decode(blob)`, but those are display-only and never write the decoded result back. `git merge-file` keeps its text contract.
- **Executable bit**: `buildTreeFromEntries` still hardcodes `100644`; pre-existing, unrelated to the codec, left alone.
- **Bundle size**: no new imports. First-load gate green (allowance 5 kB per change; 4994 kB total).

## Test plan

New file `packages/webapp/tests/git/git-stash-binary.test.ts` — 8 tests, fixtures are the 256-byte `0x00..0xFF` ramp and the JPEG SOI probe from #2818.

- [x] `npx vitest run --project webapp packages/webapp/tests/git/git-stash-binary.test.ts` — 8 passed
- [x] **Mutation-tested**: with `stash.ts` reverted to `main`, **6 of the 8 fail** (all-bytes pop, JPEG SOI pop, apply, new-binary stash, unrelated-binary preservation, binary conflict) and the 2 text tests pass on both sides. The guard actually guards.
- [x] `npx vitest run --project webapp packages/webapp/tests/git/` — 582 passed (30 files)
- [x] `npm run verify` — all 8 checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists touched
- [x] `npm run typecheck` — clean (all 9 projects)
- [x] `npm run test` — 20031 passed / 8 pre-existing failures (below)
- [x] `npm run test:coverage:webapp` — floors held
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension` + `npm run bundle-size` — green (extension 101.58 kB / 105 kB limit)
- [x] N/A for UI / screencast — no UI surface

Coverage of the new paths: byte round-trip (all-bytes + JPEG), `apply` vs `pop`, a never-committed binary, an unrelated committed binary left untouched across the round-trip, the binary conflict (stdout + stderr + working-tree bytes + entry kept), disjoint text three-way merge, and a multi-byte UTF-8 text file.

**Pre-existing failures** (verified unrelated — reproduce with `packages/webapp/src/git/commands/stash.ts` reverted to `main` in the same tree):

- `packages/dev-tools/tools/check-touched-exemptions.test.mjs` → "passes when the changed file is NOT on the float-probe debt list" (1 test). Fails identically without this diff; driven by `CHANGED_FILES` env and the float-probe baseline, nothing this PR touches.
- `packages/dev-tools/tools/check-skill-router-sync.test.mjs` (7 tests) — local sandbox artifact only; BSD `mktemp -d` ignores `$TMPDIR`. Passes when re-run outside the sandbox.

## Documentation

- [x] `docs/` — new `### git stash moves bytes, not text` section in `docs/shell-reference.md`, next to the other git-behavior notes: the byte contract, the strict-UTF-8 merge gate and how it differs from `looksLikeText`, and the binary-conflict output.
- [x] No `README.md` / `CLAUDE.md` / agent-skill change needed — no new command, flag, or agent-visible surface.

## Risk & rollback

- **Blast radius**: `git stash push` / `pop` / `apply` only, in every float. `list` / `drop` / `show` untouched.
- **New user-visible output**: the `Cannot merge binary files` warning on stderr, in a case that previously "succeeded" by corrupting the file.
- **Rollback**: revert this PR. No persisted state, no migration, no flag.
- **CI cannot catch** a real dirty-`.png`-in-a-mounted-repo round trip; the fixtures are the same probes that failed in #2818 / #2878.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Shell-command behavior change reflected in `docs/shell-reference.md`
- [x] No cross-float contract change — pure `VirtualFS`-level git logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
