### PR TITLE
fix(webapp): keep playwright-cli drop --path binary files byte-exact

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -2100,7 +2100,7 @@ await fs.writeFile('/output.jpg', newBytes);
 
 ### Tools Supporting Binary
 
-- **playwright-cli**: `screenshot --filename=<path>` saves PNGs directly to the VFS; `upload` injects VFS files into a page file input as raw bytes (no UTF-8 round-trip)
+- **playwright-cli**: `screenshot --filename=<path>` saves PNGs directly to the VFS; `upload` injects VFS files into a page file input and `drop --path` into the page's `DataTransfer`, both as raw bytes (no UTF-8 round-trip)
 - **node** / **.jsh**: `fs.readFileBinary()`, `fs.writeFileBinary()` available
 - **bash**: Limited binary support (command output truncated at 100KB)
 

--- a/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
+++ b/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
@@ -121,7 +121,7 @@ playwright-cli check --tab=<id> <ref>                            # Check checkbo
 playwright-cli uncheck --tab=<id> <ref>                          # Uncheck checkbox/radio
 playwright-cli drag --tab=<id> <startRef> <endRef>               # Drag and drop
 playwright-cli upload --tab=<id> [ref] <file> [file...]          # Upload VFS files to file input as raw bytes (optional snapshot ref targets hidden inputs)
-playwright-cli drop --tab=<id> <ref> [--path=<vfs-path>] [--data=<mime/type=value>]  # Drop files/data onto element
+playwright-cli drop --tab=<id> <ref> [--path=<vfs-path>] [--data=<mime/type=value>]  # Drop files/data onto element (--path drops raw bytes)
 playwright-cli dialog-accept --tab=<id> [text]                   # Accept JS dialog
 playwright-cli dialog-dismiss --tab=<id>                         # Dismiss JS dialog
 ```
@@ -339,6 +339,7 @@ playwright-cli stop-recording <recordingId>        # Stop and save HAR
 - The SLICC app tab and Chrome internal UI tabs are automatically excluded from `tab-list`.
 - `fill` clears and types into regular inputs, textareas, and `contenteditable` elements. Use `--submit` to press Enter after. If the text or an `eval` expression starts with `-`, put `--` before it so it is not parsed as a flag.
 - Negative numbers for `mousewheel` / `mousemove` are positionals (no `--` needed): `mousewheel --tab=<id> 0 -300`.
+- `drop --path=<vfs-path>` injects the file as **raw bytes**; a UTF-8 text round-trip would replace every byte >= 0x80 with `EF BF BD`, so mp4/zip/jpg drops stay byte-exact.
 - Screenshots default to `$TMPDIR/screenshot-<timestamp>.png` — your own scratch directory, not the shared root. Use `--filename=path` to save elsewhere —
   `screenshot <path>` is an error, because that slot is the element ref.
 - Unsupported flags and extra positionals are rejected per subcommand, so a probe that exits 0 means

--- a/packages/webapp/src/shell/supplemental-commands/playwright/binary.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/binary.ts
@@ -1,0 +1,37 @@
+/**
+ * Byte-exact VFS reads for playwright-cli handlers that inject file contents
+ * into a page.
+ *
+ * `VirtualFS.readFile()` defaults to `encoding: 'utf-8'`, and that decode is
+ * non-fatal: every byte >= 0x80 that is not part of a valid UTF-8 sequence
+ * comes back as U+FFFD, which re-encodes to `EF BF BD`. Feeding that string
+ * through `TextEncoder` and into a page `File` silently mangles every JPEG,
+ * zip and mp4 while the command still exits 0 (#2883 for `drop`, #2878 for
+ * `upload`, same family as #2818).
+ */
+
+import type { VirtualFS } from '../../../fs/index.js';
+
+/**
+ * Read a VFS file as raw bytes, never through a UTF-8 round-trip.
+ *
+ * If a backend ignores `encoding: 'binary'` and still hands back a string, a
+ * payload that already contains U+FFFD is refused rather than injected as a
+ * corrupt `File` — failing loudly beats a page that receives garbage.
+ *
+ * @throws Error when the content cannot be represented faithfully.
+ */
+export async function readVfsFileBytes(fs: VirtualFS, path: string): Promise<Uint8Array> {
+  const content = await fs.readFile(path, { encoding: 'binary' });
+  if (content instanceof Uint8Array) return content;
+  if (typeof content !== 'string') {
+    throw new Error(`cannot represent '${path}' faithfully: unexpected file content type`);
+  }
+  if (content.includes('\uFFFD')) {
+    throw new Error(
+      `cannot represent '${path}' faithfully: file was read as text (contains U+FFFD). ` +
+        'Binary files must be read as bytes, not UTF-8.'
+    );
+  }
+  return new TextEncoder().encode(content);
+}

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/mouse.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/mouse.ts
@@ -1,7 +1,13 @@
 /**
  * Mouse subcommands: mousemove, mousedown, mouseup, mousewheel, drop.
+ *
+ * `drop --path` reads the VFS file as raw bytes — a UTF-8 text round-trip
+ * substitutes U+FFFD (`EF BF BD`) for every byte >= 0x80 (#2883), so the page
+ * would receive a corrupt `File` from a command that still exited 0.
  */
 
+import { uint8ToBase64 } from '@slicc/shared-ts';
+import { readVfsFileBytes } from '../binary.js';
 import { parseRef, requireTab } from '../state.js';
 import type { PlaywrightHandler } from '../types.js';
 
@@ -12,15 +18,6 @@ function parseButton(raw: string | undefined): MouseButton | { error: string } {
   if (raw === undefined) return 'left';
   if (raw === 'left' || raw === 'right' || raw === 'middle') return raw;
   return { error: `Invalid button "${raw}". Must be left, right, or middle.\n` };
-}
-
-/** Convert a Uint8Array to a base64 string without relying on spread (avoids stack overflow). */
-function uint8ToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
 }
 
 const MIME_MAP: Record<string, string> = {
@@ -157,11 +154,11 @@ export const dropHandler: PlaywrightHandler = async ({ browser, fs, state, posit
   // Build the files array from --path
   const files: Array<{ name: string; type: string; base64: string }> = [];
   if (vfsPath) {
-    const content = await fs.readFile(vfsPath);
+    // Raw bytes only: a UTF-8 round-trip would turn every byte >= 0x80 into
+    // U+FFFD and hand the page a corrupt File (#2883).
+    const bytes = await readVfsFileBytes(fs, vfsPath);
     const name = vfsPath.split('/').pop() ?? vfsPath;
-    const type = mimeForFilename(name);
-    const bytes = typeof content === 'string' ? new TextEncoder().encode(content) : content;
-    files.push({ name, type, base64: uint8ToBase64(bytes) });
+    files.push({ name, type: mimeForFilename(name), base64: uint8ToBase64(bytes) });
   }
 
   // Build the data items array from --data (format: "mime/type=value")

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/upload.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/upload.ts
@@ -13,8 +13,9 @@
  */
 
 import { uint8ToBase64 } from '@slicc/shared-ts';
+import { readVfsFileBytes } from '../binary.js';
 import { isElementRef, requireTab } from '../state.js';
-import type { PlaywrightHandler, PlaywrightHandlerCtx, TabSnapshot } from '../types.js';
+import type { PlaywrightHandler, TabSnapshot } from '../types.js';
 
 const MIME_MAP: Record<string, string> = {
   png: 'image/png',
@@ -38,31 +39,6 @@ const MIME_MAP: Record<string, string> = {
 function mimeForFilename(name: string): string {
   const ext = name.split('.').pop()?.toLowerCase() ?? '';
   return MIME_MAP[ext] ?? 'application/octet-stream';
-}
-
-/**
- * Read a VFS file as raw bytes. Never UTF-8-decodes: a text round-trip
- * substitutes U+FFFD for every byte >= 0x80 (#2878, same family as #2818).
- *
- * If a backend still returns a string, refuse any payload that already
- * contains U+FFFD rather than uploading a silently mangled File.
- */
-export async function readUploadBytes(
-  fs: PlaywrightHandlerCtx['fs'],
-  path: string
-): Promise<Uint8Array> {
-  const content = await fs.readFile(path, { encoding: 'binary' });
-  if (content instanceof Uint8Array) return content;
-  if (typeof content !== 'string') {
-    throw new Error(`cannot represent '${path}' faithfully: unexpected file content type`);
-  }
-  if (content.includes('\uFFFD')) {
-    throw new Error(
-      `cannot represent '${path}' faithfully: file was read as text (contains U+FFFD). ` +
-        'Binary files must be read as bytes, not UTF-8.'
-    );
-  }
-  return new TextEncoder().encode(content);
 }
 
 function parseUploadArgs(
@@ -110,7 +86,7 @@ export const uploadHandler: PlaywrightHandler = async ({
 
   const files: Array<{ name: string; type: string; base64: string }> = [];
   for (const filePath of filePaths) {
-    const bytes = await readUploadBytes(fs, filePath);
+    const bytes = await readVfsFileBytes(fs, filePath);
     const name = filePath.split('/').pop() ?? filePath;
     files.push({ name, type: mimeForFilename(name), base64: uint8ToBase64(bytes) });
   }

--- a/packages/webapp/src/shell/supplemental-commands/playwright/help.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/help.ts
@@ -158,7 +158,8 @@ Commands:
   mouseup [button] --tab=<id>  Release mouse button (left/right/middle, default: left)
   mousewheel <dx> <dy> --tab=<id> Scroll mouse wheel
   drop --tab=<id> <ref> [--path=vfs-path] [--data=mime/type=value]
-                         Drop files or data onto element by ref
+                         Drop files or data onto element by ref. --path reads the VFS
+                         file as raw bytes, so binary drops stay byte-exact.
   route --tab=<id> <pattern> [--status=n] [--body=text] [--content-type=type]
         [--header=<name: value>] ...
                          Mock requests matching a URL pattern (** = any, * = segment)

--- a/packages/webapp/tests/shell/helpers/playwright-harness.ts
+++ b/packages/webapp/tests/shell/helpers/playwright-harness.ts
@@ -123,3 +123,44 @@ export function createHandlerCtx(opts?: {
     scratchDir: opts?.scratchDir ?? '/tmp',
   };
 }
+
+/**
+ * Count `EF BF BD` (UTF-8 U+FFFD) sequences in a byte string — the signature a
+ * text round-trip leaves on binary file content (#2878 / #2883).
+ */
+export function countReplacementSeqs(bytes: Uint8Array): number {
+  let n = 0;
+  for (let i = 0; i + 2 < bytes.length; i++) {
+    if (bytes[i] === 0xef && bytes[i + 1] === 0xbf && bytes[i + 2] === 0xbd) {
+      n++;
+      i += 2;
+    }
+  }
+  return n;
+}
+
+/**
+ * A `VirtualFS.readFile` whose default encoding is UTF-8 *with replacement*,
+ * exactly like production. A caller that forgets `{ encoding: 'binary' }` sees
+ * U+FFFD for every high byte, so a handler that regresses fails the test.
+ */
+export function vfsLikeReadFile(files: Map<string, string | Uint8Array>): VirtualFS['readFile'] {
+  return (async (path: string, options?: { encoding?: string }) => {
+    const stored = files.get(path);
+    if (stored === undefined) {
+      throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' as const });
+    }
+    const encoding = options?.encoding ?? 'utf-8';
+    if (stored instanceof Uint8Array) {
+      if (encoding === 'binary') return stored;
+      return new TextDecoder('utf-8').decode(stored);
+    }
+    if (encoding === 'binary') return new TextEncoder().encode(stored);
+    return stored;
+  }) as VirtualFS['readFile'];
+}
+
+/** Every byte 0x00..0xFF exactly once — the #2883 / #2878 corruption probe. */
+export function allBytesFixture(): Uint8Array {
+  return Uint8Array.from({ length: 256 }, (_, i) => i);
+}

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -4019,6 +4019,39 @@ const UPLOAD_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
+/** Issue #2883 probe page: a drop target that reports file.size and scans for EF BF BD. */
+const DROP_HTML = `<!DOCTYPE html>
+<html>
+<head><title>Drop Probe</title></head>
+<body>
+  <div id="zone" role="button" tabindex="0" aria-label="Drop Zone" style="width:200px;height:200px">Drop here</div>
+  <pre id="out"></pre>
+  <script>
+    document.getElementById('zone').addEventListener('drop', async function (e) {
+      e.preventDefault();
+      var file = e.dataTransfer.files[0];
+      if (!file) return;
+      var buf = new Uint8Array(await file.arrayBuffer());
+      var replacementSeqs = 0;
+      for (var i = 0; i + 2 < buf.length; i++) {
+        if (buf[i] === 0xEF && buf[i + 1] === 0xBF && buf[i + 2] === 0xBD) {
+          replacementSeqs++;
+          i += 2;
+        }
+      }
+      window.__dropReport = {
+        name: file.name,
+        size: file.size,
+        byteLength: buf.length,
+        replacementSeqs: replacementSeqs,
+        bytes: Array.from(buf)
+      };
+      document.getElementById('out').textContent = JSON.stringify(window.__dropReport);
+    });
+  </script>
+</body>
+</html>`;
+
 // -- Conditional integration tests -------------------------------------------
 
 const chromePath = findChromeExecutable();
@@ -4059,6 +4092,9 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
       } else if (req.url === '/upload.html') {
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(UPLOAD_HTML);
+      } else if (req.url === '/drop.html') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(DROP_HTML);
       } else {
         res.writeHead(404);
         res.end('Not found');
@@ -4407,6 +4443,69 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
     expect(parsed.byteLength).toBe(256);
     expect(parsed.replacementSeqs).toBe(0);
     expect(parsed.bytes).toEqual(Array.from(fixture));
+  });
+
+  it('drop --path of the 0x00..0xFF fixture is byte-exact on the page (#2883)', async () => {
+    const fixture = Uint8Array.from({ length: 256 }, (_, i) => i);
+    mockFs._files.set('/dropbytes.bin', fixture);
+
+    const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/drop.html`);
+    const deadline = Date.now() + FIXTURE_LOAD_TIMEOUT_MS;
+    await browser.withTab(targetId, async () => {
+      while (Date.now() < deadline) {
+        try {
+          const ready = await browser.evaluate(
+            `document.readyState === 'complete' && Boolean(document.getElementById('zone'))`
+          );
+          if (ready === true || ready === 'true') return;
+        } catch {
+          /* about:blank teardown */
+        }
+        await new Promise((r) => setTimeout(r, FIXTURE_LOAD_POLL_MS));
+      }
+      throw new Error('drop probe page did not finish loading');
+    });
+
+    const cmd = createPlaywrightCommand(
+      'playwright-cli',
+      browser as BrowserAPI,
+      mockFs as VirtualFS
+    );
+    const snap = await cmd.execute(['snapshot', `--tab=${targetId}`], mockCtx);
+    expect(snap.exitCode).toBe(0);
+    const ref = snap.stdout.match(/"Drop Zone"[^\n]*\[ref=(f?\d*e\d+)\]/)?.[1];
+    expect(ref, `no ref for the drop zone in:\n${snap.stdout}`).toBeTruthy();
+
+    const dropped = await cmd.execute(
+      ['drop', ref!, `--tab=${targetId}`, '--path=/dropbytes.bin'],
+      mockCtx
+    );
+    expect(dropped.exitCode).toBe(0);
+
+    const reportDeadline = Date.now() + 10_000;
+    let raw = 'null';
+    while (Date.now() < reportDeadline) {
+      const report = await cmd.execute(
+        ['eval', `--tab=${targetId}`, 'JSON.stringify(window.__dropReport ?? null)'],
+        mockCtx
+      );
+      raw = report.stdout.trim();
+      if (raw && raw !== 'null') break;
+      await new Promise((r) => setTimeout(r, FIXTURE_LOAD_POLL_MS));
+    }
+    expect(raw).not.toBe('null');
+    const report = JSON.parse(raw) as {
+      name: string;
+      size: number;
+      byteLength: number;
+      replacementSeqs: number;
+      bytes: number[];
+    };
+    expect(report.name).toBe('dropbytes.bin');
+    expect(report.size).toBe(256);
+    expect(report.byteLength).toBe(256);
+    expect(report.replacementSeqs).toBe(0);
+    expect(report.bytes).toEqual(Array.from(fixture));
   });
 });
 
@@ -5556,7 +5655,7 @@ describe('playwright-cli drop', () => {
       mockCtx
     );
     expect(result.exitCode).toBe(0);
-    expect(fs.readFile).toHaveBeenCalledWith('/workspace/file.txt');
+    expect(fs.readFile).toHaveBeenCalledWith('/workspace/file.txt', { encoding: 'binary' });
     expect(transport.send).toHaveBeenCalledWith(
       'DOM.resolveNode',
       expect.objectContaining({ backendNodeId: expect.any(Number) }),

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/binary.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/binary.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { VirtualFS } from '../../../../src/fs/index.js';
+import { readVfsFileBytes } from '../../../../src/shell/supplemental-commands/playwright/binary.js';
+import {
+  allBytesFixture,
+  countReplacementSeqs,
+  vfsLikeReadFile,
+} from '../../helpers/playwright-harness.js';
+
+describe('readVfsFileBytes', () => {
+  it('returns the stored bytes for a 0x00..0xFF fixture, with no U+FFFD', async () => {
+    const fixture = allBytesFixture();
+    const files = new Map<string, string | Uint8Array>([['/allbytes.bin', fixture]]);
+    const bytes = await readVfsFileBytes(
+      { readFile: vfsLikeReadFile(files) } as VirtualFS,
+      '/allbytes.bin'
+    );
+    expect(bytes.length).toBe(256);
+    expect(Array.from(bytes)).toEqual(Array.from(fixture));
+    expect(countReplacementSeqs(bytes)).toBe(0);
+  });
+
+  it('asks the VFS for binary encoding, never the UTF-8 default', async () => {
+    const readFile = vi.fn(async () => new Uint8Array([0xff, 0xd8]));
+    await readVfsFileBytes({ readFile } as unknown as VirtualFS, '/photo.jpg');
+    expect(readFile).toHaveBeenCalledWith('/photo.jpg', { encoding: 'binary' });
+  });
+
+  it('fails loudly when a backend hands back a text decode that already lost bytes', async () => {
+    const readFile = vi.fn(async () => 'ASCII\uFFFDMORE');
+    await expect(
+      readVfsFileBytes({ readFile } as unknown as VirtualFS, '/corrupt.bin')
+    ).rejects.toThrow(/faithfully/);
+  });
+
+  it('rejects a content type that is neither bytes nor string', async () => {
+    const readFile = vi.fn(async () => 42 as unknown as string);
+    await expect(
+      readVfsFileBytes({ readFile } as unknown as VirtualFS, '/weird.bin')
+    ).rejects.toThrow(/unexpected file content type/);
+  });
+
+  it('encodes a valid UTF-8 string without substitution', async () => {
+    const readFile = vi.fn(async () => 'café');
+    const bytes = await readVfsFileBytes({ readFile } as unknown as VirtualFS, '/note.txt');
+    expect(new TextDecoder().decode(bytes)).toBe('café');
+    expect(countReplacementSeqs(bytes)).toBe(0);
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/mouse.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/mouse.test.ts
@@ -9,13 +9,56 @@ import {
 } from '../../../../../src/shell/supplemental-commands/playwright/handlers/mouse.js';
 import type { TabSnapshot } from '../../../../../src/shell/supplemental-commands/playwright/types.js';
 import {
+  allBytesFixture,
+  countReplacementSeqs,
   createHandlerCtx,
   createMockBrowser,
   createMockTransport,
   createPlaywrightState,
+  vfsLikeReadFile,
 } from '../../../helpers/playwright-harness.js';
 
 const TAB = 'tab-1';
+
+type DroppedFile = { name: string; type: string; base64: string };
+type TransportCall = { method: string; params: Record<string, unknown> };
+
+function decodeBase64(base64: string): Uint8Array {
+  return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+}
+
+/**
+ * Recover the `files` array the handler sent to the page, from either drop
+ * path: `Runtime.callFunctionOn` arguments (backendNodeId) or the inlined
+ * `filesData` literal in the `Runtime.evaluate` expression (CSS fallback).
+ */
+function droppedFiles(calls: TransportCall[]): DroppedFile[] {
+  const callFn = calls.find((c) => c.method === 'Runtime.callFunctionOn');
+  if (callFn) {
+    const args = callFn.params['arguments'] as Array<{ value: unknown }> | undefined;
+    return (args?.[0]?.value ?? []) as DroppedFile[];
+  }
+  const expression = calls.find((c) => c.method === 'Runtime.evaluate')?.params['expression'] as
+    | string
+    | undefined;
+  const match = expression?.match(/var filesData = (\[[\s\S]*?\]);/);
+  return match ? (JSON.parse(match[1]) as DroppedFile[]) : [];
+}
+
+/** Mock transport that records every call and satisfies both drop paths. */
+function captureTransport(): {
+  transport: ReturnType<typeof createMockTransport>;
+  calls: TransportCall[];
+} {
+  const calls: TransportCall[] = [];
+  const transport = createMockTransport((method, params) => {
+    calls.push({ method, params: (params ?? {}) as Record<string, unknown> });
+    if (method === 'DOM.resolveNode') return { object: { objectId: 'o1' } };
+    if (method === 'Runtime.callFunctionOn') return { result: { value: 'DIV' } };
+    return {};
+  });
+  return { transport, calls };
+}
 
 function makeSnapshot(over: Partial<TabSnapshot> = {}): TabSnapshot {
   return {
@@ -164,7 +207,7 @@ describe('drop handler', () => {
       })
     );
     expect(r.stdout).toBe('Dropped onto e5\n');
-    expect(readFile).toHaveBeenCalledWith('/upload.txt');
+    expect(readFile).toHaveBeenCalledWith('/upload.txt', { encoding: 'binary' });
     expect(state.snapshots.has(TAB)).toBe(false);
   });
 
@@ -221,5 +264,109 @@ describe('drop handler', () => {
     await expect(
       dropHandler(createHandlerCtx({ browser, state, positional: ['e9'], flags: { tab: TAB } }))
     ).rejects.toThrow('Unknown ref');
+  });
+});
+
+describe('drop --path binary fidelity (#2883)', () => {
+  it('drops the 0x00..0xFF fixture byte-exactly via backendNodeId', async () => {
+    const fixture = allBytesFixture();
+    const files = new Map<string, string | Uint8Array>([['/allbytes.bin', fixture]]);
+    const { transport, calls } = captureTransport();
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 9]]) }));
+
+    const r = await dropHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['e5'],
+        flags: { tab: TAB, path: '/allbytes.bin' },
+        fs: { readFile: vfsLikeReadFile(files) },
+      })
+    );
+
+    expect(r.exitCode).toBe(0);
+    expect(calls.some((c) => c.method === 'DOM.resolveNode')).toBe(true);
+    const dropped = droppedFiles(calls);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].type).toBe('application/octet-stream');
+    const decoded = decodeBase64(dropped[0].base64);
+    expect(decoded.length).toBe(256);
+    expect(countReplacementSeqs(decoded)).toBe(0);
+    expect(Array.from(decoded)).toEqual(Array.from(fixture));
+  });
+
+  it('drops the 0x00..0xFF fixture byte-exactly via the CSS selector fallback', async () => {
+    const fixture = allBytesFixture();
+    const files = new Map<string, string | Uint8Array>([['/clip.mp4', fixture]]);
+    const { transport, calls } = captureTransport();
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToSelector: new Map([['e5', '#zone']]) }));
+
+    const r = await dropHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['e5'],
+        flags: { tab: TAB, path: '/clip.mp4' },
+        fs: { readFile: vfsLikeReadFile(files) },
+      })
+    );
+
+    expect(r.exitCode).toBe(0);
+    expect(calls.some((c) => c.method === 'Runtime.evaluate')).toBe(true);
+    const dropped = droppedFiles(calls);
+    expect(dropped[0].type).toBe('video/mp4');
+    const decoded = decodeBase64(dropped[0].base64);
+    expect(decoded.length).toBe(256);
+    expect(countReplacementSeqs(decoded)).toBe(0);
+    expect(Array.from(decoded)).toEqual(Array.from(fixture));
+  });
+
+  it('still drops ASCII and valid UTF-8 text unchanged', async () => {
+    const text = 'hello café — plain ASCII plus valid UTF-8';
+    const files = new Map<string, string | Uint8Array>([['/note.txt', text]]);
+    const { transport, calls } = captureTransport();
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 9]]) }));
+
+    const r = await dropHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['e5'],
+        flags: { tab: TAB, path: '/note.txt' },
+        fs: { readFile: vfsLikeReadFile(files) },
+      })
+    );
+
+    expect(r.exitCode).toBe(0);
+    const dropped = droppedFiles(calls);
+    expect(dropped[0].type).toBe('text/plain');
+    const decoded = decodeBase64(dropped[0].base64);
+    expect(new TextDecoder().decode(decoded)).toBe(text);
+    expect(countReplacementSeqs(decoded)).toBe(0);
+  });
+
+  it('fails instead of dropping a payload a text decode already mangled', async () => {
+    const { transport } = captureTransport();
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 9]]) }));
+
+    await expect(
+      dropHandler(
+        createHandlerCtx({
+          browser,
+          state,
+          positional: ['e5'],
+          flags: { tab: TAB, path: '/corrupt.bin' },
+          fs: { readFile: (async () => 'JFIF\uFFFD\uFFFD') as unknown as VirtualFS['readFile'] },
+        })
+      )
+    ).rejects.toThrow(/faithfully/);
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/upload.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/upload.test.ts
@@ -1,34 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { VirtualFS } from '../../../../../src/fs/index.js';
-import {
-  readUploadBytes,
-  uploadHandler,
-} from '../../../../../src/shell/supplemental-commands/playwright/handlers/upload.js';
+import { describe, expect, it } from 'vitest';
+import { uploadHandler } from '../../../../../src/shell/supplemental-commands/playwright/handlers/upload.js';
 import type { TabSnapshot } from '../../../../../src/shell/supplemental-commands/playwright/types.js';
 import {
+  allBytesFixture,
+  countReplacementSeqs,
   createHandlerCtx,
   createMockBrowser,
   createMockTransport,
   createPlaywrightState,
+  vfsLikeReadFile,
 } from '../../../helpers/playwright-harness.js';
 
 const TAB = 'tab-1';
-
-/** Issue #2878 fixture: every byte 0x00..0xFF exactly once. */
-function allBytesFixture(): Uint8Array {
-  return Uint8Array.from({ length: 256 }, (_, i) => i);
-}
-
-function countReplacementSeqs(bytes: Uint8Array): number {
-  let n = 0;
-  for (let i = 0; i + 2 < bytes.length; i++) {
-    if (bytes[i] === 0xef && bytes[i + 1] === 0xbf && bytes[i + 2] === 0xbd) {
-      n++;
-      i += 2;
-    }
-  }
-  return n;
-}
 
 function decodeUploadedBase64(base64: string): Uint8Array {
   return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
@@ -45,29 +28,6 @@ function makeSnapshot(over: Partial<TabSnapshot> = {}): TabSnapshot {
     refToFrameId: new Map(),
     ...over,
   };
-}
-
-type StoredFile = string | Uint8Array;
-
-/**
- * VirtualFS-shaped reader: default encoding is UTF-8 with replacement, matching
- * production `VirtualFS.readFile`. `{ encoding: 'binary' }` returns the stored
- * bytes. A test that forgets `encoding: 'binary'` sees U+FFFD for high bytes.
- */
-function vfsLikeReadFile(files: Map<string, StoredFile>): VirtualFS['readFile'] {
-  return (async (path: string, options?: { encoding?: string }) => {
-    const stored = files.get(path);
-    if (stored === undefined) {
-      throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' as const });
-    }
-    const encoding = options?.encoding ?? 'utf-8';
-    if (stored instanceof Uint8Array) {
-      if (encoding === 'binary') return stored;
-      return new TextDecoder('utf-8').decode(stored);
-    }
-    if (encoding === 'binary') return new TextEncoder().encode(stored);
-    return stored;
-  }) as VirtualFS['readFile'];
 }
 
 type TransportCall = { method: string; params: Record<string, unknown> };
@@ -106,39 +66,10 @@ function filesFromTransport(calls: TransportCall[]): Array<{
   return JSON.parse(match[1]) as Array<{ name: string; type: string; base64: string }>;
 }
 
-describe('readUploadBytes', () => {
-  it('returns stored bytes when encoding:binary is honoured', async () => {
-    const fixture = allBytesFixture();
-    const files = new Map<string, StoredFile>([['/allbytes.bin', fixture]]);
-    const bytes = await readUploadBytes(
-      { readFile: vfsLikeReadFile(files) } as VirtualFS,
-      '/allbytes.bin'
-    );
-    expect(bytes.length).toBe(256);
-    expect(Array.from(bytes)).toEqual(Array.from(fixture));
-    expect(countReplacementSeqs(bytes)).toBe(0);
-  });
-
-  it('fails loudly when a text decode already substituted U+FFFD', async () => {
-    const readFile = vi.fn(async () => 'ASCII\uFFFDMORE');
-    await expect(
-      readUploadBytes({ readFile } as unknown as VirtualFS, '/corrupt.bin')
-    ).rejects.toThrow(/faithfully/);
-    expect(readFile).toHaveBeenCalledWith('/corrupt.bin', { encoding: 'binary' });
-  });
-
-  it('encodes a valid UTF-8 string without substitution', async () => {
-    const readFile = vi.fn(async () => 'café');
-    const bytes = await readUploadBytes({ readFile } as unknown as VirtualFS, '/note.txt');
-    expect(new TextDecoder().decode(bytes)).toBe('café');
-    expect(countReplacementSeqs(bytes)).toBe(0);
-  });
-});
-
 describe('uploadHandler binary fidelity (#2878)', () => {
   it('uploads the 0x00..0xFF fixture through the focused-input path without U+FFFD', async () => {
     const fixture = allBytesFixture();
-    const files = new Map<string, StoredFile>([['/allbytes.bin', fixture]]);
+    const files = new Map<string, string | Uint8Array>([['/allbytes.bin', fixture]]);
     const { transport, calls } = captureTransport();
     const { browser } = createMockBrowser({ transport });
 
@@ -166,7 +97,7 @@ describe('uploadHandler binary fidelity (#2878)', () => {
 
   it('uploads the 0x00..0xFF fixture through a snapshot ref without U+FFFD', async () => {
     const fixture = allBytesFixture();
-    const files = new Map<string, StoredFile>([['/allbytes.bin', fixture]]);
+    const files = new Map<string, string | Uint8Array>([['/allbytes.bin', fixture]]);
     const { transport, calls } = captureTransport();
     const { browser } = createMockBrowser({ transport });
     const state = createPlaywrightState();
@@ -196,7 +127,7 @@ describe('uploadHandler binary fidelity (#2878)', () => {
 
   it('still uploads valid UTF-8 text files byte-exactly', async () => {
     const text = 'hello café — ASCII plus valid UTF-8';
-    const files = new Map<string, StoredFile>([['/note.txt', text]]);
+    const files = new Map<string, string | Uint8Array>([['/note.txt', text]]);
     const { transport, calls } = captureTransport();
     const { browser } = createMockBrowser({ transport });
 


### PR DESCRIPTION
Closes #2883

## Summary

`playwright-cli drop --path=<vfs-file>` UTF-8-decoded the VFS file and re-encoded it with `TextEncoder`, so every byte `>= 0x80` became U+FFFD (`EF BF BD`). The drop still exited 0 while the page's `DataTransfer` received a corrupt JPEG / zip / mp4. `drop` now reads raw bytes; if a backend still hands back a string that already contains U+FFFD, the command fails instead of injecting a mangled `File`.

Same hop as #2878 / #2888 (`upload`), different command — `drop` is the path for hidden file inputs and drag-and-drop widgets that `upload` cannot hit, so it stayed broken after #2888 landed.

## Why

The hop was `VirtualFS.readFile()` (default `encoding: 'utf-8'`, non-fatal decode → U+FFFD) → `TextEncoder.encode(string)` → base64 → page `File`. This is not the just-bash `VfsAdapter` (latin1-preserving), which is why `curl` / `ffmpeg` / `zip` were fine and this was not. Same family as #2818 (`Uint8Array` all the way to the `Blob`).

## Approach / Implementation notes

- New `playwright/binary.ts` → `readVfsFileBytes(fs, path)`: `fs.readFile(path, { encoding: 'binary' })`, returns `Uint8Array`. A string containing U+FFFD throws `cannot represent … faithfully`; a non-string/non-bytes payload throws too.
- `dropHandler` uses it and drops the local `TextEncoder` fallback.
- **#2888 merged while this was in flight**, so rather than shipping a second copy of the same helper this PR **converges** them: `readUploadBytes` moves out of `upload.ts` into `binary.ts` as `readVfsFileBytes`, and `upload` calls it. Behaviour is byte-for-byte identical — same `{ encoding: 'binary' }` read, same U+FFFD refusal, same error strings — and #2888's `isElementRef` / `parseUploadArgs` / docs are untouched. Its `readUploadBytes` unit cases move to `binary.test.ts`; its handler-level cases stay.
- The hand-rolled `uint8ToBase64` in `mouse.ts` is replaced by the `@slicc/shared-ts` one (Buffer-backed in Node, chunked in the browser) — the same swap #2888 made in `upload.ts`. `state.ts` in the same directory already imports from `@slicc/shared-ts`, so no new chunk edge.
- Page-side `File` construction is unchanged: `Uint8Array.from(atob(base64), c => c.charCodeAt(0))` → `new File([bytes], name, { type })`.
- Test fixtures shared by both commands (`allBytesFixture`, `countReplacementSeqs`, `vfsLikeReadFile`) move to `tests/shell/helpers/playwright-harness.ts`, replacing the copies #2888 had inlined in `upload.test.ts`.

## Cross-cutting impact

- **Floats**: CLI and extension share this handler; no float-specific code. No float probe.
- **Shell contexts**: same `playwright-cli` dispatcher in every float.
- ASCII and valid UTF-8 text drops are unchanged (pinned by test).
- `--data` items are unaffected — they were always strings.

## Test plan

Every claim below was checked by **reverting the fix and confirming the test fails**, not just by watching it pass.

- [x] **Live Chrome probe** — `/drop.html` fixture page reports `file.size` and scans the dropped bytes for `EF BF BD`. With the fix: `size 256`, `byteLength 256`, `replacementSeqs 0`, bytes identical. Reverted: `AssertionError: expected 512 to be 256` — the issue's exact arithmetic, in a real browser.
- [x] **Unit, both drop paths** — 256-byte `0x00..0xFF` fixture decoded back off the CDP wire via the backendNodeId `Runtime.callFunctionOn` path *and* the CSS-selector `Runtime.evaluate` fallback. Reverted: both fail 512 ≠ 256.
- [x] Fail-loud case: a reader returning a string that already contains U+FFFD rejects instead of dropping. Reverted: resolves with exit 0.
- [x] The pre-existing `drop with --path reads file from VFS` test now asserts the `{ encoding: 'binary' }` call. Reverted: fails.
- [x] ASCII + valid UTF-8 (`café`) drop still round-trips exactly (no-regression pin; passes either way by design).
- [x] `readVfsFileBytes` unit suite in `binary.test.ts`.
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/` — 18 files, 199 passed
- [x] `SLICC_TEST_CHROME_INTEGRATION=1 npx vitest run … -t "byte-exact"` — both the #2878 upload probe and the new #2883 drop probe pass against real headless Chrome
- [x] `npm run lint` — 0 errors (43 warnings, same count as `origin/main`)
- [x] `npm run typecheck` — clean (all 9 projects)
- [x] `npm run test` — 20047 passed
- [x] `npm run test:coverage:webapp` — 16148 passed, floors held
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension` — both exit 0, no `dist/` diff
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists

The unit tests read through `vfsLikeReadFile` — a `VirtualFS`-faithful mock whose **default** encoding is UTF-8-with-replacement, so a regression to `fs.readFile(path)` fails them rather than silently passing.

**Pre-existing failure** (unrelated, also on clean `origin/main` — verified by detached checkout): `packages/dev-tools/tools/check-touched-exemptions.test.mjs` › `passes when the changed file is NOT on the float-probe debt list`. Same one #2888 flagged.

## Documentation

- [x] `packages/vfs-root/workspace/skills/playwright-cli/SKILL.md` — raw-bytes contract on `drop --path`
- [x] `packages/webapp/src/shell/supplemental-commands/playwright/help.ts` — `drop --help`
- [x] `docs/shell-reference.md` — binary-capable tools list (now names both `upload` and `drop --path`)

## Risk & rollback

- Blast radius: every `playwright-cli drop --path` and `upload` (CLI + extension). Text drops/uploads are byte-identical to before; binary ones stop being corrupt.
- The `upload` half is a pure relocation of #2888's helper — no behaviour change, covered by that PR's tests plus its live probe, both still green.
- Rollback: revert this PR. No persisted state, no migration.
- New failure mode is a loud error on an unrepresentable read, replacing a silent corruption.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Public `drop` contract documented
- [x] Linear history; rebased onto `origin/main`
