### PR TITLE
test(dev-tools): make the touched-exemptions added-entry test hermetic to checkout depth

### DIFF
--- a/packages/dev-tools/tools/check-touched-exemptions.test.mjs
+++ b/packages/dev-tools/tools/check-touched-exemptions.test.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -60,78 +60,64 @@ function run(env, baseRef = 'origin/main') {
 }
 
 /**
- * Build a scratch commit — a child of HEAD with exactly one file's blob
- * swapped for `content` — without touching the real index or working tree.
- * Returns the commit SHA, which `readBaseJson`'s `git show <ref>:<path>`
- * accepts directly (no branch/tag needs to exist). Uses a throwaway
- * `GIT_INDEX_FILE` so the developer's / CI runner's real index is never
- * touched; the commit itself is a dangling object once the test ends (never
- * referenced by a branch), so it needs no cleanup beyond the scratch index
- * file.
- *
- * This is what makes the "the changed file is not on the debt list" test
- * hermetic to checkout depth: the base ref it diffs against is guaranteed
- * to already contain the fake entry, so the added-entry check has nothing
- * to find regardless of whether `origin/main` happens to be resolvable.
- *
- * Uses `os.tmpdir()`, not a path under `repoRoot/.git/` — in a git
- * *worktree* (like this repo commonly runs in), `.git` is a text file
- * pointing at the real gitdir elsewhere, not a directory, so treating it as
- * one throws ENOTDIR.
- *
- * `commit-tree` also needs an author/committer identity, which a developer's
- * machine has (global `user.name`/`user.email`) but a CI runner may not —
- * `node-matrix-tests` has none, so this failed there with `fatal: empty
- * ident name` even though it passed on every local machine. GIT_AUTHOR_* /
- * GIT_COMMITTER_* are set explicitly so the fixture never depends on
- * config/GECOS/hostname fallback being present anywhere, and
- * GIT_CONFIG_GLOBAL=/dev/null keeps a developer's global git config (hooks,
- * aliases, unrelated settings) from leaking into the scratch commit either.
+ * Explicit git identity for every scratch git invocation below.
+ * `commit-tree`/`commit` need an author/committer identity, which a
+ * developer's machine has (global `user.name`/`user.email`, or at worst a
+ * GECOS/hostname fallback) but a CI runner may not — `node-matrix-tests` has
+ * none of those, so an earlier version of this fixture failed there with
+ * `fatal: empty ident name` despite passing on every machine it was tested
+ * on before pushing (#2899). Set explicitly so the fixture never depends on
+ * config/GECOS/hostname being present anywhere; GIT_CONFIG_GLOBAL=/dev/null
+ * also keeps a developer's global git config (hooks, aliases, unrelated
+ * settings) from leaking in.
  */
-function makeScratchCommit(fileRelPath, content) {
-  const scratchIndex = resolve(tmpdir(), `touched-exemptions-test-index-${process.pid}`);
-  const env = {
-    ...process.env,
-    GIT_INDEX_FILE: scratchIndex,
-    GIT_CONFIG_GLOBAL: '/dev/null',
-    GIT_AUTHOR_NAME: 'check-touched-exemptions test',
-    GIT_AUTHOR_EMAIL: 'noreply@slicc.test',
-    GIT_COMMITTER_NAME: 'check-touched-exemptions test',
-    GIT_COMMITTER_EMAIL: 'noreply@slicc.test',
+const SCRATCH_GIT_ENV = {
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_AUTHOR_NAME: 'check-touched-exemptions test',
+  GIT_AUTHOR_EMAIL: 'noreply@slicc.test',
+  GIT_COMMITTER_NAME: 'check-touched-exemptions test',
+  GIT_COMMITTER_EMAIL: 'noreply@slicc.test',
+};
+
+/**
+ * Build a throwaway git repo under `os.tmpdir()` containing exactly one
+ * file, at `fileRelPath`, holding `content`, committed at its root. Returns
+ * the commit SHA and that repo's own object directory.
+ *
+ * `readBaseJson`'s `git show <ref>:<path>` (run against THIS repo, in
+ * `check-touched-exemptions.mjs`) can still resolve that SHA — pass
+ * `objectsDir` as `GIT_ALTERNATE_OBJECT_DIRECTORIES` to the `run()` call
+ * that exercises it, and git will search the alternate directory to
+ * resolve objects without ever copying them in. This repo is commonly a git
+ * *worktree* sharing ONE object store with every sibling worktree/session;
+ * an earlier version of this fixture built the scratch commit directly
+ * there (`commit-tree`/`hash-object -w` against `repoRoot`), leaving
+ * dangling blob/tree/commit objects in that SHARED store permanently
+ * (#2899 round-2 review). A fully separate throwaway repo, resolved only
+ * via the alternates mechanism, writes nothing there at all — the same
+ * pattern `check-swift-resolved-drift.test.mjs` uses for its end-to-end
+ * fixture, minus the object-database isolation this one additionally needs
+ * (that guard's throwaway repo is also the CWD the guard runs against, so
+ * it never touches the real repo's objects to begin with).
+ *
+ * Call `cleanup()` when done.
+ */
+function makeScratchBaseRef(fileRelPath, content) {
+  const repoDir = mkdtempSync(resolve(tmpdir(), 'touched-exemptions-scratch-'));
+  const env = { ...process.env, ...SCRATCH_GIT_ENV };
+  const git = (...args) =>
+    execFileSync('git', args, { cwd: repoDir, env, encoding: 'utf8' }).trim();
+  git('init', '-q');
+  const filePath = resolve(repoDir, fileRelPath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+  git('add', fileRelPath);
+  git('commit', '-q', '-m', 'scratch: check-touched-exemptions test fixture');
+  return {
+    sha: git('rev-parse', 'HEAD'),
+    objectsDir: resolve(repoDir, '.git', 'objects'),
+    cleanup: () => rmSync(repoDir, { recursive: true, force: true }),
   };
-  try {
-    execFileSync('git', ['read-tree', 'HEAD'], { cwd: repoRoot, env });
-    const blobSha = execFileSync('git', ['hash-object', '-w', '--stdin'], {
-      cwd: repoRoot,
-      env,
-      input: content,
-      encoding: 'utf8',
-    }).trim();
-    execFileSync(
-      'git',
-      ['update-index', '--add', '--cacheinfo', `100644,${blobSha},${fileRelPath}`],
-      { cwd: repoRoot, env }
-    );
-    const treeSha = execFileSync('git', ['write-tree'], {
-      cwd: repoRoot,
-      env,
-      encoding: 'utf8',
-    }).trim();
-    return execFileSync(
-      'git',
-      [
-        'commit-tree',
-        treeSha,
-        '-p',
-        'HEAD',
-        '-m',
-        'scratch: check-touched-exemptions test fixture',
-      ],
-      { cwd: repoRoot, env, encoding: 'utf8' }
-    ).trim();
-  } finally {
-    rmSync(scratchIndex, { force: true });
-  }
 }
 
 const FAKE_PATH = 'packages/webapp/src/scoops/__fake_float_probe_test_file__.ts';
@@ -172,14 +158,52 @@ describe('check-touched-exemptions: float-probe debt list wiring', () => {
     // resolvable there, which degrades the added-entry check to a no-op
     // instead of genuinely exercising this scenario).
     const fakeContent = `${JSON.stringify({ [FAKE_PATH]: 1 }, null, 2)}\n`;
-    const scratchBaseRef = makeScratchCommit(FLOAT_PROBE_BASELINE_REL, fakeContent);
+    const scratch = makeScratchBaseRef(FLOAT_PROBE_BASELINE_REL, fakeContent);
     writeFileSync(FLOAT_PROBE_BASELINE_PATH, fakeContent);
-    const { code, out } = run(
-      { CHANGED_FILES: 'packages/webapp/src/scoops/unrelated-file.ts' },
-      scratchBaseRef
-    );
-    expect(code).toBe(0);
-    expect(out).toContain('OK');
+    try {
+      const { code, out } = run(
+        {
+          CHANGED_FILES: 'packages/webapp/src/scoops/unrelated-file.ts',
+          GIT_ALTERNATE_OBJECT_DIRECTORIES: scratch.objectsDir,
+        },
+        scratch.sha
+      );
+      expect(code).toBe(0);
+      expect(out).toContain('OK');
+      // A skip (base ref unresolvable — see the describe block below) must
+      // never be mistaken for a genuine "nothing added" pass; the very next
+      // test proves this same mechanism genuinely gates growth rather than
+      // always skipping.
+      expect(out).not.toContain('could not read the float-probe debt list');
+    } finally {
+      scratch.cleanup();
+    }
+  });
+
+  it('FAILS — does not silently skip — when an untouched file made the debt list grow', () => {
+    // Companion to the pass above, round-2 review (#2899, Grok): none of
+    // the pre-existing cases actually required the added-entry check to
+    // RUN to pass — a script that always skipped it (or the original #2843
+    // empty-baseline bug) would have passed every one of them too. This is
+    // the base ref genuinely containing FEWER entries than the working
+    // tree, so a correct run must fail even though CHANGED_FILES names an
+    // unrelated file.
+    const scratch = makeScratchBaseRef(FLOAT_PROBE_BASELINE_REL, '{}\n');
+    writeFileSync(FLOAT_PROBE_BASELINE_PATH, `${JSON.stringify({ [FAKE_PATH]: 1 }, null, 2)}\n`);
+    try {
+      const { code, out } = run(
+        {
+          CHANGED_FILES: 'packages/webapp/src/scoops/unrelated-file.ts',
+          GIT_ALTERNATE_OBJECT_DIRECTORIES: scratch.objectsDir,
+        },
+        scratch.sha
+      );
+      expect(code).toBe(1);
+      expect(out).toContain('must not grow');
+      expect(out).not.toContain('could not read the float-probe debt list');
+    } finally {
+      scratch.cleanup();
+    }
   });
 
   it('passes with the real, empty baseline untouched (sanity: no debt lists at all today)', () => {

--- a/packages/dev-tools/tools/check-touched-exemptions.test.mjs
+++ b/packages/dev-tools/tools/check-touched-exemptions.test.mjs
@@ -78,10 +78,27 @@ function run(env, baseRef = 'origin/main') {
  * *worktree* (like this repo commonly runs in), `.git` is a text file
  * pointing at the real gitdir elsewhere, not a directory, so treating it as
  * one throws ENOTDIR.
+ *
+ * `commit-tree` also needs an author/committer identity, which a developer's
+ * machine has (global `user.name`/`user.email`) but a CI runner may not —
+ * `node-matrix-tests` has none, so this failed there with `fatal: empty
+ * ident name` even though it passed on every local machine. GIT_AUTHOR_* /
+ * GIT_COMMITTER_* are set explicitly so the fixture never depends on
+ * config/GECOS/hostname fallback being present anywhere, and
+ * GIT_CONFIG_GLOBAL=/dev/null keeps a developer's global git config (hooks,
+ * aliases, unrelated settings) from leaking into the scratch commit either.
  */
 function makeScratchCommit(fileRelPath, content) {
   const scratchIndex = resolve(tmpdir(), `touched-exemptions-test-index-${process.pid}`);
-  const env = { ...process.env, GIT_INDEX_FILE: scratchIndex };
+  const env = {
+    ...process.env,
+    GIT_INDEX_FILE: scratchIndex,
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_AUTHOR_NAME: 'check-touched-exemptions test',
+    GIT_AUTHOR_EMAIL: 'noreply@slicc.test',
+    GIT_COMMITTER_NAME: 'check-touched-exemptions test',
+    GIT_COMMITTER_EMAIL: 'noreply@slicc.test',
+  };
   try {
     execFileSync('git', ['read-tree', 'HEAD'], { cwd: repoRoot, env });
     const blobSha = execFileSync('git', ['hash-object', '-w', '--stdin'], {

--- a/packages/dev-tools/tools/check-touched-exemptions.test.mjs
+++ b/packages/dev-tools/tools/check-touched-exemptions.test.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -8,6 +9,7 @@ import { BASELINE_PATH as FLOAT_PROBE_BASELINE_PATH } from './check-no-float-pro
 const filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(filename), '..', '..', '..');
 const scriptPath = resolve(repoRoot, 'packages/dev-tools/tools/check-touched-exemptions.mjs');
+const FLOAT_PROBE_BASELINE_REL = 'packages/dev-tools/tools/float-probe-baseline.json';
 
 // `check-touched-exemptions.mjs` calls `process.exit(main())` unconditionally
 // at module load (no `import.meta.url === …` entry guard), so it cannot be
@@ -28,11 +30,19 @@ const scriptPath = resolve(repoRoot, 'packages/dev-tools/tools/check-touched-exe
 // `check-touched-exemptions.mjs`'s `main()`), so a caller that already knows
 // its changed-file set — this test, but also plausibly a future non-PR
 // caller — gets a hermetic, event-independent run.
-function run(env) {
+//
+// `baseRef` defaults to `origin/main`, but is itself a hidden environment
+// dependency: `node-matrix-tests`' CI checkout (unlike `lint`'s) has no
+// `fetch-depth: 0`, so `origin/main` is NOT a resolvable ref there (only the
+// one commit under test is fetched). That silently degrades the base-ref
+// reads to `null` (see `readBaseJson`), which skips the added-entry check
+// entirely — see the dedicated describe block below, which pins that
+// production behavior on purpose instead of leaving it accidental.
+function run(env, baseRef = 'origin/main') {
   try {
     return {
       code: 0,
-      out: execFileSync('node', [scriptPath, 'origin/main'], {
+      out: execFileSync('node', [scriptPath, baseRef], {
         cwd: repoRoot,
         encoding: 'utf8',
         env: {
@@ -46,6 +56,64 @@ function run(env) {
     };
   } catch (err) {
     return { code: err.status ?? 1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+/**
+ * Build a scratch commit — a child of HEAD with exactly one file's blob
+ * swapped for `content` — without touching the real index or working tree.
+ * Returns the commit SHA, which `readBaseJson`'s `git show <ref>:<path>`
+ * accepts directly (no branch/tag needs to exist). Uses a throwaway
+ * `GIT_INDEX_FILE` so the developer's / CI runner's real index is never
+ * touched; the commit itself is a dangling object once the test ends (never
+ * referenced by a branch), so it needs no cleanup beyond the scratch index
+ * file.
+ *
+ * This is what makes the "the changed file is not on the debt list" test
+ * hermetic to checkout depth: the base ref it diffs against is guaranteed
+ * to already contain the fake entry, so the added-entry check has nothing
+ * to find regardless of whether `origin/main` happens to be resolvable.
+ *
+ * Uses `os.tmpdir()`, not a path under `repoRoot/.git/` — in a git
+ * *worktree* (like this repo commonly runs in), `.git` is a text file
+ * pointing at the real gitdir elsewhere, not a directory, so treating it as
+ * one throws ENOTDIR.
+ */
+function makeScratchCommit(fileRelPath, content) {
+  const scratchIndex = resolve(tmpdir(), `touched-exemptions-test-index-${process.pid}`);
+  const env = { ...process.env, GIT_INDEX_FILE: scratchIndex };
+  try {
+    execFileSync('git', ['read-tree', 'HEAD'], { cwd: repoRoot, env });
+    const blobSha = execFileSync('git', ['hash-object', '-w', '--stdin'], {
+      cwd: repoRoot,
+      env,
+      input: content,
+      encoding: 'utf8',
+    }).trim();
+    execFileSync(
+      'git',
+      ['update-index', '--add', '--cacheinfo', `100644,${blobSha},${fileRelPath}`],
+      { cwd: repoRoot, env }
+    );
+    const treeSha = execFileSync('git', ['write-tree'], {
+      cwd: repoRoot,
+      env,
+      encoding: 'utf8',
+    }).trim();
+    return execFileSync(
+      'git',
+      [
+        'commit-tree',
+        treeSha,
+        '-p',
+        'HEAD',
+        '-m',
+        'scratch: check-touched-exemptions test fixture',
+      ],
+      { cwd: repoRoot, env, encoding: 'utf8' }
+    ).trim();
+  } finally {
+    rmSync(scratchIndex, { force: true });
   }
 }
 
@@ -77,8 +145,22 @@ describe('check-touched-exemptions: float-probe debt list wiring', () => {
   });
 
   it('passes when the changed file is NOT on the float-probe debt list', () => {
-    writeFileSync(FLOAT_PROBE_BASELINE_PATH, `${JSON.stringify({ [FAKE_PATH]: 1 }, null, 2)}\n`);
-    const { code, out } = run({ CHANGED_FILES: 'packages/webapp/src/scoops/unrelated-file.ts' });
+    // The added-entry check (`findAddedExemptions`) is NOT scoped to
+    // CHANGED_FILES — it diffs the whole debt-list file against the base
+    // ref, repo-wide, by design (a PR may not grow the list even via an
+    // untouched-file edit). So the on-disk fake entry must ALREADY be
+    // present at the base ref too, or this test would trip that check
+    // regardless of which file is "changed" — exactly the bug that let it
+    // silently pass in CI (see the module-load note: `origin/main` isn't
+    // resolvable there, which degrades the added-entry check to a no-op
+    // instead of genuinely exercising this scenario).
+    const fakeContent = `${JSON.stringify({ [FAKE_PATH]: 1 }, null, 2)}\n`;
+    const scratchBaseRef = makeScratchCommit(FLOAT_PROBE_BASELINE_REL, fakeContent);
+    writeFileSync(FLOAT_PROBE_BASELINE_PATH, fakeContent);
+    const { code, out } = run(
+      { CHANGED_FILES: 'packages/webapp/src/scoops/unrelated-file.ts' },
+      scratchBaseRef
+    );
     expect(code).toBe(0);
     expect(out).toContain('OK');
   });
@@ -87,6 +169,46 @@ describe('check-touched-exemptions: float-probe debt list wiring', () => {
     const { code, out } = run({ CHANGED_FILES: FAKE_PATH });
     expect(code).toBe(0);
     expect(out).toContain('no debt lists found');
+  });
+});
+
+/**
+ * `node-matrix-tests`' CI checkout has no `fetch-depth: 0` (unlike `lint`'s),
+ * so `origin/main` is not a resolvable ref there — only the single commit
+ * under test is fetched. `readBaseJson`'s `git show <ref>:<path>` then fails
+ * for every rule, which is caught and returns `null`, which makes
+ * `baseReadable` false, which SKIPS the added-entry check entirely (see
+ * `main()`'s `ruleStates.filter((rule) => rule.baseReadable)`). That's a
+ * real, currently-relied-upon behavior — not a hypothetical — verified by
+ * replaying the exact depth-1 `git fetch` of PR #2843's own merge commit
+ * (`3b5b77594157ca69f67980ff62cc3f541a4c2e57`) locally: `origin/main`
+ * doesn't resolve, and the suite passes. Pin it explicitly here instead of
+ * leaving it an accident of checkout depth.
+ */
+describe('check-touched-exemptions: unresolvable base ref (shallow-checkout parity)', () => {
+  const originalBaseline = readFileSync(FLOAT_PROBE_BASELINE_PATH, 'utf8');
+
+  afterEach(() => {
+    writeFileSync(FLOAT_PROBE_BASELINE_PATH, originalBaseline);
+  });
+
+  it('skips the added-entry check (not just "no entries added") when the base ref cannot be read', () => {
+    writeFileSync(FLOAT_PROBE_BASELINE_PATH, `${JSON.stringify({ [FAKE_PATH]: 1 }, null, 2)}\n`);
+    const { code, out } = run(
+      { CHANGED_FILES: 'packages/webapp/src/scoops/unrelated-file.ts' },
+      'this-ref-does-not-exist-anywhere'
+    );
+    expect(code).toBe(0);
+    expect(out).toContain('notice — could not read the float-probe debt list');
+    expect(out).toContain('OK');
+  });
+
+  it('still runs the touched-file check when the base ref cannot be read', () => {
+    writeFileSync(FLOAT_PROBE_BASELINE_PATH, `${JSON.stringify({ [FAKE_PATH]: 1 }, null, 2)}\n`);
+    const { code, out } = run({ CHANGED_FILES: FAKE_PATH }, 'this-ref-does-not-exist-anywhere');
+    expect(code).toBe(1);
+    expect(out).toContain('float-probe debt list');
+    expect(out).toContain(FAKE_PATH);
   });
 });
 


### PR DESCRIPTION
## Summary

`check-touched-exemptions.test.mjs`'s "passes when the changed file is NOT on the float-probe debt list" test (landed in #2843) only ever passed by accident. Makes it hermetic to checkout depth instead.

## Root cause

Two layered issues:

1. **Test logic bug.** `check-touched-exemptions.mjs`'s "added-entry / debt list must not grow" check (`findAddedExemptions`) is not scoped to `CHANGED_FILES` at all — by design it diffs the *whole* debt-list file against the base ref, repo-wide (a PR may not grow the list even via an untouched-file edit). The test wrote a brand-new key into the on-disk baseline to simulate "an entry exists but wasn't touched," which unconditionally also trips that separate, repo-wide check — regardless of which file `CHANGED_FILES` names.

2. **Why CI didn't catch it.** `node-matrix-tests`' checkout step has no `fetch-depth: 0` (unlike `lint`'s, which does — with a comment explaining exactly why). In that shallow, single-commit checkout, `origin/main` is not a resolvable git ref. `readBaseJson`'s `git show origin/main:<path>` then fails, is caught, and returns `null` — which sets `baseReadable = false` and silently *skips* the added-entry check for every rule. The test "passed" for the wrong reason: the very check it was meant to exercise never ran in that job.

Confirmed by replaying the exact `git fetch --depth=1` of #2843's own merge commit (`3b5b77594157ca69f67980ff62cc3f541a4c2e57`) locally: `origin/main` does not resolve, and the suite passes. With full history (a normal local checkout, or the `lint` job) it fails reliably. Verified against the real merge_group CI log for that commit too — `node-matrix-tests (25)` shows all 5 tests green.

## Fix

- Build the fake baseline entry into a **scratch git commit** — a child of `HEAD` with one blob swapped, via a throwaway `GIT_INDEX_FILE` so the real index is never touched — and diff against *that* instead of `origin/main`. The scratch base ref already contains the fake entry, so the added-entry check has nothing to find regardless of whether `origin/main` happens to be resolvable. (Uses `os.tmpdir()`, not a path under `repoRoot/.git/`: in a git *worktree* `.git` is a text file pointing at the real gitdir elsewhere, not a directory, so treating it as one throws `ENOTDIR`.)
- Added a dedicated `describe` block that pins the "base ref unresolvable" production behavior *explicitly* — an unresolvable ref skips the added-entry check, but the touched-file check still runs — instead of leaving it an accident of checkout depth.

No change to the gate script itself (`check-touched-exemptions.mjs`) — this is a test-only fix.

## Test plan

- [x] `npx vitest run packages/dev-tools/tools/check-touched-exemptions.test.mjs` — 7/7 pass in a full-history worktree
- [x] Replayed a `git fetch --depth=1` of the exact commit `node-matrix-tests` checks out for a merge_group run — 7/7 pass there too (same suite, previously only passed by accident in this exact scenario)
- [x] Mutation-tested: removing the `baseReadable` filter from `check-touched-exemptions.mjs` correctly fails the new "unresolvable base ref" test
- [x] `npx vitest run --project dev-tools` — 1346/1346 pass
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — `no debt lists found — nothing to gate`
- [x] `npm run lint` — clean

Part of #2276 (closed) — this is cleanup on a test #2843 (the float-probe lint gate) shipped as part of that issue's slice D.
