### PR TITLE
fix(dev-tools): keep the cluster sweep in one session

### DIFF
--- a/.github/workflows/regression-cluster-hunter.yml
+++ b/.github/workflows/regression-cluster-hunter.yml
@@ -31,6 +31,12 @@ name: Regression Cluster Hunter
 #   2. claude-code-action reads that fix's diff, states the defect as a rule,
 #      tests each candidate against it, and files an issue per confirmed sibling.
 #
+# `Task` is in --disallowedTools deliberately. On the first live run Claude fanned
+# the sweep out to one sub-agent per package, then ended its turn with "I'll wait
+# for their final reports" — but nothing waits, the session simply terminates.
+# The run went green, filed zero issues, and cost $7.27 in fan-out cache reads.
+# One session, working sequentially and filing as it confirms, is the contract.
+#
 # TRIGGER — why `workflow_run` and not `on: release`. semantic-release publishes
 # the GitHub Release with `secrets.GITHUB_TOKEN` (see release.yml), and GitHub
 # does not start workflow runs from events created by GITHUB_TOKEN. An
@@ -199,6 +205,6 @@ jobs:
           claude_args: |
             --model ${{ vars.CLUSTER_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
             --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*),Bash(git:*)"
-            --disallowedTools "Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh issue close:*),Edit,Write"
+            --disallowedTools "Task,Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh issue close:*),Edit,Write"
             --max-turns 200
           prompt: ${{ steps.scan.outputs.prompt }}

--- a/packages/dev-tools/regression-cluster-hunter/README.md
+++ b/packages/dev-tools/regression-cluster-hunter/README.md
@@ -108,6 +108,17 @@ This is exactly why the brief tells Claude the table is a lead rather than a
 finding, and instructs it to grep for the _concept_. Do not raise the caps to
 chase the last siblings — that trades a reviewable shortlist for a grep dump.
 
+## The sweep runs in one session
+
+`Task` is in `--disallowedTools`, and the brief says so twice. On the first
+live run (`33960038570`) Claude fanned the sweep out to one sub-agent per
+package, then ended its turn with _"I'll wait for their final reports"_. Nothing
+waits — the session terminated, the run went green, and it filed **zero issues**
+after spending $7.27, almost all of it fan-out cache reads. The brief now also
+requires filing each sibling the moment it is confirmed rather than batching
+verdicts for the end, so a session that runs out of room still leaves its
+findings behind.
+
 ## Cost gates
 
 Releases land ~8×/day here (~27 `fix` commits/day), so an ungated hunt-per-

--- a/packages/dev-tools/regression-cluster-hunter/lib.mjs
+++ b/packages/dev-tools/regression-cluster-hunter/lib.mjs
@@ -528,6 +528,24 @@ ${c.shapeSection}
 4. **Do not report the fix itself, and do not report anything the fix already
    repaired.** Those files are listed above; they are the cure.
 
+## How to work — read this before you start
+
+**One session, no delegation.** Do not spawn sub-agents or fan the sweep out by
+package. The first live run of this workflow did exactly that, then ended its
+turn with *"I'll wait for their final reports"* — but nothing waits. The session
+terminated, the run went green, and it filed **zero issues** after spending
+$7.27. There is no background to wait for: if you did not do it in this
+session, it did not happen.
+
+**File as you confirm, never at the end.** The moment a candidate passes the
+rule, run \`gh issue create\` for it and move on. Do not accumulate verdicts to
+batch later — a session that ends mid-batch loses everything it found.
+
+**Budget your turns.** Work the candidates in the order given, best-first. If
+you sense you are running low, stop investigating, file what you have already
+confirmed, and print a one-line summary of what you did not get to. A partial
+sweep that files two real issues beats a thorough one that files none.
+
 ## Filing
 
 Work **read-only** on the code: Read, Grep, Glob and \`git\` for evidence, no

--- a/packages/dev-tools/regression-cluster-hunter/lib.test.mjs
+++ b/packages/dev-tools/regression-cluster-hunter/lib.test.mjs
@@ -395,6 +395,15 @@ describe('buildPrompt', () => {
     expect(buildPrompt(candidate)).toContain('a lead, not a finding');
   });
 
+  it('forbids delegation and demands filing as it goes', () => {
+    // The first live run fanned out to one sub-agent per package, ended its
+    // turn waiting for reports that never arrive, and filed nothing after
+    // spending $7.27. Both halves of the fix live in the brief.
+    const p = buildPrompt(candidate);
+    expect(p).toContain('One session, no delegation');
+    expect(p).toContain('File as you confirm, never at the end');
+  });
+
   it('makes filing nothing an explicitly good outcome', () => {
     expect(buildPrompt(candidate)).toContain('Filing nothing is a good outcome');
   });


### PR DESCRIPTION
## Summary

Follow-up to #2901. The first live run of the merged workflow ([33960038570](https://github.com/ai-ecoverse/slicc/actions/runs/33960038570)) went **green and filed nothing**. This makes the sweep run in one session.

## Why

Claude fanned the sweep out to one sub-agent per package, then ended its turn with *"All three remaining agents are still actively reading… I'll wait for their final reports rather than poll further."* Nothing waits — the session terminates when Claude stops. Result: 34 turns, **$7.27** spent almost entirely on fan-out cache reads (3.7M cache-read tokens), **zero issues filed**, `conclusion: success`, and nothing in the digest saying anything went wrong. Its own final message shows it had already *cleared* webapp and dev-tools and was mid-verdict on three more packages — findings that died with the session.

Worth being precise about the failure mode: the run is indistinguishable from the legitimate "filing nothing is a good outcome" path unless you read the log. That is the part that makes it worth fixing rather than tolerating.

## Approach

- **`Task` added to `--disallowedTools`.** The previous `--allowedTools` list didn't include it, but that only restricts *some* surfaces; the fan-out happened anyway. Explicit denial is the fix.
- **The brief carries the contract twice**, because the model has to internalise it before it starts planning:
  - *One session, no delegation* — with the failure narrated, so the instruction has a reason attached rather than being a bare prohibition.
  - *File as you confirm, never at the end* — the moment a candidate passes the rule, `gh issue create` and move on. A session that ends mid-batch loses everything it found.
  - *Budget your turns* — stop investigating, file what's confirmed, print what you didn't reach. A partial sweep that files two real issues beats a thorough one that files none.

## Cross-cutting impact

- CI tooling only; no runtime code, same as #2901.
- The `$7.27` was on `us.anthropic.claude-opus-4-8` (`vars.RUM_BEDROCK_MODEL`), not the `claude-sonnet-4-6` default in the workflow's fallback chain. Removing the fan-out should cut the dominant cost (cache reads), but **the per-run cost is still worth watching** — see below.

## Test plan

- [x] `npm run lint` — exit 0
- [x] `npx vitest run --project dev-tools` — **1433 passed / 0 failed**
- [x] New test asserts the brief carries both halves of the contract
- [x] N/A for UI

Still unproven: that a non-delegating run actually files good issues. That needs another live dispatch after this merges, which is the next step.

## Documentation

- [x] `packages/dev-tools/regression-cluster-hunter/README.md` — new "The sweep runs in one session" section with the run ID and cost
- [x] Workflow header comment explains why `Task` is denied

## Risk & rollback

- Blast radius: CI only. Revert cleanly.
- **Open question for the reviewer**: at ~$7/run on opus-4-8 with a 12h cooldown, this is roughly $14/day if it dispatches every window. If the non-delegating run doesn't come down substantially, the honest options are pinning `CLUSTER_BEDROCK_MODEL` to a cheaper model, raising `CLUSTER_MIN_INTERVAL_HOURS`, or tightening the candidate caps. I'd rather surface that now than let it run up quietly.

Generated with [Claude Code](https://claude.com/claude-code)
