### PR TITLE
docs(skill-authoring): correct the sliccy:usb realm method names

### DIFF
--- a/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
@@ -392,7 +392,24 @@ const bytes = await reply;
 console.log([...bytes].map((b) => b.toString(16).padStart(2, '0')).join(' '));
 ```
 
-`serial.*` and `usb.*` mirror the shell surface (`open` / `close` / `read` / `write` / `getSignals` / `setSignals` on serial ports; `open` / `close` / `claim` / `release` / `controlIn` / `controlOut` / `transferIn` / `transferOut` on usb devices). They don't carry the `EventTarget` shape — those transports are explicit-poll.
+`serial.*` mirrors the shell surface (`open` / `close` / `read` / `write` / `getSignals` / `setSignals` on serial ports). **`usb.*` does not** — USB device methods carry their **WebUSB** names, not the `usb` shell command's verbs:
+
+```typescript
+device.open(): Promise<void>
+device.close(): Promise<void>
+device.reset(): Promise<void>
+device.selectConfiguration(configurationValue: number): Promise<void>
+device.claimInterface(interfaceNumber: number): Promise<void>
+device.releaseInterface(interfaceNumber: number): Promise<void>
+device.controlTransferIn(setup, length): Promise<{ status: string; data: DataView }>
+device.controlTransferOut(setup, data): Promise<{ status: string; bytesWritten: number }>
+device.transferIn(endpointNumber: number, length: number): Promise<{ status: string; data: DataView }>
+device.transferOut(endpointNumber: number, data): Promise<{ status: string; bytesWritten: number }>
+```
+
+So it is `claimInterface(1)`, not `claim(1)`; `controlTransferIn(...)`, not `controlIn(...)`. Note the read results resolve `{ status, data }` where `data` is a **`DataView`** — wrap it (`new Uint8Array(d.data.buffer, d.data.byteOffset, d.data.byteLength)`) before treating it as bytes.
+
+Neither `serial.*` nor `usb.*` carries the `EventTarget` shape — those transports are explicit-poll.
 
 For ESP32 / ESP8266 work, drive `esptool` through `require('sliccy:exec')` (there is no bare `exec` global). Beyond the existing `chip_id` / `read_mac` / `erase_flash` / `write_flash` verbs, the read/inspect set is now `flash_id`, `read_reg <addr>`, `read_flash <addr> <size> <outfile>`, `erase_region <addr> <size>`, and `run`. Pass `--port <handle>` to reuse a port from `serial request` so no second picker fires:
 


### PR DESCRIPTION
## Summary

`jsh-runtime-extensions.md` described the `sliccy:usb` realm surface as mirroring
the `usb` **shell command's** verbs — `claim` / `release` / `controlIn` /
`controlOut`. The realm bridge actually exposes **WebUSB** names. A script
written from the doc fails immediately:

```
TypeError: dev.claim is not a function
```

`reset` and `selectConfiguration` were missing from the list entirely, and the
`{ status, data: DataView }` result shape wasn't mentioned. The `serial.*` half
of that sentence was correct and is unchanged.

## Why

Hit while writing a `.jsh` that speaks the ADB wire protocol to an Android phone
over WebUSB. `usb.list()` and `open()` worked, then `claim(1)` threw. Probing the
live object gave the real surface:

```
own: handle,vendorId,productId,productName,manufacturerName,serialNumber,opened,
     open,close,reset,selectConfiguration,claimInterface,releaseInterface,
     controlTransferIn,controlTransferOut,transferIn,transferOut
```

which matches `RealmUsbDevice` in
`packages/webapp/src/kernel/realm/realm-usb-bridge.ts:14-32` and
`UsbDeviceHandle` in `packages/webapp/src/kernel/usb-device-registry.ts:55-58`.
The doc is the drifted copy — the source is right.

## Approach / Implementation notes

Replaced the prose list with the interface block as declared in
`realm-usb-bridge.ts`, so the doc now fails the same way the source would if it
drifts again. Added the `DataView` note because it's the immediate follow-on
trap: `transferIn` resolves `{ status, data }` with `data` a `DataView`, so
byte-oriented code needs
`new Uint8Array(r.data.buffer, r.data.byteOffset, r.data.byteLength)`.

Scope kept to the one inaccurate sentence — no reflow of surrounding prose, to
keep the diff reviewable.

## Cross-cutting impact

Documentation only. No runtime, no test, no behavior change. The file ships in
the VFS under `packages/vfs-root/workspace/skills/skill-authoring/`, so it
reaches agents as skill-authoring guidance.

## Test plan

- [x] `npx prettier --check packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md` — clean
- [x] `node packages/dev-tools/tools/lint-skills.mjs` — all 31 skills pass
- [x] `node packages/dev-tools/tools/check-doc-sizes.mjs` — all budgeted docs within limits
- [x] `node packages/dev-tools/tools/check-doc-refs.mjs` — no dead references (816 paths checked)
- [x] **Verified live** against the running standalone harness with a physically
      attached device: the corrected calls (`selectConfiguration(1)`,
      `claimInterface(1)`, `transferOut(2, …)`, `transferIn(3, …)`,
      `releaseInterface(1)`) complete an ADB `CNXN` handshake and return the
      device's `AUTH` challenge. The documented-but-wrong names throw.
- [ ] `npm run test` / `npm run build` — N/A, docs-only.

## Documentation

- [x] `docs/` (agent reference) — this **is** the documentation change.

## Risk & rollback

None beyond the text. Reverts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
