### PR TITLE
fix(dev-tools): verify :8787 is the SLICC worker before reusing it

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -227,10 +227,16 @@ profile collisions.
 
 **Shared behavior across all harnesses:**
 
-- **Wrangler reuse-or-start**: an already-listening `:8787` is reused as-is;
-  otherwise the harness starts one and gates cleanup behind
-  `STARTED_WRANGLER`. A `kill -0 "$WRANGLER_PID"` liveness guard in the
-  readiness loop fails fast if wrangler exits before binding.
+- **Wrangler reuse-or-start**: a listener on `:8787` is reused only when
+  `GET /status` identifies it as the SLICC worker
+  (`"service": "slicc-tray-hub"`); anything else on that port is left alone
+  and the harness starts its own wrangler, which then fails to bind and says
+  so. `/status` is a worker route rather than a static asset, so it answers
+  before `dist/ui` is built. Otherwise the harness starts one and gates
+  cleanup behind `STARTED_WRANGLER`. A `kill -0 "$WRANGLER_PID"` liveness
+  guard in the readiness loop fails fast if wrangler exits before binding.
+  If the port is held by an unrelated server, stop it or pick another port
+  with `WRANGLER_PORT=…`.
 - **Labeled Chrome clones**: `clone-labeled-chrome.sh` APFS-COW-clones a
   Chrome for Testing `.app` under a distinct `CFBundleName` /
   `CFBundleIdentifier`, re-signs ad-hoc (top-level only), and registers with

--- a/packages/dev-tools/tools/dev-electron-node-fresh.sh
+++ b/packages/dev-tools/tools/dev-electron-node-fresh.sh
@@ -105,16 +105,18 @@ else
   echo "✔  Leader UI built (dist/ui/index.html)"
 fi
 
-# Treat ANY HTTP response from the wrangler port as "up". `curl -sf` exits
-# non-zero on a 4xx (e.g. the SPA's 404 before dist/ui is built), which would
-# false-negative the reuse/readiness check and try to bind a SECOND wrangler to
-# the already-occupied port. Checking only that curl got a status line (non-000,
-# non-empty) avoids that.
+# Identify the SLICC worker, not merely "something is listening". Any stray
+# server on this port (another dev server, a local model API) answers with a
+# status line, and the old any-status probe adopted it as the leader origin —
+# the harness printed "Reusing existing wrangler" and every later failure
+# pointed somewhere else. `/status` is a worker route, not a static asset
+# (see packages/cloudflare-worker/src/index.ts — it is deliberately kept
+# reachable ahead of the SPA intercept, and the Playwright suite already gates
+# on it), so it still answers before dist/ui is built. That was the reason the
+# probe tolerated a 4xx, and it is preserved.
 wrangler_up() {
-  local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 \
-    "http://127.0.0.1:${WRANGLER_PORT}/?slicc=leader" 2>/dev/null || true)"
-  [ -n "$code" ] && [ "$code" != "000" ]
+  curl -s --max-time 2 "http://127.0.0.1:${WRANGLER_PORT}/status" 2>/dev/null |
+    grep -q '"service"[[:space:]]*:[[:space:]]*"slicc-tray-hub"'
 }
 
 # ── 4b. Reuse-or-start wrangler (UI / leader origin on :8787) ────────
@@ -138,6 +140,8 @@ else
     fi
     if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
       echo "❌  Wrangler exited before binding :${WRANGLER_PORT}"
+      echo "    If something else already holds that port, it is not the SLICC"
+      echo "    worker (/status did not identify it) — stop it or set WRANGLER_PORT."
       exit 1
     fi
     [ "$i" -eq 30 ] && { echo "❌  Wrangler failed to start"; kill "$WRANGLER_PID" 2>/dev/null || true; exit 1; }

--- a/packages/dev-tools/tools/dev-electron-swift-fresh.sh
+++ b/packages/dev-tools/tools/dev-electron-swift-fresh.sh
@@ -111,16 +111,18 @@ else
   echo "✔  Leader UI built (dist/ui/index.html)"
 fi
 
-# Treat ANY HTTP response from the wrangler port as "up". `curl -sf` exits
-# non-zero on a 4xx (e.g. the SPA's 404 before dist/ui is built), which would
-# false-negative the reuse/readiness check and try to bind a SECOND wrangler to
-# the already-occupied port. Checking only that curl got a status line (non-000,
-# non-empty) avoids that.
+# Identify the SLICC worker, not merely "something is listening". Any stray
+# server on this port (another dev server, a local model API) answers with a
+# status line, and the old any-status probe adopted it as the leader origin —
+# the harness printed "Reusing existing wrangler" and every later failure
+# pointed somewhere else. `/status` is a worker route, not a static asset
+# (see packages/cloudflare-worker/src/index.ts — it is deliberately kept
+# reachable ahead of the SPA intercept, and the Playwright suite already gates
+# on it), so it still answers before dist/ui is built. That was the reason the
+# probe tolerated a 4xx, and it is preserved.
 wrangler_up() {
-  local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 \
-    "http://127.0.0.1:${WRANGLER_PORT}/?slicc=leader" 2>/dev/null || true)"
-  [ -n "$code" ] && [ "$code" != "000" ]
+  curl -s --max-time 2 "http://127.0.0.1:${WRANGLER_PORT}/status" 2>/dev/null |
+    grep -q '"service"[[:space:]]*:[[:space:]]*"slicc-tray-hub"'
 }
 
 # ── 3b. Reuse-or-start wrangler (UI / leader origin on :8787) ────────
@@ -144,6 +146,8 @@ else
     fi
     if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
       echo "❌  Wrangler exited before binding :${WRANGLER_PORT}"
+      echo "    If something else already holds that port, it is not the SLICC"
+      echo "    worker (/status did not identify it) — stop it or set WRANGLER_PORT."
       exit 1
     fi
     [ "$i" -eq 30 ] && { echo "❌  Wrangler failed to start"; kill "$WRANGLER_PID" 2>/dev/null || true; exit 1; }

--- a/packages/dev-tools/tools/dev-extension-fresh.sh
+++ b/packages/dev-tools/tools/dev-extension-fresh.sh
@@ -158,16 +158,18 @@ else
   echo "✔  Leader UI built (dist/ui/index.html)"
 fi
 
-# Treat ANY HTTP response from the wrangler port as "up". `curl -sf` exits
-# non-zero on a 4xx (e.g. the SPA's 404 before dist/ui is built), which would
-# false-negative the reuse/readiness check and try to bind a SECOND wrangler to
-# the already-occupied port. Checking only that curl got a status line (non-000,
-# non-empty) avoids that.
+# Identify the SLICC worker, not merely "something is listening". Any stray
+# server on this port (another dev server, a local model API) answers with a
+# status line, and the old any-status probe adopted it as the leader origin —
+# the harness printed "Reusing existing wrangler" and every later failure
+# pointed somewhere else. `/status` is a worker route, not a static asset
+# (see packages/cloudflare-worker/src/index.ts — it is deliberately kept
+# reachable ahead of the SPA intercept, and the Playwright suite already gates
+# on it), so it still answers before dist/ui is built. That was the reason the
+# probe tolerated a 4xx, and it is preserved.
 wrangler_up() {
-  local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 \
-    "http://127.0.0.1:${WRANGLER_PORT}/?slicc=leader" 2>/dev/null || true)"
-  [ -n "$code" ] && [ "$code" != "000" ]
+  curl -s --max-time 2 "http://127.0.0.1:${WRANGLER_PORT}/status" 2>/dev/null |
+    grep -q '"service"[[:space:]]*:[[:space:]]*"slicc-tray-hub"'
 }
 
 # ── 6b. Reuse-or-start wrangler (UI / leader origin) ─────────────────
@@ -203,6 +205,8 @@ else
     fi
     if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
       echo "❌  Wrangler exited before binding :${WRANGLER_PORT}"
+      echo "    If something else already holds that port, it is not the SLICC"
+      echo "    worker (/status did not identify it) — stop it or set WRANGLER_PORT."
       exit 1
     fi
     [ "$i" -eq 30 ] && { echo "❌  Wrangler failed to start"; kill "$WRANGLER_PID" 2>/dev/null || true; exit 1; }

--- a/packages/dev-tools/tools/dev-standalone-fresh.sh
+++ b/packages/dev-tools/tools/dev-standalone-fresh.sh
@@ -232,15 +232,18 @@ else
 	echo "✔  Leader UI built (dist/ui/index.html)"
 fi
 
-# Treat ANY HTTP response from the wrangler port as "up". `curl -sf` exits
-# non-zero on a 4xx (e.g. the SPA's 404 before dist/ui is built), which would
-# false-negative the readiness check; checking only that curl got a status line
-# (non-000, non-empty) avoids that.
+# Identify the SLICC worker, not merely "something is listening". Any stray
+# server on this port (another dev server, a local model API) answers with a
+# status line, and the old any-status probe adopted it as the leader origin —
+# the harness printed "Reusing existing wrangler" and every later failure
+# pointed somewhere else. `/status` is a worker route, not a static asset
+# (see packages/cloudflare-worker/src/index.ts — it is deliberately kept
+# reachable ahead of the SPA intercept, and the Playwright suite already gates
+# on it), so it still answers before dist/ui is built. That was the reason the
+# probe tolerated a 4xx, and it is preserved.
 wrangler_up() {
-	local code
-	code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 \
-		"http://127.0.0.1:${WRANGLER_PORT}/?slicc=leader" 2>/dev/null || true)"
-	[ -n "$code" ] && [ "$code" != "000" ]
+	curl -s --max-time 2 "http://127.0.0.1:${WRANGLER_PORT}/status" 2>/dev/null |
+		grep -q '"service"[[:space:]]*:[[:space:]]*"slicc-tray-hub"'
 }
 
 # ── 4b. Reuse-or-start wrangler (UI / leader origin on :8787) ────────
@@ -264,6 +267,8 @@ else
 		fi
 		if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
 			echo "❌  Wrangler exited before binding :${WRANGLER_PORT}"
+			echo "    If something else already holds that port, it is not the SLICC"
+			echo "    worker (/status did not identify it) — stop it or set WRANGLER_PORT."
 			exit 1
 		fi
 		[ "$i" -eq 30 ] && {

--- a/packages/dev-tools/tools/dev-standalone-fresh.sh
+++ b/packages/dev-tools/tools/dev-standalone-fresh.sh
@@ -101,6 +101,20 @@ print_bridge_port_suggestions() {
 	fi
 }
 
+# Identify the SLICC worker, not merely "something is listening". Any stray
+# server on this port (another dev server, a local model API) answers with a
+# status line, and the old any-status probe adopted it as the leader origin —
+# the harness printed "Reusing existing wrangler" and every later failure
+# pointed somewhere else. `/status` is a worker route, not a static asset
+# (see packages/cloudflare-worker/src/index.ts — it is deliberately kept
+# reachable ahead of the SPA intercept, and the Playwright suite already gates
+# on it), so it still answers before dist/ui is built. That was the reason the
+# probe tolerated a 4xx, and it is preserved.
+wrangler_up() {
+	curl -s --max-time 2 "http://127.0.0.1:${WRANGLER_PORT}/status" 2>/dev/null |
+		grep -q '"service"[[:space:]]*:[[:space:]]*"slicc-tray-hub"'
+}
+
 # Allow Vitest to source and exercise the guard and protected-port refusal
 # without running browser discovery, builds, port checks, or harness processes.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
@@ -232,19 +246,6 @@ else
 	echo "✔  Leader UI built (dist/ui/index.html)"
 fi
 
-# Identify the SLICC worker, not merely "something is listening". Any stray
-# server on this port (another dev server, a local model API) answers with a
-# status line, and the old any-status probe adopted it as the leader origin —
-# the harness printed "Reusing existing wrangler" and every later failure
-# pointed somewhere else. `/status` is a worker route, not a static asset
-# (see packages/cloudflare-worker/src/index.ts — it is deliberately kept
-# reachable ahead of the SPA intercept, and the Playwright suite already gates
-# on it), so it still answers before dist/ui is built. That was the reason the
-# probe tolerated a 4xx, and it is preserved.
-wrangler_up() {
-	curl -s --max-time 2 "http://127.0.0.1:${WRANGLER_PORT}/status" 2>/dev/null |
-		grep -q '"service"[[:space:]]*:[[:space:]]*"slicc-tray-hub"'
-}
 
 # ── 4b. Reuse-or-start wrangler (UI / leader origin on :8787) ────────
 STARTED_WRANGLER=0

--- a/packages/dev-tools/tools/dev-standalone-fresh.test.mjs
+++ b/packages/dev-tools/tools/dev-standalone-fresh.test.mjs
@@ -1,4 +1,5 @@
 import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -55,6 +56,32 @@ function bridgeSuggestions(port) {
     ],
     { encoding: 'utf8' }
   );
+}
+
+/**
+ * Run `wrangler_up` against a stubbed `curl` that returns `body`. Sourcing the
+ * script stops at the BASH_SOURCE guard, so only the helpers above it are
+ * defined — which is why `wrangler_up` lives there.
+ */
+function wranglerUp(body) {
+  const r = spawnSync(
+    'bash',
+    [
+      '-c',
+      'curl() { printf "%s" "$FAKE_BODY"; }; source "$1"; wrangler_up && echo UP || echo DOWN',
+      'bash',
+      scriptPath,
+    ],
+    { encoding: 'utf8', env: { ...process.env, FAKE_BODY: body, WRANGLER_PORT: '8787' } }
+  );
+  return r.stdout.trim();
+}
+
+/** The `wrangler_up` body, normalised, as it appears in each harness script. */
+function wranglerUpBody(scriptName) {
+  const text = readFileSync(resolve(dirname(scriptPath), scriptName), 'utf8');
+  const match = text.match(/^wrangler_up\(\) \{\n([\s\S]*?)^\}$/m);
+  return match ? match[1].replace(/\s+/g, ' ').trim() : null;
 }
 
 describe('dev-standalone-fresh bridge port guard', () => {
@@ -140,5 +167,48 @@ describe('dev-standalone-fresh bridge port guard', () => {
     const result = reapPort(port);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Refusing to reap invalid port:');
+  });
+});
+
+describe('dev-standalone-fresh wrangler identity probe', () => {
+  const SLICC_STATUS =
+    '{"status":"ok","service":"slicc-tray-hub","timestamp":"2026-01-01T00:00:00.000Z"}';
+
+  it('reuses a listener whose /status identifies the SLICC worker', () => {
+    expect(wranglerUp(SLICC_STATUS)).toBe('UP');
+  });
+
+  it('tolerates the compact JSON form', () => {
+    expect(wranglerUp('{"service":"slicc-tray-hub"}')).toBe('UP');
+  });
+
+  it('does not reuse an unrelated server that merely answers', () => {
+    // A local model API held :8787 for days and answered 200; the previous
+    // any-status probe adopted it as the leader origin.
+    expect(wranglerUp('<!DOCTYPE html><title>H3 Ref2VA API</title>')).toBe('DOWN');
+  });
+
+  it('does not reuse a listener that serves a different worker', () => {
+    expect(wranglerUp('{"status":"ok","service":"some-other-worker"}')).toBe('DOWN');
+  });
+
+  it('treats an unavailable listener as not up', () => {
+    expect(wranglerUp('')).toBe('DOWN');
+  });
+
+  it('keeps the predicate identical across all five harnesses', () => {
+    // The scripts are deliberately standalone, so the probe is duplicated.
+    // Only the standalone copy is behaviourally tested above; this pins the
+    // other four to it so one cannot silently drift back to any-status reuse.
+    const baseline = wranglerUpBody('dev-standalone-fresh.sh');
+    expect(baseline).toContain('slicc-tray-hub');
+    for (const name of [
+      'dev-swift-fresh.sh',
+      'dev-extension-fresh.sh',
+      'dev-electron-node-fresh.sh',
+      'dev-electron-swift-fresh.sh',
+    ]) {
+      expect(wranglerUpBody(name), `${name} drifted from the standalone probe`).toBe(baseline);
+    }
   });
 });

--- a/packages/dev-tools/tools/dev-swift-fresh.sh
+++ b/packages/dev-tools/tools/dev-swift-fresh.sh
@@ -144,16 +144,18 @@ else
   echo "✔  Leader UI built (dist/ui/index.html)"
 fi
 
-# Treat ANY HTTP response from the wrangler port as "up". `curl -sf` exits
-# non-zero on a 4xx (e.g. the SPA's 404 before dist/ui is built), which would
-# false-negative the reuse/readiness check and try to bind a SECOND wrangler to
-# the already-occupied port. Checking only that curl got a status line (non-000,
-# non-empty) avoids that.
+# Identify the SLICC worker, not merely "something is listening". Any stray
+# server on this port (another dev server, a local model API) answers with a
+# status line, and the old any-status probe adopted it as the leader origin —
+# the harness printed "Reusing existing wrangler" and every later failure
+# pointed somewhere else. `/status` is a worker route, not a static asset
+# (see packages/cloudflare-worker/src/index.ts — it is deliberately kept
+# reachable ahead of the SPA intercept, and the Playwright suite already gates
+# on it), so it still answers before dist/ui is built. That was the reason the
+# probe tolerated a 4xx, and it is preserved.
 wrangler_up() {
-  local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 \
-    "http://127.0.0.1:${WRANGLER_PORT}/?slicc=leader" 2>/dev/null || true)"
-  [ -n "$code" ] && [ "$code" != "000" ]
+  curl -s --max-time 2 "http://127.0.0.1:${WRANGLER_PORT}/status" 2>/dev/null |
+    grep -q '"service"[[:space:]]*:[[:space:]]*"slicc-tray-hub"'
 }
 
 # ── 4b. Reuse-or-start wrangler (UI origin) ──────────────────────────
@@ -179,6 +181,8 @@ else
     fi
     if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
       echo "❌  Wrangler exited before binding :${WRANGLER_PORT}"
+      echo "    If something else already holds that port, it is not the SLICC"
+      echo "    worker (/status did not identify it) — stop it or set WRANGLER_PORT."
       exit 1
     fi
     [ "$i" -eq 30 ] && { echo "❌  Wrangler failed to start"; kill "$WRANGLER_PID" 2>/dev/null || true; exit 1; }


### PR DESCRIPTION
## Summary

All five `dev-*-fresh.sh` harnesses decided "wrangler is already up on `:8787`"
from the **HTTP status alone** — anything other than curl's `000` counted. Any
listener satisfies that, so an unrelated server on the port got adopted as the
leader origin: the harness printed `✔ Reusing existing wrangler on :8787` and the
run then failed somewhere far away from the cause.

Now the probe asks `/status` whether it is actually talking to the SLICC worker.

## Why

Not hypothetical — I hit it on the first command of a session. A local model
server (ComfyUI / MiniMax-H3) had been sitting on `:8787` for days, and it
answers `/?slicc=leader` with **200**:

```
$ curl -s -o /dev/null -w '%{http_code}' 'http://127.0.0.1:8787/?slicc=leader'
200
```

so the old predicate returns true and the harness binds SLICC's leader origin to
an unrelated ML API. I only avoided it by checking the port by hand first.

**Repro**

1. `python3 -m http.server 8787 --bind 127.0.0.1`
2. `npm run dev:standalone:fresh`

Expected: the harness does not treat that as wrangler.
Actual (before): `✔  Reusing existing wrangler on :8787 (not started by us)`

## Approach / Implementation notes

The obvious fix — grep the body of `/?slicc=leader` for `<title>slicc</title>` —
is wrong, and the comment being replaced says why: wrangler can be up *before*
`dist/ui` is built, the SPA 404s, and a body check would false-negative and try
to bind a second wrangler to an occupied port. That tolerance is deliberate.

`/status` avoids the tradeoff. It is a worker route rather than a static asset,
and `packages/cloudflare-worker/src/index.ts` explicitly documents that it must
stay reachable ahead of the SPA intercept — the Playwright suite already gates
wrangler readiness on it for exactly this reason. So it answers regardless of
build state *and* identifies the service:

```json
{ "status": "ok", "service": "slicc-tray-hub", ... }
```

The five copies are patched in place rather than factored into a shared helper —
these scripts are deliberately standalone (nothing `source`s anything today), and
introducing a shared lib is a bigger change than this fix warrants.

Second, smaller change: when a foreign server holds the port, the harness now
correctly declines to reuse it, tries to start its own wrangler, and hits the
existing bind failure — whose message didn't mention the port conflict. It now
names the likely cause, so the diagnosis lands where the symptom appears.

## Cross-cutting impact

- **Harnesses touched**: all five (standalone, swift, extension, electron-node,
  electron-swift) — identical change, matching each file's existing indentation.
- **Behavior change**: strictly narrows what counts as reuse. A genuine wrangler
  is still reused; anything else is no longer silently adopted.
- **Not touched**: the bridge-port guard, reaping semantics, `:5710`/`:9222`
  protections, CDP handling.
- **CI**: `prettier --check .` skips `.sh` when globbing a directory (verified);
  it only errors if such a file is named explicitly.

## Test plan

- [x] `bash -n` on all five — parse clean
- [x] `shellcheck --severity=error` on all five — no errors
- [x] `npx prettier --check packages/dev-tools/tools/` — clean
- [x] **Predicate unit-tested by extracting it verbatim from the patched files**
      (both the tab-indented standalone and a space-indented one):

  | port | what's there | result |
  |---|---|---|
  | 8788 | real wrangler | `REUSE` |
  | 8790 | foreign HTTP server | `START-OWN` |
  | 9999 | nothing | `START-OWN` |

  The old predicate returns `REUSE` for the foreign server — that's the bug.

- [x] **End-to-end, foreign server on the port**: `PORT=5716 WRANGLER_PORT=8791
      npm run dev:standalone:fresh` with a stray server on `:8791`:

  ```
  🌐  Starting wrangler on :8791…
  ❌  Wrangler exited before binding :8791
      If something else already holds that port, it is not the SLICC
      worker (/status did not identify it) — stop it or set WRANGLER_PORT.
  ```

- [x] **End-to-end, legitimate reuse preserved** (the regression risk):
      `PORT=5717 WRANGLER_PORT=8788` against a real running wrangler →
      `✔  Reusing existing wrangler on :8788 (not started by us)`, bridge came up
      against it.
- [x] No stray processes left by either run; the pre-existing harness on
      `:5715`/`:8788` stayed healthy throughout.
- [ ] `npm run test` / `npm run build` — N/A, shell-only change to dev harnesses.

## Risk & rollback

Small and self-contained; reverts cleanly. The failure mode moves from "silently
wrong origin, confusing downstream failure" to "refuses to start, says why".

One judgement call worth a reviewer's eye: if anyone is deliberately fronting
`:8787` with a proxy that doesn't pass `/status` through, this now declines to
reuse it. I couldn't find such a setup in the repo, and `WRANGLER_PORT` remains
the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
