### PR TITLE
feat(webapp): expose USB configuration descriptors to the realm

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -2084,17 +2084,67 @@ slicc.hid.on('inputreport', ({ handle, reportId, data }) => {
 await slicc.hid.sendReport(info.handle, 0, new Uint8Array([0x01, 0x02]));
 ```
 
-| Method                                                   | Returns                       | Notes                                                                                            |
-| -------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ |
-| `slicc.hid.list()`                                       | `Promise<HidDeviceInfo[]>`    | Already-granted devices; no picker.                                                              |
-| `slicc.hid.request(filters?)`                            | `Promise<HidDeviceInfo[]>`    | Shows the WebHID picker; every granted interface of a multi-interface device is registered.      |
-| `slicc.hid.open(handle)` / `slicc.hid.close(handle)`     | `Promise<void>`               | `open` auto-attaches the host's input-report listener; `close` (or sprinkle close) detaches it.  |
-| `slicc.hid.sendReport(handle, reportId, data)`           | `Promise<void>`               | `data` is `Uint8Array`.                                                                          |
-| `slicc.hid.on('inputreport', cb)` / `slicc.hid.off(...)` | `void`                        | `cb({handle, reportId, data})` — `data` is a `Uint8Array`. Subscriptions are torn down on close. |
-| `slicc.serial.list()` / `slicc.serial.request(filters?)` | `Promise<SerialDeviceInfo[]>` | Already-granted vs. picker; parity with `hid`.                                                   |
-| `slicc.serial.open(handle, options)` / `serial.close(h)` | `Promise<void>`               | `options` mirrors the Web Serial open shape (`baudRate`, `dataBits`, …).                         |
-| `slicc.usb.list()` / `slicc.usb.request(filters?)`       | `Promise<UsbDeviceInfo[]>`    | Already-granted vs. picker; parity with `hid`.                                                   |
-| `slicc.usb.open(handle)` / `slicc.usb.close(handle)`     | `Promise<void>`               | Control / bulk transfers stay on the realm-side `usb` global for v1.                             |
+| Method                                                   | Returns                       | Notes                                                                                                     |
+| -------------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `slicc.hid.list()`                                       | `Promise<HidDeviceInfo[]>`    | Already-granted devices; no picker.                                                                       |
+| `slicc.hid.request(filters?)`                            | `Promise<HidDeviceInfo[]>`    | Shows the WebHID picker; every granted interface of a multi-interface device is registered.               |
+| `slicc.hid.open(handle)` / `slicc.hid.close(handle)`     | `Promise<void>`               | `open` auto-attaches the host's input-report listener; `close` (or sprinkle close) detaches it.           |
+| `slicc.hid.sendReport(handle, reportId, data)`           | `Promise<void>`               | `data` is `Uint8Array`.                                                                                   |
+| `slicc.hid.on('inputreport', cb)` / `slicc.hid.off(...)` | `void`                        | `cb({handle, reportId, data})` — `data` is a `Uint8Array`. Subscriptions are torn down on close.          |
+| `slicc.serial.list()` / `slicc.serial.request(filters?)` | `Promise<SerialDeviceInfo[]>` | Already-granted vs. picker; parity with `hid`.                                                            |
+| `slicc.serial.open(handle, options)` / `serial.close(h)` | `Promise<void>`               | `options` mirrors the Web Serial open shape (`baudRate`, `dataBits`, …).                                  |
+| `slicc.usb.list()` / `slicc.usb.request(filters?)`       | `Promise<UsbDeviceInfo[]>`    | Already-granted vs. picker; parity with `hid`. Each `UsbDeviceInfo` carries `configurations` — see below. |
+| `slicc.usb.open(handle)` / `slicc.usb.close(handle)`     | `Promise<void>`               | Control / bulk transfers stay on the realm-side `usb` global for v1.                                      |
+
+#### `UsbDeviceInfo.configurations`
+
+Alongside identity (`handle`, `vendorId`, `productId`, `productName`,
+`manufacturerName`, `serialNumber`, `opened`), a device carries its
+configuration descriptors as plain data — so a script can locate an interface
+by class/subclass/protocol without opening the device and re-reading the
+descriptor over a control transfer:
+
+```typescript
+configurations?: Array<{
+  configurationValue: number;
+  configurationName?: string;
+  interfaces: Array<{
+    interfaceNumber: number;
+    claimed: boolean;
+    alternates: Array<{
+      alternateSetting: number;
+      interfaceClass: number;
+      interfaceSubclass: number;
+      interfaceProtocol: number;
+      interfaceName?: string;
+      endpoints: Array<{
+        endpointNumber: number;
+        direction: 'in' | 'out';
+        type: 'bulk' | 'interrupt' | 'isochronous';
+        packetSize: number;
+      }>;
+    }>;
+  }>;
+}>;
+```
+
+The field is **optional** — absent when the platform does not expose the
+descriptor tree — so branch on it rather than assuming it. Endpoints whose
+`direction` or `type` falls outside the vocabulary above are omitted rather
+than passed through, so a match on those fields is safe.
+
+Finding ADB's interface (class `0xff`, subclass `0x42`, protocol `0x01`):
+
+```javascript
+const usb = require('sliccy:usb');
+const [device] = await usb.list();
+const adb = (device.configurations ?? [])
+  .flatMap((c) => c.interfaces)
+  .flatMap((i) => i.alternates.map((a) => ({ interfaceNumber: i.interfaceNumber, ...a })))
+  .find(
+    (a) => a.interfaceClass === 0xff && a.interfaceSubclass === 0x42 && a.interfaceProtocol === 0x01
+  );
+```
 
 Untrusted inline-chat dips (fenced ` ```shtml ` blocks emitted by the agent) NEVER receive `slicc.hid` / `serial` / `usb`. Any spoofed request from such an iframe is rejected with `device access not allowed for this dip` before it reaches the registry.
 

--- a/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
+++ b/packages/vfs-root/workspace/skills/skill-authoring/jsh-runtime-extensions.md
@@ -409,6 +409,39 @@ device.transferOut(endpointNumber: number, data): Promise<{ status: string; byte
 
 So it is `claimInterface(1)`, not `claim(1)`; `controlTransferIn(...)`, not `controlIn(...)`. Note the read results resolve `{ status, data }` where `data` is a **`DataView`** — wrap it (`new Uint8Array(d.data.buffer, d.data.byteOffset, d.data.byteLength)`) before treating it as bytes.
 
+Each device also carries its **configuration descriptors** as plain data, so an
+interface can be located by class/subclass/protocol without opening the device
+and re-reading the descriptor over a control transfer:
+
+```typescript
+device.configurations?: Array<{
+  configurationValue: number;
+  configurationName?: string;
+  interfaces: Array<{
+    interfaceNumber: number;
+    claimed: boolean;
+    alternates: Array<{
+      alternateSetting: number;
+      interfaceClass: number;
+      interfaceSubclass: number;
+      interfaceProtocol: number;
+      interfaceName?: string;
+      endpoints: Array<{
+        endpointNumber: number;
+        direction: 'in' | 'out';
+        type: 'bulk' | 'interrupt' | 'isochronous';
+        packetSize: number;
+      }>;
+    }>;
+  }>;
+}>
+```
+
+It is **optional** — absent when the platform does not expose the tree — so
+branch on it. Endpoints reported with a direction or type outside the vocabulary
+above are omitted rather than passed through, so matching on those fields is
+safe.
+
 Neither `serial.*` nor `usb.*` carries the `EventTarget` shape — those transports are explicit-poll.
 
 For ESP32 / ESP8266 work, drive `esptool` through `require('sliccy:exec')` (there is no bare `exec` global). Beyond the existing `chip_id` / `read_mac` / `erase_flash` / `write_flash` verbs, the read/inspect set is now `flash_id`, `read_reg <addr>`, `read_flash <addr> <size> <outfile>`, `erase_region <addr> <size>`, and `run`. Pass `--port <handle>` to reuse a port from `serial request` so no second picker fires:

--- a/packages/webapp/src/kernel/usb-device-registry.ts
+++ b/packages/webapp/src/kernel/usb-device-registry.ts
@@ -42,6 +42,70 @@ export interface UsbOutTransferResult {
   status?: string;
 }
 
+/** The live WebUSB descriptor objects, as read off a `USBDevice`. */
+interface UsbLiveEndpoint {
+  readonly endpointNumber: number;
+  readonly direction: string;
+  readonly type: string;
+  readonly packetSize: number;
+}
+
+interface UsbLiveAlternate {
+  readonly alternateSetting: number;
+  readonly interfaceClass: number;
+  readonly interfaceSubclass: number;
+  readonly interfaceProtocol: number;
+  readonly interfaceName?: string;
+  readonly endpoints: readonly UsbLiveEndpoint[];
+}
+
+interface UsbLiveInterface {
+  readonly interfaceNumber: number;
+  readonly claimed: boolean;
+  readonly alternates: readonly UsbLiveAlternate[];
+}
+
+interface UsbLiveConfiguration {
+  readonly configurationValue: number;
+  readonly configurationName?: string;
+  readonly interfaces: readonly UsbLiveInterface[];
+}
+
+/**
+ * Configuration descriptors, flattened to plain data.
+ *
+ * WebUSB's `USBConfiguration` / `USBInterface` / `USBEndpoint` are live class
+ * instances and cannot cross `postMessage`, so they are mapped to these
+ * structural equivalents before being sent over the bridge.
+ */
+export interface UsbEndpointDescriptor {
+  endpointNumber: number;
+  direction: 'in' | 'out';
+  type: 'bulk' | 'interrupt' | 'isochronous';
+  packetSize: number;
+}
+
+export interface UsbAlternateDescriptor {
+  alternateSetting: number;
+  interfaceClass: number;
+  interfaceSubclass: number;
+  interfaceProtocol: number;
+  interfaceName?: string;
+  endpoints: UsbEndpointDescriptor[];
+}
+
+export interface UsbInterfaceDescriptor {
+  interfaceNumber: number;
+  claimed: boolean;
+  alternates: UsbAlternateDescriptor[];
+}
+
+export interface UsbConfigurationDescriptor {
+  configurationValue: number;
+  configurationName?: string;
+  interfaces: UsbInterfaceDescriptor[];
+}
+
 /** The subset of `USBDevice` the registry and handlers touch. */
 export interface UsbDevice {
   readonly vendorId: number;
@@ -50,6 +114,8 @@ export interface UsbDevice {
   readonly manufacturerName?: string;
   readonly serialNumber?: string;
   readonly opened: boolean;
+  /** Absent on stubs and on some non-Chromium implementations. */
+  readonly configurations?: readonly UsbLiveConfiguration[];
   open(): Promise<void>;
   close(): Promise<void>;
   selectConfiguration(configurationValue: number): Promise<void>;
@@ -77,6 +143,12 @@ export interface UsbDeviceInfo {
   manufacturerName?: string;
   serialNumber?: string;
   opened: boolean;
+  /**
+   * Interface/endpoint layout, when the platform exposes it. Realm callers
+   * would otherwise have to re-read the configuration descriptor over a
+   * control transfer just to find an interface by class/subclass/protocol.
+   */
+  configurations?: UsbConfigurationDescriptor[];
 }
 
 /** Read `navigator.usb` from the current realm, or null when absent. */
@@ -138,6 +210,48 @@ export function getSharedUsbRegistry(): DeviceHandleRegistry {
 /** Maximum bytes for a single control/bulk transfer (v1 cap). */
 export const MAX_USB_TRANSFER_BYTES = 4 * 1024 * 1024;
 
+const ENDPOINT_DIRECTIONS = new Set(['in', 'out']);
+const ENDPOINT_TYPES = new Set(['bulk', 'interrupt', 'isochronous']);
+
+/**
+ * Copy the live descriptor tree into plain objects. Endpoints whose
+ * direction/type the platform reports as something outside the WebUSB
+ * vocabulary are dropped rather than widened — callers match on these, and a
+ * surprise value should not silently look like a usable endpoint.
+ */
+function configurationsToDescriptors(
+  configurations: readonly UsbLiveConfiguration[]
+): UsbConfigurationDescriptor[] {
+  return configurations.map((configuration) => ({
+    configurationValue: configuration.configurationValue,
+    ...(configuration.configurationName
+      ? { configurationName: configuration.configurationName }
+      : {}),
+    interfaces: (configuration.interfaces ?? []).map((iface) => ({
+      interfaceNumber: iface.interfaceNumber,
+      claimed: !!iface.claimed,
+      alternates: (iface.alternates ?? []).map((alternate) => ({
+        alternateSetting: alternate.alternateSetting,
+        interfaceClass: alternate.interfaceClass,
+        interfaceSubclass: alternate.interfaceSubclass,
+        interfaceProtocol: alternate.interfaceProtocol,
+        ...(alternate.interfaceName ? { interfaceName: alternate.interfaceName } : {}),
+        endpoints: (alternate.endpoints ?? [])
+          .filter(
+            (endpoint) =>
+              ENDPOINT_DIRECTIONS.has(endpoint.direction) && ENDPOINT_TYPES.has(endpoint.type)
+          )
+          .map((endpoint) => ({
+            endpointNumber: endpoint.endpointNumber,
+            direction: endpoint.direction as 'in' | 'out',
+            type: endpoint.type as 'bulk' | 'interrupt' | 'isochronous',
+            packetSize: endpoint.packetSize,
+          })),
+      })),
+    })),
+  }));
+}
+
 /** Build the serializable descriptor for a registered device. */
 export function deviceToInfo(handle: string, device: UsbDevice): UsbDeviceInfo {
   return {
@@ -148,5 +262,8 @@ export function deviceToInfo(handle: string, device: UsbDevice): UsbDeviceInfo {
     ...(device.manufacturerName ? { manufacturerName: device.manufacturerName } : {}),
     ...(device.serialNumber ? { serialNumber: device.serialNumber } : {}),
     opened: device.opened,
+    ...(device.configurations
+      ? { configurations: configurationsToDescriptors(device.configurations) }
+      : {}),
   };
 }

--- a/packages/webapp/tests/kernel/usb-device-registry.test.ts
+++ b/packages/webapp/tests/kernel/usb-device-registry.test.ts
@@ -67,6 +67,119 @@ describe('deviceToInfo', () => {
       opened: false,
     });
   });
+
+  it('omits `configurations` when the platform does not expose it', () => {
+    expect(deviceToInfo('usb1', fakeDevice())).not.toHaveProperty('configurations');
+  });
+
+  it('flattens the descriptor tree into plain, serializable data', () => {
+    // Shaped after a real Android device: interface 0 is vendor-specific,
+    // interface 1 is ADB (class 0xff / subclass 0x42 / protocol 0x01).
+    const info = deviceToInfo(
+      'usb1',
+      fakeDevice({
+        configurations: [
+          {
+            configurationValue: 1,
+            configurationName: 'default',
+            interfaces: [
+              {
+                interfaceNumber: 1,
+                claimed: false,
+                alternates: [
+                  {
+                    alternateSetting: 0,
+                    interfaceClass: 0xff,
+                    interfaceSubclass: 0x42,
+                    interfaceProtocol: 0x01,
+                    endpoints: [
+                      { endpointNumber: 3, direction: 'in', type: 'bulk', packetSize: 512 },
+                      { endpointNumber: 2, direction: 'out', type: 'bulk', packetSize: 512 },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    expect(info.configurations).toEqual([
+      {
+        configurationValue: 1,
+        configurationName: 'default',
+        interfaces: [
+          {
+            interfaceNumber: 1,
+            claimed: false,
+            alternates: [
+              {
+                alternateSetting: 0,
+                interfaceClass: 0xff,
+                interfaceSubclass: 0x42,
+                interfaceProtocol: 0x01,
+                endpoints: [
+                  { endpointNumber: 3, direction: 'in', type: 'bulk', packetSize: 512 },
+                  { endpointNumber: 2, direction: 'out', type: 'bulk', packetSize: 512 },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    // Must survive the postMessage boundary it exists to cross.
+    expect(() => structuredClone(info)).not.toThrow();
+  });
+
+  it('drops endpoints whose direction or type is outside the WebUSB vocabulary', () => {
+    const info = deviceToInfo(
+      'usb1',
+      fakeDevice({
+        configurations: [
+          {
+            configurationValue: 1,
+            interfaces: [
+              {
+                interfaceNumber: 0,
+                claimed: false,
+                alternates: [
+                  {
+                    alternateSetting: 0,
+                    interfaceClass: 0xff,
+                    interfaceSubclass: 0xff,
+                    interfaceProtocol: 0,
+                    endpoints: [
+                      { endpointNumber: 1, direction: 'in', type: 'bulk', packetSize: 64 },
+                      { endpointNumber: 2, direction: 'sideways', type: 'bulk', packetSize: 64 },
+                      { endpointNumber: 3, direction: 'out', type: 'quantum', packetSize: 64 },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    expect(info.configurations?.[0]?.interfaces[0]?.alternates[0]?.endpoints).toEqual([
+      { endpointNumber: 1, direction: 'in', type: 'bulk', packetSize: 64 },
+    ]);
+  });
+
+  it('tolerates a descriptor tree with missing nested arrays', () => {
+    const info = deviceToInfo(
+      'usb1',
+      fakeDevice({
+        configurations: [
+          { configurationValue: 1, interfaces: undefined },
+        ] as unknown as UsbDevice['configurations'],
+      })
+    );
+    expect(info.configurations).toEqual([{ configurationValue: 1, interfaces: [] }]);
+  });
 });
 
 describe('usb-operations', () => {


### PR DESCRIPTION
## Summary

`UsbDeviceInfo` carried identity only — `handle`, ids, names, `opened` — so
`sliccy:usb` device objects had **no `configurations`**, unlike page-side WebUSB.
A realm script that needs an interface by class/subclass/protocol had to open the
device and re-read the configuration descriptor over a control transfer just to
learn a layout the platform already knew.

This maps the descriptor tree into `UsbDeviceInfo`, so the realm gets it directly.

## Why

Written while building an ADB client as a `.jsh` (ADB lives on a vendor-specific
interface: class `0xff` / subclass `0x42` / protocol `0x01`, two bulk endpoints).
`usb.list()` gave no way to find it, so the script carries ~50 lines that
`controlTransferIn` a `GET_DESCRIPTOR(CONFIGURATION)`, then walk the raw bytes
for interface and endpoint descriptors. Every script driving a vendor-specific
device re-derives that. Hardcoding "interface 1" is the tempting alternative and
is wrong on the next device.

## Approach / Implementation notes

- Mapping lives in `deviceToInfo`, the single construction point for
  `UsbDeviceInfo`, so page and extension realms and every backend get it for
  free. The realm bridge already spreads `...info` — **no change needed there**,
  which is also why `RealmUsbDevice` needed no edit.
- The live `USBConfiguration` / `USBInterface` / `USBEndpoint` are class
  instances and cannot cross `postMessage`, hence structural copies rather than
  passing references. There's a `structuredClone` assertion in the tests pinning
  exactly that.
- Two type families deliberately: unexported `UsbLive*` for what is read off a
  real `USBDevice` (where `direction`/`type` are plain `string`), and exported
  `Usb*Descriptor` for the serializable form with the literal unions. The
  narrowing happens once, at the boundary.
- Endpoints whose `direction`/`type` fall outside the WebUSB vocabulary are
  **dropped, not widened**. Callers match on those fields; an unexpected value
  should not read as a usable endpoint.
- `configurations` is optional throughout, so anything ignoring it is unchanged.

**Deliberately not included:** shell exposure. `usb list` prints one compact line
per device and has no `--json`, so surfacing descriptors there means designing new
output rather than plumbing data. The realm is the consumer that motivated this;
a `usb info <handle> --json` can follow if wanted.

## Cross-cutting impact

- **Floats**: mapping sits in the shared kernel registry, so standalone,
  extension, and sprinkle-bridge paths all get it identically.
- **Other callers of the changed contract**: `UsbDeviceInfo` is consumed by
  `usb-backends.ts`, `usb-command.ts` (`formatDeviceInfo` reads named fields
  only), `sprinkle-bridge.ts`, and `realm-usb-bridge.ts`. All either name fields
  explicitly or spread; adding an optional field affects none. The existing
  `deviceToInfo` exact-match test still passes unchanged, which is the useful
  proof that absent stays absent.
- **Wire size**: one extra object tree per device in `list`/`request`/`info`
  responses. Bounded by the device's own descriptor (single-digit KB worst case).
- **Security**: descriptors are already readable by any granted holder via a
  control transfer. No new capability, no new permission.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — **0 errors**, against a **0-error
      baseline** on `origin/main` in the same tree
- [x] `npx vitest run` on all three USB suites (registry, realm bridge, usb
      command) — **41 passing**
- [x] 4 new tests: descriptor flattening (shaped after a real Android device),
      `configurations` omitted when unexposed, out-of-vocabulary endpoints
      dropped, missing nested arrays tolerated, plus a `structuredClone`
      assertion for the postMessage boundary
- [x] `npx biome check` / `npx prettier --check` on both files — clean
- [x] `check-layer-back-edges.mjs`, `check-record-string-unknown.mjs` — ok
- [x] **Verified live** against a Motorola moto g67 over USB: built this branch's
      webapp, served it on the existing dev origin so the browser's WebUSB grant
      carried over, and ran a `.jsh` probe in the realm:

  ```
  configurations: PRESENT (1 config)
  adb interface found without a control transfer: [{"iface":1,"eps":["out:2:bulk","in:3:bulk"]}]
  ```

  That matches exactly what the control-transfer descriptor walk returns on the
  same device — same interface number, same endpoints — so the mapping is
  faithful to the wire, not merely well-typed.

## Risk & rollback

Additive and optional; reverts cleanly. No migration, no persisted state, no
feature flag. Worst case is the field being absent again, which is today.

Reviewer note: CI can't see a real device. The unit tests pin the mapping shape,
but "the descriptors match the hardware" is the live check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
