### PR TITLE
feat(webapp): allow USB transfers from sprinkles

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -2084,18 +2084,19 @@ slicc.hid.on('inputreport', ({ handle, reportId, data }) => {
 await slicc.hid.sendReport(info.handle, 0, new Uint8Array([0x01, 0x02]));
 ```
 
-| Method                                                   | Returns                       | Notes                                                                                                                           |
-| -------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `slicc.hid.list()`                                       | `Promise<HidDeviceInfo[]>`    | Already-granted devices; no picker.                                                                                             |
-| `slicc.hid.request(filters?)`                            | `Promise<HidDeviceInfo[]>`    | Shows the WebHID picker; every granted interface of a multi-interface device is registered.                                     |
-| `slicc.hid.open(handle)` / `slicc.hid.close(handle)`     | `Promise<void>`               | `open` auto-attaches the host's input-report listener; `close` (or sprinkle close) detaches it.                                 |
-| `slicc.hid.sendReport(handle, reportId, data)`           | `Promise<void>`               | `data` is `Uint8Array`.                                                                                                         |
-| `slicc.hid.on('inputreport', cb)` / `slicc.hid.off(...)` | `void`                        | `cb({handle, reportId, data})` — `data` is a `Uint8Array`. Subscriptions are torn down on close.                                |
-| `slicc.serial.list()` / `slicc.serial.request(filters?)` | `Promise<SerialDeviceInfo[]>` | Already-granted vs. picker; parity with `hid`.                                                                                  |
-| `slicc.serial.open(handle, options)` / `serial.close(h)` | `Promise<void>`               | `options` mirrors the Web Serial open shape (`baudRate`, `dataBits`, …).                                                        |
-| `slicc.usb.list()` / `slicc.usb.request(filters?)`       | `Promise<UsbDeviceInfo[]>`    | Already-granted vs. picker; parity with `hid`. Each `UsbDeviceInfo` carries `configurations` — see below.                       |
-| `slicc.usb.open(handle)` / `slicc.usb.close(handle)`     | `Promise<void>`               | Control / bulk transfers stay on the realm-side `usb` global for v1.                                                            |
-| `slicc.usb.clearHalt(handle, direction, endpoint)`       | `Promise<void>`               | Clears one stalled endpoint; `direction` is `'in'` or `'out'`. Targeted alternative to `reset`, which re-enumerates the device. |
+| Method                                                              | Returns                                                        | Notes                                                                                                                                                                                  |
+| ------------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slicc.hid.list()`                                                  | `Promise<HidDeviceInfo[]>`                                     | Already-granted devices; no picker.                                                                                                                                                    |
+| `slicc.hid.request(filters?)`                                       | `Promise<HidDeviceInfo[]>`                                     | Shows the WebHID picker; every granted interface of a multi-interface device is registered.                                                                                            |
+| `slicc.hid.open(handle)` / `slicc.hid.close(handle)`                | `Promise<void>`                                                | `open` auto-attaches the host's input-report listener; `close` (or sprinkle close) detaches it.                                                                                        |
+| `slicc.hid.sendReport(handle, reportId, data)`                      | `Promise<void>`                                                | `data` is `Uint8Array`.                                                                                                                                                                |
+| `slicc.hid.on('inputreport', cb)` / `slicc.hid.off(...)`            | `void`                                                         | `cb({handle, reportId, data})` — `data` is a `Uint8Array`. Subscriptions are torn down on close.                                                                                       |
+| `slicc.serial.list()` / `slicc.serial.request(filters?)`            | `Promise<SerialDeviceInfo[]>`                                  | Already-granted vs. picker; parity with `hid`.                                                                                                                                         |
+| `slicc.serial.open(handle, options)` / `serial.close(h)`            | `Promise<void>`                                                | `options` mirrors the Web Serial open shape (`baudRate`, `dataBits`, …).                                                                                                               |
+| `slicc.usb.list()` / `slicc.usb.request(filters?)`                  | `Promise<UsbDeviceInfo[]>`                                     | Already-granted vs. picker; parity with `hid`. Each `UsbDeviceInfo` carries `configurations` — see below.                                                                              |
+| `slicc.usb.open(handle)` / `slicc.usb.close(handle)`                | `Promise<void>`                                                | Also `reset`, `selectConfiguration(h, value)`, `claimInterface(h, n)`, `releaseInterface(h, n)`, `clearHalt(h, direction, ep)`.                                                        |
+| `slicc.usb.transferIn(h, ep, length)` / `transferOut(h, ep, bytes)` | `Promise<{status, bytes}>` / `Promise<{status, bytesWritten}>` | Bulk/interrupt transfers, page-side. `controlTransferIn`/`controlTransferOut` take a setup packet. Payloads cross the iframe boundary as base64 and arrive back as real `Uint8Array`s. |
+| `slicc.usb.clearHalt(handle, direction, endpoint)`                  | `Promise<void>`                                                | Clears one stalled endpoint; `direction` is `'in'` or `'out'`. Targeted alternative to `reset`, which re-enumerates the device.                                                        |
 
 #### `UsbDeviceInfo.configurations`
 
@@ -2146,6 +2147,11 @@ const adb = (device.configurations ?? [])
     (a) => a.interfaceClass === 0xff && a.interfaceSubclass === 0x42 && a.interfaceProtocol === 0x01
   );
 ```
+
+Transfers are available page-side, not only in the realm, because a `.jsh`
+cannot stream: realm stdout is buffered and delivered when the run completes,
+so anything that reads a device for as long as it stays interesting — a video
+stream, a sensor feed — has to drive the device from the sprinkle.
 
 Untrusted inline-chat dips (fenced ` ```shtml ` blocks emitted by the agent) NEVER receive `slicc.hid` / `serial` / `usb`. Any spoofed request from such an iframe is rejected with `device access not allowed for this dip` before it reaches the registry.
 

--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -353,10 +353,30 @@ slicc.hid.sendReport(handle, reportId, data: Uint8Array): Promise<void>
 slicc.hid.on('inputreport', cb): void                    // cb: ({ handle, reportId, data })
 slicc.hid.off('inputreport', cb): void
 
-// Serial / USB — parity list/request/open/close; streaming I/O stays on the realm API.
+// Serial — parity list/request/open/close; streaming I/O stays on the realm API.
 slicc.serial.list() / request(filters?) / open(handle, options) / close(handle)
-slicc.usb.list()    / request(filters?) / open(handle) / close(handle)
+
+// USB — full transfer surface, so a sprinkle can drive a device itself.
+slicc.usb.list(): Promise<UsbDeviceInfo[]>
+slicc.usb.request(filters?): Promise<UsbDeviceInfo>      // needs button-click gesture
+slicc.usb.open(handle) / close(handle) / reset(handle): Promise<void>
+slicc.usb.selectConfiguration(handle, value): Promise<void>
+slicc.usb.claimInterface(handle, n) / releaseInterface(handle, n): Promise<void>
+slicc.usb.clearHalt(handle, 'in' | 'out', endpoint): Promise<void>
+slicc.usb.transferIn(handle, endpoint, length): Promise<{ status, bytes: Uint8Array }>
+slicc.usb.transferOut(handle, endpoint, bytes: Uint8Array): Promise<{ status, bytesWritten }>
+slicc.usb.controlTransferIn(handle, setup, length): Promise<{ status, bytes: Uint8Array }>
+slicc.usb.controlTransferOut(handle, setup, bytes): Promise<{ status, bytesWritten }>
 ```
+
+Transfers are on the sprinkle surface, not realm-only, because a `.jsh` cannot
+stream: realm stdout is buffered and delivered when the run completes. Anything
+that reads a device for as long as it stays interesting — a video stream, a
+sensor feed — has to drive the device from the sprinkle and render as it goes.
+
+You hand in and get back real `Uint8Array`s; the base64 the iframe boundary
+needs is handled for you. `UsbDeviceInfo` also carries `configurations`, so an
+interface can be located by class/subclass/protocol without a descriptor read.
 
 ```html
 <button

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -27,6 +27,7 @@ import {
 import {
   getNavigatorUsb,
   getSharedUsbRegistry,
+  type UsbControlSetup,
   type UsbDeviceFilter,
   type UsbDeviceInfo,
 } from '../kernel/usb-device-registry.js';
@@ -222,15 +223,48 @@ export interface SprinkleSerialApi {
 }
 
 /**
- * `slicc.usb` — parity surface for WebUSB. Mirrors the realm `usb`
- * global's `list`/`request`/`open`/`close` shape; control/bulk
- * transfers stay on the realm-side API for v1.
+ * `slicc.usb` — parity surface for WebUSB, mirroring the realm `usb` global.
+ *
+ * Transfers are here rather than realm-only because a page-side consumer
+ * cannot use the realm for a continuous stream: `.jsh` stdout is buffered
+ * and delivered on completion, so anything that reads a device for as long
+ * as it is interesting (a video stream, a sensor feed) has to drive the
+ * device from the page.
+ *
+ * Payloads cross the sandboxed-iframe boundary as base64, matching
+ * `readFileBinary` / `writeFileBinary`; the boundary is not structured
+ * clone, so a `Uint8Array` cannot be passed through directly.
  */
 export interface SprinkleUsbApi {
   list(): Promise<UsbDeviceInfo[]>;
   request(filters?: UsbDeviceFilter[]): Promise<UsbDeviceInfo>;
   open(handle: string): Promise<void>;
   close(handle: string): Promise<void>;
+  reset(handle: string): Promise<void>;
+  selectConfiguration(handle: string, configurationValue: number): Promise<void>;
+  claimInterface(handle: string, interfaceNumber: number): Promise<void>;
+  releaseInterface(handle: string, interfaceNumber: number): Promise<void>;
+  clearHalt(handle: string, direction: 'in' | 'out', endpointNumber: number): Promise<void>;
+  controlTransferIn(
+    handle: string,
+    setup: UsbControlSetup,
+    length: number
+  ): Promise<{ status: string; bytes: Uint8Array }>;
+  controlTransferOut(
+    handle: string,
+    setup: UsbControlSetup,
+    bytes: Uint8Array
+  ): Promise<{ status: string; bytesWritten: number }>;
+  transferIn(
+    handle: string,
+    endpointNumber: number,
+    length: number
+  ): Promise<{ status: string; bytes: Uint8Array }>;
+  transferOut(
+    handle: string,
+    endpointNumber: number,
+    bytes: Uint8Array
+  ): Promise<{ status: string; bytesWritten: number }>;
 }
 
 // ── Tier 1 jsh bridge: node -e command builder + result parser ──
@@ -323,6 +357,13 @@ export async function runJshOp(
 }
 
 /** Base64-encode bytes for transport across the page→iframe boundary. */
+/** Detach a `Uint8Array` view into its own buffer for the WebUSB call. */
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(copy).set(bytes);
+  return copy;
+}
+
 function u8ToBase64(bytes: Uint8Array): string {
   let bin = '';
   const chunk = 0x8000;
@@ -709,6 +750,67 @@ export class SprinkleBridge {
         await usbOps.usbClose(reg, args[0] as string);
         return { ok: true };
       }
+      case 'reset': {
+        await usbOps.usbReset(reg, args[0] as string);
+        return { ok: true };
+      }
+      case 'selectConfig': {
+        await usbOps.usbSelectConfiguration(reg, args[0] as string, args[1] as number);
+        return { ok: true };
+      }
+      case 'claim': {
+        await usbOps.usbClaimInterface(reg, args[0] as string, args[1] as number);
+        return { ok: true };
+      }
+      case 'release': {
+        await usbOps.usbReleaseInterface(reg, args[0] as string, args[1] as number);
+        return { ok: true };
+      }
+      case 'clearHalt': {
+        await usbOps.usbClearHalt(
+          reg,
+          args[0] as string,
+          args[1] as 'in' | 'out',
+          args[2] as number
+        );
+        return { ok: true };
+      }
+      case 'controlIn': {
+        const r = await usbOps.usbControlTransferIn(
+          reg,
+          args[0] as string,
+          args[1] as UsbControlSetup,
+          args[2] as number
+        );
+        return { status: r.status, base64: u8ToBase64(new Uint8Array(r.bytes)) };
+      }
+      case 'controlOut': {
+        const r = await usbOps.usbControlTransferOut(
+          reg,
+          args[0] as string,
+          args[1] as UsbControlSetup,
+          toArrayBuffer(base64ToU8(args[2] as string))
+        );
+        return { status: r.status, bytesWritten: r.bytesWritten };
+      }
+      case 'transferIn': {
+        const r = await usbOps.usbTransferIn(
+          reg,
+          args[0] as string,
+          args[1] as number,
+          args[2] as number
+        );
+        return { status: r.status, base64: u8ToBase64(new Uint8Array(r.bytes)) };
+      }
+      case 'transferOut': {
+        const r = await usbOps.usbTransferOut(
+          reg,
+          args[0] as string,
+          args[1] as number,
+          toArrayBuffer(base64ToU8(args[2] as string))
+        );
+        return { status: r.status, bytesWritten: r.bytesWritten };
+      }
       default:
         throw new Error(`usb: unknown op '${op}'`);
     }
@@ -996,6 +1098,47 @@ export class SprinkleBridge {
       close: async (handle: string) => {
         await this.usbOp(sprinkleName, 'close', [handle]);
       },
+      reset: async (handle: string) => {
+        await this.usbOp(sprinkleName, 'reset', [handle]);
+      },
+      selectConfiguration: async (handle: string, configurationValue: number) => {
+        await this.usbOp(sprinkleName, 'selectConfig', [handle, configurationValue]);
+      },
+      claimInterface: async (handle: string, interfaceNumber: number) => {
+        await this.usbOp(sprinkleName, 'claim', [handle, interfaceNumber]);
+      },
+      releaseInterface: async (handle: string, interfaceNumber: number) => {
+        await this.usbOp(sprinkleName, 'release', [handle, interfaceNumber]);
+      },
+      clearHalt: async (handle: string, direction: 'in' | 'out', endpointNumber: number) => {
+        await this.usbOp(sprinkleName, 'clearHalt', [handle, direction, endpointNumber]);
+      },
+      controlTransferIn: async (handle: string, setup: UsbControlSetup, length: number) => {
+        const r = (await this.usbOp(sprinkleName, 'controlIn', [handle, setup, length])) as {
+          status: string;
+          base64: string;
+        };
+        return { status: r.status, bytes: base64ToU8(r.base64) };
+      },
+      controlTransferOut: async (handle: string, setup: UsbControlSetup, bytes: Uint8Array) =>
+        this.usbOp(sprinkleName, 'controlOut', [handle, setup, u8ToBase64(bytes)]) as Promise<{
+          status: string;
+          bytesWritten: number;
+        }>,
+      transferIn: async (handle: string, endpointNumber: number, length: number) => {
+        const r = (await this.usbOp(sprinkleName, 'transferIn', [
+          handle,
+          endpointNumber,
+          length,
+        ])) as { status: string; base64: string };
+        return { status: r.status, bytes: base64ToU8(r.base64) };
+      },
+      transferOut: async (handle: string, endpointNumber: number, bytes: Uint8Array) =>
+        this.usbOp(sprinkleName, 'transferOut', [
+          handle,
+          endpointNumber,
+          u8ToBase64(bytes),
+        ]) as Promise<{ status: string; bytesWritten: number }>,
     };
   }
 

--- a/packages/webapp/src/ui/sprinkle-follower-controller.ts
+++ b/packages/webapp/src/ui/sprinkle-follower-controller.ts
@@ -19,7 +19,7 @@
 import { createLogger } from '../base/logger.js';
 import type { SprinkleSummary } from '../scoops/tray-sync-protocol.js';
 import { toPreviewUrl } from '../shell/supplemental-commands/shared.js';
-import type { SprinkleBridgeAPI } from './sprinkle-bridge.js';
+import type { SprinkleBridgeAPI, SprinkleUsbApi } from './sprinkle-bridge.js';
 import type { SprinkleAddOptions } from './sprinkle-manager.js';
 import { SprinkleRenderer } from './sprinkle-renderer.js';
 
@@ -82,6 +82,35 @@ interface OpenEntry {
 }
 
 type UpdateCallback = (data: unknown) => void;
+
+/**
+ * The `slicc.usb` surface for a follower-rendered sprinkle: every op rejects,
+ * because a follower has no device registry of its own.
+ *
+ * Built from one shared thunk rather than written out per method so a future
+ * addition to {@link SprinkleUsbApi} cannot silently be missing here and
+ * surface inside the sprinkle as "api.usb.transferIn is not a function"
+ * instead of a clear rejection.
+ */
+function followerUsbApi(): SprinkleUsbApi {
+  const unsupported = () =>
+    Promise.reject(new Error('usb not supported in follower-rendered sprinkle'));
+  return {
+    list: unsupported,
+    request: unsupported,
+    open: unsupported,
+    close: unsupported,
+    reset: unsupported,
+    selectConfiguration: unsupported,
+    claimInterface: unsupported,
+    releaseInterface: unsupported,
+    clearHalt: unsupported,
+    controlTransferIn: unsupported,
+    controlTransferOut: unsupported,
+    transferIn: unsupported,
+    transferOut: unsupported,
+  } as SprinkleUsbApi;
+}
 
 export class SprinkleFollowerController {
   private readonly sync: SprinkleFollowerSync;
@@ -632,12 +661,7 @@ export class SprinkleFollowerController {
         close: () =>
           Promise.reject(new Error('serial not supported in follower-rendered sprinkle')),
       },
-      usb: {
-        list: () => Promise.reject(new Error('usb not supported in follower-rendered sprinkle')),
-        request: () => Promise.reject(new Error('usb not supported in follower-rendered sprinkle')),
-        open: () => Promise.reject(new Error('usb not supported in follower-rendered sprinkle')),
-        close: () => Promise.reject(new Error('usb not supported in follower-rendered sprinkle')),
-      },
+      usb: followerUsbApi(),
       readFileBinary: () =>
         Promise.reject(new Error('readFileBinary not supported in follower-rendered sprinkle')),
       writeFileBinary: () =>

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -561,7 +561,37 @@ export class SprinkleRenderer {
       list: function() { return _deviceCall('usb', 'list', []); },
       request: function(filters) { return _deviceCall('usb', 'request', [filters || []]); },
       open: function(handle) { return _deviceCall('usb', 'open', [handle]).then(function() {}); },
-      close: function(handle) { return _deviceCall('usb', 'close', [handle]).then(function() {}); }
+      close: function(handle) { return _deviceCall('usb', 'close', [handle]).then(function() {}); },
+      reset: function(handle) { return _deviceCall('usb', 'reset', [handle]).then(function() {}); },
+      selectConfiguration: function(handle, value) {
+        return _deviceCall('usb', 'selectConfig', [handle, value]).then(function() {});
+      },
+      claimInterface: function(handle, n) {
+        return _deviceCall('usb', 'claim', [handle, n]).then(function() {});
+      },
+      releaseInterface: function(handle, n) {
+        return _deviceCall('usb', 'release', [handle, n]).then(function() {});
+      },
+      clearHalt: function(handle, direction, ep) {
+        return _deviceCall('usb', 'clearHalt', [handle, direction, ep]).then(function() {});
+      },
+      // Payloads cross as base64 — see the note on SprinkleUsbApi.
+      controlTransferIn: function(handle, setup, length) {
+        return _deviceCall('usb', 'controlIn', [handle, setup, length]).then(function(r) {
+          return { status: r.status, bytes: _b64ToU8(r.base64) };
+        });
+      },
+      controlTransferOut: function(handle, setup, bytes) {
+        return _deviceCall('usb', 'controlOut', [handle, setup, _u8ToB64(bytes)]);
+      },
+      transferIn: function(handle, ep, length) {
+        return _deviceCall('usb', 'transferIn', [handle, ep, length]).then(function(r) {
+          return { status: r.status, bytes: _b64ToU8(r.base64) };
+        });
+      },
+      transferOut: function(handle, ep, bytes) {
+        return _deviceCall('usb', 'transferOut', [handle, ep, _u8ToB64(bytes)]);
+      }
     },
     readFileBinary: function(path) { return _jshCall('readFileBinary', [path]).then(function(r) { return _b64ToU8(r.base64); }); },
     writeFileBinary: function(path, bytes) { return _jshCall('writeFileBinary', [path, _u8ToB64(bytes)]); },

--- a/packages/webapp/tests/ui/sprinkle-bridge-devices.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-bridge-devices.test.ts
@@ -6,6 +6,11 @@ import {
   type HidDevice,
   type HidInputReportEvent,
 } from '../../src/kernel/hid-device-registry.js';
+import {
+  getSharedUsbRegistry,
+  type UsbApi,
+  type UsbDevice,
+} from '../../src/kernel/usb-device-registry.js';
 import type { LickEvent } from '../../src/scoops/lick-manager.js';
 import { SprinkleBridge, type SprinkleHidInputReport } from '../../src/ui/sprinkle-bridge.js';
 
@@ -77,6 +82,57 @@ function buildBridge(iframePusher?: (name: string, channel: string, payload: unk
     undefined,
     iframePusher
   );
+}
+
+/** A fake WebUSB device that records transfer calls. */
+function makeFakeUsbDevice(over: Partial<UsbDevice> = {}): UsbDevice {
+  return {
+    vendorId: 0x22b8,
+    productId: 0x2e76,
+    productName: 'Fake Phone',
+    manufacturerName: 'Test',
+    serialNumber: 'USB-1',
+    opened: false,
+    open: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    reset: vi.fn(async () => undefined),
+    selectConfiguration: vi.fn(async () => undefined),
+    claimInterface: vi.fn(async () => undefined),
+    releaseInterface: vi.fn(async () => undefined),
+    clearHalt: vi.fn(async () => undefined),
+    controlTransferIn: vi.fn(async () => ({
+      status: 'ok',
+      data: { buffer: new Uint8Array([1, 2, 3]).buffer, byteOffset: 0, byteLength: 3 },
+    })),
+    controlTransferOut: vi.fn(async () => ({ status: 'ok', bytesWritten: 2 })),
+    transferIn: vi.fn(async () => ({
+      status: 'ok',
+      data: {
+        buffer: new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer,
+        byteOffset: 0,
+        byteLength: 4,
+      },
+    })),
+    transferOut: vi.fn(async () => ({ status: 'ok', bytesWritten: 4 })),
+    ...over,
+  } as UsbDevice;
+}
+
+/** Stub `navigator.usb` for the duration of a test, then restore. */
+function stubNavigatorUsb(usb: UsbApi): () => void {
+  const nav = (globalThis as { navigator?: { usb?: UsbApi } }).navigator;
+  if (!nav) {
+    (globalThis as { navigator?: { usb?: UsbApi } }).navigator = { usb };
+    return () => {
+      delete (globalThis as { navigator?: { usb?: UsbApi } }).navigator;
+    };
+  }
+  const prev = nav.usb;
+  nav.usb = usb;
+  return () => {
+    if (prev) nav.usb = prev;
+    else delete nav.usb;
+  };
 }
 
 /** Stub `navigator.hid` for the duration of a test, then restore. */
@@ -230,5 +286,95 @@ describe('SprinkleBridge — slicc.hid surface', () => {
     await expect(api._device('bogus' as 'hid', 'list', [])).rejects.toThrow(
       /unknown device channel/
     );
+  });
+});
+
+describe('SprinkleBridge — slicc.usb transfers', () => {
+  let restoreUsb: (() => void) | null = null;
+
+  afterEach(() => {
+    const reg = getSharedUsbRegistry();
+    for (const { handle } of reg.list()) reg.remove(handle);
+    if (restoreUsb) {
+      restoreUsb();
+      restoreUsb = null;
+    }
+  });
+
+  async function grant(device: UsbDevice) {
+    const usb: UsbApi = {
+      getDevices: vi.fn().mockResolvedValue([device]),
+      requestDevice: vi.fn(),
+    };
+    restoreUsb = stubNavigatorUsb(usb);
+    const api = buildBridge().createAPI('demo');
+    const [info] = await api.usb.list();
+    return { api, handle: info.handle };
+  }
+
+  it('routes the interface lifecycle ops to the device', async () => {
+    const device = makeFakeUsbDevice();
+    const { api, handle } = await grant(device);
+    await api.usb.selectConfiguration(handle, 1);
+    await api.usb.claimInterface(handle, 1);
+    await api.usb.clearHalt(handle, 'in', 3);
+    await api.usb.releaseInterface(handle, 1);
+    await api.usb.reset(handle);
+    expect(device.selectConfiguration).toHaveBeenCalledWith(1);
+    expect(device.claimInterface).toHaveBeenCalledWith(1);
+    expect(device.clearHalt).toHaveBeenCalledWith('in', 3);
+    expect(device.releaseInterface).toHaveBeenCalledWith(1);
+    expect(device.reset).toHaveBeenCalled();
+  });
+
+  it('transferIn decodes the base64 the boundary carries back into bytes', async () => {
+    // The sandboxed-iframe boundary is not structured clone, so payloads
+    // cross as base64. A caller must still see real bytes.
+    const device = makeFakeUsbDevice();
+    const { api, handle } = await grant(device);
+    const r = await api.usb.transferIn(handle, 3, 64);
+    expect(device.transferIn).toHaveBeenCalledWith(3, 64);
+    expect(r.status).toBe('ok');
+    expect(r.bytes).toBeInstanceOf(Uint8Array);
+    expect([...r.bytes]).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it('transferOut delivers the caller bytes to the device unchanged', async () => {
+    const device = makeFakeUsbDevice();
+    const { api, handle } = await grant(device);
+    const payload = new Uint8Array([0x00, 0x01, 0xfe, 0xff]);
+    const r = await api.usb.transferOut(handle, 2, payload);
+    expect(r.bytesWritten).toBe(4);
+    const sent = (device.transferOut as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    expect(sent[0]).toBe(2);
+    expect([...new Uint8Array(sent[1] as ArrayBuffer)]).toEqual([0x00, 0x01, 0xfe, 0xff]);
+  });
+
+  it('round-trips bytes that are not valid UTF-8', async () => {
+    // Guards the base64 marshalling: a naive string conversion mangles
+    // high bytes and lone surrogates.
+    const payload = new Uint8Array([0x80, 0xff, 0x00, 0xed, 0xa0, 0x80]);
+    const device = makeFakeUsbDevice();
+    const { api, handle } = await grant(device);
+    await api.usb.transferOut(handle, 2, payload);
+    const sent = (device.transferOut as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    expect([...new Uint8Array(sent[1] as ArrayBuffer)]).toEqual([...payload]);
+  });
+
+  it('controlTransferIn/Out carry the setup packet through', async () => {
+    const device = makeFakeUsbDevice();
+    const { api, handle } = await grant(device);
+    const setup = {
+      requestType: 'standard' as const,
+      recipient: 'device' as const,
+      request: 6,
+      value: 0x0200,
+      index: 0,
+    };
+    const inResult = await api.usb.controlTransferIn(handle, setup, 9);
+    expect(device.controlTransferIn).toHaveBeenCalledWith(setup, 9);
+    expect([...inResult.bytes]).toEqual([1, 2, 3]);
+    await api.usb.controlTransferOut(handle, setup, new Uint8Array([0xaa, 0xbb]));
+    expect(device.controlTransferOut).toHaveBeenCalled();
   });
 });

--- a/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
@@ -79,6 +79,7 @@ vi.mock('../../src/ui/sprinkle-renderer.js', () => {
   return { SprinkleRenderer: FakeRenderer };
 });
 
+import type { SprinkleUsbApi } from '../../src/ui/sprinkle-bridge.js';
 // Bring the mock surface into the test file so we can assert against it.
 import { SprinkleRenderer } from '../../src/ui/sprinkle-renderer.js';
 
@@ -93,6 +94,7 @@ const FakeRenderer = SprinkleRenderer as unknown as {
       stopCone: () => void;
       on: (event: 'update', cb: (data: unknown) => void) => void;
       off: (event: 'update', cb: (data: unknown) => void) => void;
+      usb: SprinkleUsbApi;
     };
   }>;
   reset(): void;
@@ -373,6 +375,34 @@ describe('SprinkleFollowerController', () => {
 
       expect(removeSprinkle).toHaveBeenCalledWith('welcome');
       expect(FakeRenderer.instances[0].disposed).toBe(true);
+    });
+
+    it('every slicc.usb method rejects on a follower, none is undefined', async () => {
+      // The follower has no device registry, so all USB ops must reject. The
+      // failure mode this guards is a NEW method on SprinkleUsbApi being
+      // absent here and surfacing inside the sprinkle as
+      // "api.usb.transferIn is not a function" instead of a clear rejection.
+      sync.contentByName.set('welcome', '<p>hi</p>');
+      await controller.updateAvailable([makeSprinkle('welcome', { open: true })]);
+      const { usb } = FakeRenderer.instances[0].api;
+
+      const calls: Array<[string, Promise<unknown>]> = [
+        ['list', usb.list()],
+        ['request', usb.request()],
+        ['open', usb.open('usb1')],
+        ['close', usb.close('usb1')],
+        ['reset', usb.reset('usb1')],
+        ['selectConfiguration', usb.selectConfiguration('usb1', 1)],
+        ['claimInterface', usb.claimInterface('usb1', 1)],
+        ['releaseInterface', usb.releaseInterface('usb1', 1)],
+        ['clearHalt', usb.clearHalt('usb1', 'in', 3)],
+        ['transferIn', usb.transferIn('usb1', 3, 64)],
+        ['transferOut', usb.transferOut('usb1', 2, new Uint8Array([1]))],
+      ];
+
+      for (const [name, promise] of calls) {
+        await expect(promise, name).rejects.toThrow(/usb not supported/);
+      }
     });
 
     it('publishes the renderer before releasing a queued close lifecycle call', async () => {

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SprinkleBridgeAPI } from '../../src/ui/sprinkle-bridge.js';
+import { SprinkleBridge, type SprinkleBridgeAPI } from '../../src/ui/sprinkle-bridge.js';
 import { isFullDocument, SprinkleRenderer } from '../../src/ui/sprinkle-renderer.js';
 
 function makeBridge(name: string): SprinkleBridgeAPI {
@@ -263,6 +263,41 @@ describe('full document rendering', () => {
     expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin');
     // Should NOT have a .sprinkle-content wrapper
     expect(container.querySelector('.sprinkle-content')).toBeNull();
+  });
+
+  it('the in-iframe usb shim exposes every method the page-side API has', async () => {
+    // The sprinkle's `slicc.usb` is a hand-written shim inside the srcdoc,
+    // separate from `SprinkleBridge.createAPI`. Adding a method to one and
+    // not the other compiles and unit-tests clean, then fails at runtime with
+    // "slicc.usb.<name> is not a function" — which is exactly how the
+    // transfer surface first shipped half-wired.
+    const bridge = makeBridge('full-doc');
+    const renderer = new SprinkleRenderer(container, bridge);
+    await renderer.render(
+      '<!DOCTYPE html><html><head><title>T</title></head><body></body></html>',
+      'full-doc'
+    );
+    const srcdoc = container.querySelector('iframe')?.getAttribute('srcdoc') ?? '';
+
+    // Source of truth is the real page-side API, not the hand-built fake.
+    const real = new SprinkleBridge(
+      {} as never,
+      vi.fn() as never,
+      vi.fn() as never,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn().mockResolvedValue({ base64: '', width: 0, height: 0, mimeType: 'image/png' }),
+      undefined,
+      vi.fn()
+    ).createAPI('parity');
+    const pageSide = Object.keys(real.usb as unknown as Record<string, unknown>);
+    expect(pageSide.length).toBeGreaterThan(4);
+    for (const method of pageSide) {
+      expect(srcdoc, `slicc.usb.${method} missing from the iframe shim`).toContain(
+        `${method}: function(`
+      );
+    }
   });
 
   it('injects bridge script into srcdoc', async () => {


### PR DESCRIPTION
## Summary

`slicc.usb` exposed only `list` / `request` / `open` / `close`, with transfers
deferred — *"control/bulk transfers stay on the realm-side API for v1"*. This
adds `selectConfiguration`, `claimInterface`, `releaseInterface`, `reset`,
`clearHalt`, `controlTransferIn/Out` and `transferIn/Out`.

## Why

It reads as a limitation, but it is a capability gap: **a page-side consumer
cannot fall back to the realm for a continuous read.** `.jsh` stdout is buffered
and delivered when the run completes, so anything that reads a device for as long
as it stays interesting — a video stream, a sensor feed — cannot be built at all
today. The realm can talk to the device but cannot stream; the sprinkle can render
but cannot talk. Neither half is sufficient alone.

Concretely: I was streaming an Android phone's display into SLICC over the
ADB-on-WebUSB client from #2915/#2916 — `screenrecord` H.264 → `VideoDecoder` →
canvas — and there was no way to get the bytes to the thing doing the decoding.

## Approach / Implementation notes

Reuses the same `usb-operations` the realm and shell already share, so there is
one implementation of each op and this is purely a surface change.

**`slicc.usb` exists in two places, and this is the trap.** There is the page-side
API in `sprinkle-bridge.ts`, and a separate hand-written shim injected into the
sandboxed iframe in `sprinkle-renderer.ts` (~line 560). Updating one alone
compiles, typechecks and passes unit tests, then fails at runtime with
`slicc.usb.controlTransferIn is not a function` — which is exactly how I first
wrote it, and the unit tests happily went green. `sprinkle-renderer.test.ts` now
enumerates the **real** page-side API (not a fake) and asserts the srcdoc defines
every method, so the two cannot drift silently again.

**Payloads cross as base64**, matching the `readFileBinary` / `writeFileBinary`
precedent: the sandboxed-iframe boundary is not structured clone, so a
`Uint8Array` cannot pass through directly. Callers on both sides still hand in and
receive real `Uint8Array`s — the encoding is contained in the bridge and the shim.

The follower stub gains the same methods, built from one shared `unsupported`
thunk rather than written out per method, so a future addition to the interface
cannot silently be missing there and surface inside a sprinkle as a `TypeError`
instead of a clear rejection.

## Cross-cutting impact

- **Contract widening**: `SprinkleUsbApi` gains required members. Every
  implementor is in-repo and updated — the bridge, the iframe shim, and the
  follower stub.
- **Not touched**: `slicc.hid` and `slicc.serial` keep their existing surfaces.
  Serial has the same v1 gap (no `read`/`write` page-side); left alone
  deliberately, since nothing needs it yet and this PR is already a surface
  widening.
- **Security**: no new capability. Every op acts only on a device the user has
  already granted through the WebUSB chooser and the sprinkle has opened; the
  registry and permission model are unchanged. Untrusted inline-chat dips still
  receive no device surface at all.
- **Wire cost**: base64 inflates payloads ~33% across the iframe boundary. Fine
  at the scale these transfers run at (a 1 MB/s video stream is ~60 messages/sec),
  and it matches what file I/O already does.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — **0 errors**, from a 0-error baseline
- [x] `npx biome check .` — **0 errors** repo-wide
- [x] `npx vitest run packages/webapp/tests/ui/` — **2946 passing**, 19 skipped
- [x] 6 new tests: interface-lifecycle routing; `transferIn` base64 → bytes;
      `transferOut` bytes → device unchanged; a **non-UTF-8 round-trip**
      (`0x80 0xff 0x00 0xed 0xa0 0x80`) that a naive string conversion would
      mangle; control transfers carrying the setup packet; and the iframe/page
      parity check
- [x] Plus a follower test asserting **every** `slicc.usb` method rejects and none
      is `undefined`
- [x] **Both new guards verified to fail when they should.** Removing
      `transferIn` from the iframe shim →
      `AssertionError: slicc.usb.transferIn missing from the iframe shim`;
      removing it from the follower stub →
      `TypeError: usb.transferIn is not a function`
- [x] **Verified live** against a Motorola moto g67: a sprinkle drove the full ADB
      handshake (RSA-signed) over these transfers, opened
      `exec:screenrecord --output-format=h264`, received 85 KB of Annex-B, and
      decoded an IDR through `VideoDecoder` onto a canvas — the phone's home
      screen rendered inside SLICC with no host `adb` binary in the path.
- [ ] `npm run build` / full `npm run test` — not run; change is confined to the
      sprinkle device surface and its tests.

## Risk & rollback

Additive; reverts cleanly. No persisted state, no migration, no flag. The only
breaking-shaped part is the widened interface, and every implementor is in this
diff.

Reviewer note: the thing CI cannot check is that the iframe shim and the page API
agree at *runtime* — the parity test compares generated source text against the
real API's method names, which is the closest automatable proxy. The live
verification above is what actually exercised both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
