### PR TITLE
fix(renovate): run a full npm install so workspace lockfiles update

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,21 @@ node -p "JSON.parse(require('fs').readFileSync('package-lock.json','utf8')).pack
 npm view <dep> version
 ```
 
+### Lockfile artifact updates
+
+`renovate.json` sets `skipInstalls: false`. Mend-hosted Renovate otherwise
+defaults to `npm install --package-lock-only`, and npm's arborist then fails
+with `EMISSINGTARGET` on this workspace: a `link: true` entry such as
+`node_modules/@slicc/webapp` → `packages/webapp` is rewritten without the
+matching `packages/webapp` key. The lockfile on `main` is valid; only the
+lockfile-only rewrite is broken. That left PRs #2848, #2882, #2903, #2831,
+and #2922 with a `package.json` bump and a stale lockfile (`npm ci` red
+everywhere). A full `npm install` (what `skipInstalls: false` runs; scripts
+still ignored) produces the lockfile that CI can consume.
+
+Do not re-enable skipInstalls without a reproduction that the lockfile-only
+path no longer throws `EMISSINGTARGET` on a workspace bump.
+
 ### Companion reconcile workflows
 
 The Mend-hosted Renovate app cannot run `postUpgradeTasks`. Four workflows

--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,15 @@
   "extends": ["config:recommended"],
   "description": [
     "Dependency updates are intentionally NOT grouped into one 'non-major' PR — each package updates in its own PR so a breaking transitive bump fails in isolation and is trivial to identify (see the e2b 2.33.0 / Cloudflare workerd incident). Keep the purposeful cohesion groups below (semantic-release, xterm, earendil-works, just-bash, patched dependencies, v86); do not re-add a broad catch-all group.",
-    "gitIgnoredAuthors is the github-actions[bot] identity that the renovate-format-reconcile, renovate-patch-reconcile, renovate-swift-pin-reconcile, and renovate-skill-pin-reconcile workflows push their reflow/reconcile commits as. Listing it here stops Renovate treating those commits as a 'someone else edited this PR' foreign edit — without it Renovate posts an Edited/Blocked notice and disables auto-rebase on the amended PR (automerge still fires once green; see #1602). Keep in sync with the `git config user.email` in those four workflows."
+    "gitIgnoredAuthors is the github-actions[bot] identity that the renovate-format-reconcile, renovate-patch-reconcile, renovate-swift-pin-reconcile, and renovate-skill-pin-reconcile workflows push their reflow/reconcile commits as. Listing it here stops Renovate treating those commits as a 'someone else edited this PR' foreign edit — without it Renovate posts an Edited/Blocked notice and disables auto-rebase on the amended PR (automerge still fires once green; see #1602). Keep in sync with the `git config user.email` in those four workflows.",
+    "skipInstalls is false so lockfile updates run a real `npm install` instead of `npm install --package-lock-only`. The lockfile-only path hits arborist's EMISSINGTARGET on this npm workspace (`packages/webapp` referenced by `node_modules/@slicc/webapp` but 'does not exist' in the rewritten lockfile) — PRs #2848, #2882, #2903, #2831, #2922 all shipped package.json bumps with a stale lockfile. The lockfile on disk is valid; only Renovate's skipInstalls rewrite is broken. rarkins' workaround for this class of npm lockfile bugs: https://github.com/renovatebot/renovate/discussions/34940"
   ],
   "rebaseWhen": "conflicted",
   "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,
+  "skipInstalls": false,
   "minimumReleaseAge": "7 days",
   "prHourlyLimit": 4,
   "internalChecksFilter": "strict",


### PR DESCRIPTION
## Summary

Stop Mend-hosted Renovate from rewriting `package-lock.json` with `npm install --package-lock-only`. Set `skipInstalls: false` so lockfile updates run a real `npm install` (scripts still ignored).

## Why

Every recent workspace bump has landed with a `package.json` change and a stale lockfile. Renovate then comments **Artifact update problem** and CI dies at `npm ci`.

Repro (Renovate's default path):

1. Bump a dep declared in a workspace `package.json` (e.g. `lucide` in `packages/webapp` + `packages/webcomponents`).
2. Run `npm install --package-lock-only` the way Mend-hosted Renovate does (`skipInstalls` default).
3. Expected: lockfile records the new version.
4. Actual: arborist throws `EMISSINGTARGET` — `packages/webapp` is referenced by `node_modules/@slicc/webapp` but "does not exist" in the rewritten lockfile.

The lockfile on `main` is valid; local `npm install` always succeeds. Same failure on #2848, #2882, #2903, #2831, and #2922.

Renovate maintainers' workaround for this class of npm lockfile bugs: [`skipInstalls: false`](https://github.com/renovatebot/renovate/discussions/34940).

## Approach / Implementation notes

- Top-level `skipInstalls: false` in `renovate.json`, with the rationale in the config `description` array (same style as the pin / gitIgnoredAuthors notes).
- Documented under Dependency Update Policy in `docs/development.md`.
- No lockfile-reconcile workflow: if this flag works, the existing format/patch/swift/skill reconcilers stay the only post-upgrade Actions.

## Cross-cutting impact

- **Floats exercised**: none. Config-only; no runtime code.
- **Renovate runtime**: artifact updates get slower (full install vs lockfile-only). `ignoreScripts` still applies, so `postinstall` builds do not run on Mend's runner.
- Do not flip `skipInstalls` back without a reproduction that `--package-lock-only` no longer throws `EMISSINGTARGET` on a workspace bump.

## Test plan

- [x] `npm run verify` — all 8 checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — nothing to gate
- [x] `python3 -c 'import json; json.load(open("renovate.json"))'` — valid JSON
- [ ] N/A for `typecheck` / `test` / `build` — no TS/runtime change
- [ ] After merge, the next workspace-package Renovate PR (e.g. another lucide bump) should include a `package-lock.json` diff and should not post the Artifact update problem comment

## Documentation

- [x] `docs/development.md` — new "Lockfile artifact updates" subsection

## Risk & rollback

- Blast radius: Renovate PRs only. If `skipInstalls: false` is too slow or hits a Mend resource limit, revert this PR.
- Rollback: revert. No persisted state.

## Checklist

- [x] Commits are focused
- [x] No hand-edited files under `dist/`
- [x] No secrets