### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -51,10 +51,10 @@
       ]
     },
     "chrome-extension": {
-      "lines": 85,
-      "statements": 84,
-      "functions": 76,
-      "branches": 73,
+      "lines": 88,
+      "statements": 86,
+      "functions": 80,
+      "branches": 76,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.