### PR TITLE
fix(webapp): unblock require() of real npm packages in the JS realm

### DIFF
--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -165,9 +165,16 @@ self-reference.
 ### `util`
 
 `promisify` (with `promisify.custom`), `inspect` (with `inspect.custom`),
-`inherits`, `format`, `formatWithOptions`.
+`inherits`, `format`, `formatWithOptions`, `deprecate`.
 
-**Not available:** `types`, `deprecate`, `callbackify`,
+**Per-realm**: `deprecate`'s one-shot `DeprecationWarning` goes to the calling
+realm's stderr, so a shared module-scope shim would misroute it to the kernel
+worker's console. Packages call `deprecate` while their module body evaluates
+(`@eslint/eslintrc` does), so an absent one is a `TypeError` at REQUIRE time and
+the package never loads at all. There is no `--no-deprecation` flag and no
+`process.on('warning')` to consult, so the warning always fires once.
+
+**Not available:** `types`, `callbackify`,
 `TextEncoder` / `TextDecoder` (use the globals).
 
 ### `events`

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -425,6 +425,30 @@ the canonical `NODE_NATIVE_PACKAGES` and asserts the hand-mirror carries
 it. A package added to the canonical set without mirroring fails CI
 rather than silently re-enabling the 5-minute realm hang.
 
+**An unresolvable nested `require()` is a require-time error, never a
+graph-build error.** `buildModuleGraph` walks the whole dependency closure
+ahead of execution, so it sees specifiers Node would never resolve at all.
+`try { require('supports-color') } catch {}` is the standard optional-dependency
+idiom (`debug/src/node.js` is the one everybody hits), and Node only fails it
+when the line RUNS — inside the caller's `try`. A walker that throws on the
+first unresolvable edge instead sinks the entire graph, and the caller sees an
+error from a module it never asked for:
+
+```text
+While loading '/shared/lib/node_modules/debug/src/node.js': Cannot find module 'supports-color'
+```
+
+That error surfaces from `require('eslint/universal')`, three levels up, and no
+amount of `ipk add` fixes it because the missing package is genuinely optional.
+`ModuleGraph.edgeErrors` (keyed `fromPath → specifier → message`) now records
+the failure and `visit()` keeps walking; the realm's `requireFromEdges(edgeMap,
+id, fromPath)` throws the recorded message only when that specifier is actually
+required. Order matters there: consult `edgeErrors` **after** the edge lookup
+misses, or a specifier that failed from one file would shadow the resolved
+edge of another. Entry-point failures still throw — those are the ones the
+caller named. Regressions: `tests/shell/ipk/module-loader.test.ts`,
+`tests/shell/ipk/optional-dependency-require-e2e.test.ts`.
+
 ## RestrictedFS Path Behavior
 
 **File**: `packages/webapp/src/fs/restricted-fs.ts`

--- a/packages/webapp/src/kernel/realm/helpers/node-util.ts
+++ b/packages/webapp/src/kernel/realm/helpers/node-util.ts
@@ -223,12 +223,64 @@ function nodePromisify(original: Function): Function {
   return fn;
 }
 
+/**
+ * Node's `util.deprecate(fn, msg, code)`: a wrapper that warns ONCE on first
+ * call and then forwards to `fn` forever. Packages call it at module scope to
+ * mark a legacy export (`eslint/universal` reaches it through
+ * `@eslint/eslintrc`), so an absent `deprecate` is a `TypeError` at REQUIRE
+ * time — the package never loads at all, however deprecated the wrapped
+ * function is.
+ *
+ * The warning goes to `warn`, which the per-realm module wires to THAT realm's
+ * stderr — where Node puts a `DeprecationWarning`. Module scope has no access
+ * to a realm's streams, so a bare `console.error` here would land on the
+ * kernel worker's console and never reach the script's output; that is the
+ * same reason `os` and `readline` are per-realm. The realm has no
+ * `--no-deprecation` flag and no `process.on('warning')`, so there is nothing
+ * to consult before emitting; `code` is accepted and included for parity.
+ */
+function makeDeprecate(warn: (message: string) => void) {
+  return function nodeDeprecate<T extends Function>(fn: T, msg: string, code?: string): T {
+    if (typeof fn !== 'function') {
+      throw new TypeError('The "fn" argument must be of type function');
+    }
+    let warned = false;
+    function deprecated(this: unknown, ...args: unknown[]): unknown {
+      if (!warned) {
+        warned = true;
+        warn(code ? `[${code}] DeprecationWarning: ${msg}` : `DeprecationWarning: ${msg}`);
+      }
+      // An ES class throws `cannot be invoked without 'new'` when called, so a
+      // construct call has to stay a construct call. Forwarding `new.target`
+      // also keeps the instance's prototype right when the wrapper is
+      // subclassed.
+      if (new.target) {
+        return Reflect.construct(
+          fn as unknown as new (
+            ...a: unknown[]
+          ) => object,
+          args,
+          new.target
+        );
+      }
+      return (fn as unknown as (...a: unknown[]) => unknown).apply(this, args);
+    }
+    // Node keeps the wrapper substitutable for the original: same prototype
+    // (so `new deprecated()` still works for a deprecated constructor) and the
+    // original's own properties.
+    Object.setPrototypeOf(deprecated, Object.getPrototypeOf(fn));
+    if (fn.prototype) deprecated.prototype = fn.prototype;
+    return deprecated as unknown as T;
+  };
+}
+
 export interface NodeUtil {
   format(...args: unknown[]): string;
   formatWithOptions(opts: NodeInspectOptions, ...args: unknown[]): string;
   inspect: { (value: unknown, opts?: NodeInspectOptions): string; custom: symbol };
   inherits(ctor: Function, superCtor: Function): void;
   promisify: { (original: Function): Function; custom: symbol };
+  deprecate<T extends Function>(fn: T, msg: string, code?: string): T;
 }
 
 const utilInspect = nodeInspect as NodeUtil['inspect'];
@@ -236,10 +288,27 @@ utilInspect.custom = UTIL_INSPECT_CUSTOM;
 const utilPromisify = nodePromisify as NodeUtil['promisify'];
 utilPromisify.custom = UTIL_PROMISIFY_CUSTOM;
 
-export const nodeUtil: NodeUtil = {
-  format: nodeFormat,
-  formatWithOptions: nodeFormatWithOptions,
-  inspect: utilInspect,
-  inherits: nodeInherits,
-  promisify: utilPromisify,
-};
+/**
+ * Build the per-realm `util` module. `warn` receives one already-formatted
+ * `DeprecationWarning` line (no trailing newline) and should put it on THIS
+ * realm's stderr. Everything else on the module is stateless and shared.
+ */
+export function createNodeUtil(warn: (message: string) => void): NodeUtil {
+  return {
+    format: nodeFormat,
+    formatWithOptions: nodeFormatWithOptions,
+    inspect: utilInspect,
+    inherits: nodeInherits,
+    promisify: utilPromisify,
+    deprecate: makeDeprecate(warn),
+  };
+}
+
+/**
+ * Sink-less default, for a caller with no realm streams to write to (tests and
+ * the require-shim fallback). Deprecation warnings are dropped rather than
+ * misrouted to the kernel worker's console; the wrapped function still runs.
+ */
+export const nodeUtil: NodeUtil = createNodeUtil(() => {
+  /* no realm stderr to write to */
+});

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -33,7 +33,7 @@ export { nodeTty } from './helpers/node-tty.js';
 export type { NodeUrl } from './helpers/node-url.js';
 export { nodeUrl } from './helpers/node-url.js';
 export type { NodeInspectOptions, NodeUtil } from './helpers/node-util.js';
-export { nodeUtil } from './helpers/node-util.js';
+export { createNodeUtil, nodeUtil } from './helpers/node-util.js';
 export type { NodeZlib } from './helpers/node-zlib.js';
 export { nodeZlib } from './helpers/node-zlib.js';
 export type { ParsedFlags } from './helpers/parse-flags.js';

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -27,6 +27,7 @@ import {
   createColor,
   createNodeChildProcess,
   createNodeOs,
+  createNodeUtil,
 } from './js-realm-helpers.js';
 import { createSliccyAgentModule } from './realm-agent-module.js';
 import { createBrowserBridge, serializeRequestInit } from './realm-browser-bridge.js';
@@ -365,6 +366,9 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
     // Per-realm too: `os.tmpdir()`/`os.homedir()` read the SAME `init.env`
     // that `process.env` exposes, so one script cannot see two machines.
     nodeOsModule: createNodeOs(init.env),
+    // And `util`, so `util.deprecate`'s one-shot DeprecationWarning reaches
+    // THIS realm's stderr instead of the kernel worker's console.
+    nodeUtilModule: createNodeUtil((message) => writeStderr(`${message}\n`)),
   });
   const requireShim = moduleSystem.require;
 

--- a/packages/webapp/src/kernel/realm/realm-module-system.ts
+++ b/packages/webapp/src/kernel/realm/realm-module-system.ts
@@ -87,7 +87,9 @@ export async function loadModuleGraph(
   cwd: string,
   filename: string
 ): Promise<RealmModuleGraph> {
-  if (!mightNeedModuleGraph(code)) return { files: [], entryMap: {}, edges: {}, errors: {} };
+  if (!mightNeedModuleGraph(code)) {
+    return { files: [], entryMap: {}, edges: {}, edgeErrors: {}, errors: {} };
+  }
   return rpc.call<RealmModuleGraph>('module', 'buildGraph', [
     code,
     entryFromDir(filename, cwd),
@@ -201,12 +203,24 @@ export function createModuleSystem(opts: {
     return { hit: false };
   };
 
-  const requireFromEdges = (edgeMap: Record<string, string> | undefined, id: string): unknown => {
+  /**
+   * Resolve one specifier for the module at `fromPath` (`null` for the entry).
+   * Deferred failures are consulted only after the edge lookup misses, so a
+   * specifier the host DID resolve is never shadowed by a stale error entry.
+   */
+  const requireFromEdges = (
+    edgeMap: Record<string, string> | undefined,
+    id: string,
+    fromPath: string | null
+  ): unknown => {
     const builtin = resolveBuiltin(id);
     if (builtin.hit) return builtin.value;
     const targetPath = edgeMap?.[id];
     if (targetPath) return requireFile(targetPath);
-    if (id in graph.errors) throw new Error(graph.errors[id]);
+    // The host deferred this specifier's resolution failure to require time
+    // (Node semantics), so surface its exact message now.
+    const deferred = fromPath === null ? graph.errors[id] : graph.edgeErrors?.[fromPath]?.[id];
+    if (deferred) throw new Error(deferred);
     throw cannotFindModuleError(id);
   };
 
@@ -218,7 +232,7 @@ export function createModuleSystem(opts: {
     const moduleObj = { exports: {} as ModuleExports };
     // Register before evaluation so a require cycle sees the partial exports.
     cache.set(path, moduleObj);
-    const childRequire = (id: string): unknown => requireFromEdges(graph.edges[path], id);
+    const childRequire = (id: string): unknown => requireFromEdges(graph.edges[path], id, path);
     const moduleDir = dirnameOf(path);
     const compiled = new Function(
       'module',
@@ -248,7 +262,7 @@ export function createModuleSystem(opts: {
   }
 
   return {
-    require: (id: string): unknown => requireFromEdges(graph.entryMap, id),
+    require: (id: string): unknown => requireFromEdges(graph.entryMap, id, null),
   };
 }
 

--- a/packages/webapp/src/kernel/realm/realm-module-system.ts
+++ b/packages/webapp/src/kernel/realm/realm-module-system.ts
@@ -10,6 +10,7 @@ import {
   fmt,
   type NodeChildProcess,
   type NodeOs,
+  type NodeUtil,
   nodeAssert,
   nodeAssertStrict,
   nodeCrypto,
@@ -167,6 +168,12 @@ export function createModuleSystem(opts: {
    * unit (#2267). Omitted, the envless default keeps the pre-#2267 constants.
    */
   nodeOsModule?: NodeOs;
+  /**
+   * Per-realm `util` module — `util.deprecate`'s one-shot warning lands on
+   * THIS realm's stderr. Omitted, the sink-less default drops the warning
+   * rather than misrouting it to the kernel worker's console.
+   */
+  nodeUtilModule?: NodeUtil;
 }): { require: (id: string) => unknown } {
   const {
     graph,
@@ -178,6 +185,7 @@ export function createModuleSystem(opts: {
     shimmedPackages = {},
     nodeReadline,
     nodeOsModule = nodeOs,
+    nodeUtilModule = nodeUtil,
   } = opts;
   const sourceByPath = new Map(graph.files.map((f) => [f.path, f.cjsSource]));
   const kindByPath = new Map(graph.files.map((f) => [f.path, f.kind]));
@@ -188,14 +196,14 @@ export function createModuleSystem(opts: {
       return { hit: true, value: resolveSliccyModule(id, sliccyModules) };
     }
     const bareId = id.startsWith('node:') ? id.slice(5) : id;
-    const served = resolveServedBuiltin(
-      bareId,
+    const served = resolveServedBuiltin(bareId, {
       fsBridge,
       processShim,
       childProcess,
       nodeOsModule,
-      nodeReadline
-    );
+      nodeUtilModule,
+      nodeReadline,
+    });
     if (served.hit) return served;
     if (NODE_NATIVE_PACKAGES.has(bareId)) throw nativePackageError(id, bareId);
     if (NODE_BUILTINS_UNAVAILABLE.has(bareId)) throw unavailableBuiltinError(id, bareId);
@@ -280,12 +288,17 @@ export function createModuleSystem(opts: {
  */
 function resolveServedBuiltin(
   bareId: string,
-  fsBridge: unknown,
-  processShim: unknown,
-  childProcess: NodeChildProcess,
-  nodeOsModule: NodeOs,
-  nodeReadline?: NodeReadlineModule
+  served: {
+    fsBridge: unknown;
+    processShim: unknown;
+    childProcess: NodeChildProcess;
+    nodeOsModule: NodeOs;
+    nodeUtilModule: NodeUtil;
+    nodeReadline?: NodeReadlineModule;
+  }
 ): { hit: boolean; value?: unknown } {
+  const { fsBridge, processShim, childProcess, nodeOsModule, nodeUtilModule, nodeReadline } =
+    served;
   if (bareId === 'fs') return { hit: true, value: fsBridge };
   // Same object — fsBridge is already Promise-based; callback/sync APIs are not shimmed here.
   if (bareId === 'fs/promises') return { hit: true, value: fsBridge };
@@ -298,7 +311,7 @@ function resolveServedBuiltin(
   }
   if (bareId === 'assert') return { hit: true, value: nodeAssert };
   if (bareId === 'assert/strict') return { hit: true, value: nodeAssertStrict };
-  if (bareId === 'util') return { hit: true, value: nodeUtil };
+  if (bareId === 'util') return { hit: true, value: nodeUtilModule };
   if (bareId === 'events') return { hit: true, value: nodeEvents };
   if (bareId === 'os') return { hit: true, value: nodeOsModule };
   if (bareId === 'tty') return { hit: true, value: nodeTty };

--- a/packages/webapp/src/kernel/realm/realm-types.ts
+++ b/packages/webapp/src/kernel/realm/realm-types.ts
@@ -182,12 +182,16 @@ export type RealmRpcChannel =
  * structured-clone-safe shape (raw `source` is dropped; only `cjsSource` and
  * `kind` cross the port). `errors` carries the per-entry resolution failure
  * message (e.g. `Cannot find module 'x' (run: ipk install x)`) so the realm
- * shim can throw it at `require()` time without a CDN round-trip.
+ * shim can throw it at `require()` time without a CDN round-trip;
+ * `edgeErrors` carries the same, per requiring file, for a NESTED specifier
+ * that did not resolve — deferring it is what lets the optional-dependency
+ * `try { require('x') } catch {}` idiom work as it does in Node.
  */
 export interface RealmModuleGraph {
   files: { path: string; cjsSource: string; kind: string }[];
   entryMap: Record<string, string>;
   edges: Record<string, Record<string, string>>;
+  edgeErrors: Record<string, Record<string, string>>;
   errors: Record<string, string>;
   /**
    * The host-transpiled entry source — present only when the realm's entry

--- a/packages/webapp/src/shell/ipk/module-loader.ts
+++ b/packages/webapp/src/shell/ipk/module-loader.ts
@@ -68,6 +68,13 @@ export interface ModuleGraph {
    * preloaded graph.
    */
   edges: Record<string, Record<string, string>>;
+  /**
+   * Per-file DEFERRED resolution failures: for each module path, a map of the
+   * literal specifier to the resolver's error message. The realm shim throws
+   * it from `require()` — and only then — so a specifier a module never
+   * actually requires costs nothing, exactly as in Node.
+   */
+  edgeErrors: Record<string, Record<string, string>>;
 }
 
 /** ESM->CJS transpile hook (wired host-side in M5 via esbuild/tsc). */
@@ -206,8 +213,19 @@ async function toCjsSource(
 /**
  * Build the ordered CJS module graph for `entrySpecifiers`, recursively
  * following nested `require()` edges over `reader`. Cycles terminate (each
- * file is visited once); unresolvable bare requires propagate the resolver's
- * exact `Cannot find module '<x>' (run: ipk install <x>)` error.
+ * file is visited once).
+ *
+ * An unresolvable NESTED specifier is deferred, not fatal: the resolver's
+ * exact `Cannot find module '<x>' (run: ipk install <x>)` message is recorded
+ * in `edgeErrors[<requiring file>][<specifier>]` and thrown by the realm shim
+ * only if that module actually requires it. This is what Node does, and the
+ * optional-dependency idiom depends on it — `debug/src/node.js` requires
+ * `supports-color` inside a `try/catch`, so a hard failure here sank the whole
+ * graph (and with it every package that transitively uses `debug`) over a
+ * specifier the code is written to do without.
+ *
+ * An unresolvable ENTRY specifier still throws: `buildRealmModuleGraph`
+ * resolves entries one at a time and records each failure in `errors`.
  */
 export async function buildModuleGraph(options: BuildModuleGraphOptions): Promise<ModuleGraph> {
   const { entrySpecifiers, fromDir, reader, conditions, transpile } = options;
@@ -217,6 +235,7 @@ export async function buildModuleGraph(options: BuildModuleGraphOptions): Promis
   const built = new Map<string, LoadedModule>();
   const order: string[] = [];
   const edges: Record<string, Record<string, string>> = {};
+  const edgeErrors: Record<string, Record<string, string>> = {};
 
   async function visit(path: string, kind: ModuleKind): Promise<void> {
     if (built.has(path)) return;
@@ -226,14 +245,15 @@ export async function buildModuleGraph(options: BuildModuleGraphOptions): Promis
     built.set(path, { path, source, cjsSource, kind });
     const moduleDir = dirOf(path);
     const fileEdges: Record<string, string> = {};
+    const fileEdgeErrors: Record<string, string> = {};
     for (const { specifier, kind: edgeKind } of extractModuleSpecifiers(source)) {
       let result: ResolveResult;
       try {
         const edgeConditions = edgeKind === 'import' ? importConditions : requireConditions;
         result = await resolve(specifier, moduleDir, reader, { conditions: edgeConditions });
       } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        throw new Error(`While loading '${path}': ${reason}`);
+        fileEdgeErrors[specifier] = err instanceof Error ? err.message : String(err);
+        continue;
       }
       if (result.type === 'file') {
         fileEdges[specifier] = result.path;
@@ -241,6 +261,7 @@ export async function buildModuleGraph(options: BuildModuleGraphOptions): Promis
       }
     }
     edges[path] = fileEdges;
+    if (Object.keys(fileEdgeErrors).length > 0) edgeErrors[path] = fileEdgeErrors;
     order.push(path);
   }
 
@@ -261,6 +282,7 @@ export async function buildModuleGraph(options: BuildModuleGraphOptions): Promis
     }),
     entryMap,
     edges,
+    edgeErrors,
   };
 }
 
@@ -269,6 +291,7 @@ export interface RealmGraphResult {
   files: { path: string; cjsSource: string; kind: ModuleKind }[];
   entryMap: Record<string, string>;
   edges: Record<string, Record<string, string>>;
+  edgeErrors: Record<string, Record<string, string>>;
   errors: Record<string, string>;
   /**
    * The transpiled entry source when the entry used ESM / dynamic-import
@@ -307,6 +330,21 @@ function isGraphSpecifier(specifier: string): boolean {
 }
 
 /**
+ * Fold one per-entry-specifier `fromPath -> specifier -> value` map into the
+ * accumulator, merging rather than replacing each file's inner record: two
+ * entry specifiers can reach the same shared file and each may have walked a
+ * different subset of its edges.
+ */
+function mergePerFileMaps(
+  target: Record<string, Record<string, string>>,
+  source: Record<string, Record<string, string>>
+): void {
+  for (const [path, entries] of Object.entries(source)) {
+    target[path] = { ...(target[path] ?? {}), ...entries };
+  }
+}
+
+/**
  * Build the realm's complete CJS module graph from its ENTRY CODE: extract the
  * tagged `require`/`import` specifiers, resolve each in isolation (so a single
  * uninstalled entry surfaces as `errors[specifier]` without sinking the
@@ -325,6 +363,7 @@ export async function buildRealmModuleGraph(
   const order: string[] = [];
   const entryMap: Record<string, string> = {};
   const edges: Record<string, Record<string, string>> = {};
+  const edgeErrors: Record<string, Record<string, string>> = {};
   const errors: Record<string, string> = {};
 
   for (const { specifier, kind } of extractModuleSpecifiers(entryCode)) {
@@ -346,9 +385,8 @@ export async function buildRealmModuleGraph(
         }
       }
       Object.assign(entryMap, graph.entryMap);
-      for (const [path, fileEdges] of Object.entries(graph.edges)) {
-        edges[path] = { ...(edges[path] ?? {}), ...fileEdges };
-      }
+      mergePerFileMaps(edges, graph.edges);
+      mergePerFileMaps(edgeErrors, graph.edgeErrors);
     } catch (err) {
       errors[specifier] = err instanceof Error ? err.message : String(err);
     }
@@ -371,6 +409,7 @@ export async function buildRealmModuleGraph(
     }),
     entryMap,
     edges,
+    edgeErrors,
     errors,
   };
   if (entrySource !== undefined) result.entrySource = entrySource;

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -307,6 +307,65 @@ describe('NS3: util built-in is served by the nodeUtil shim', () => {
     expect(out.stderr).not.toContain('not available in the browser');
     expect(out.stdout.trim()).toBe("{ k: 'v' }");
   });
+
+  it('util.deprecate forwards to the wrapped function and warns once on stderr', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const util = require('util');
+       const doubled = util.deprecate((v) => v * 2, 'twice() is deprecated', 'DEP0001');
+       console.log(doubled(2), doubled(3), doubled(4));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('4 6 8');
+    expect(out.stderr).toContain('[DEP0001] DeprecationWarning: twice() is deprecated');
+    // Three calls, exactly one warning.
+    expect(out.stderr.match(/DeprecationWarning/g)?.length).toBe(1);
+  });
+
+  it('util.deprecate keeps a deprecated ES class constructible with new', async () => {
+    // A class body throws `cannot be invoked without 'new'` when merely called,
+    // so the wrapper has to forward a construct call as a construct call.
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const util = require('util');
+       class Legacy { constructor(v) { this.v = v; } label() { return 'v=' + this.v; } }
+       const Wrapped = util.deprecate(Legacy, 'Legacy is deprecated');
+       const inst = new Wrapped(7);
+       console.log(inst.label(), inst instanceof Wrapped, inst instanceof Legacy);
+       class Sub extends Wrapped { constructor() { super(9); } }
+       const sub = new Sub();
+       console.log(sub.label(), sub instanceof Sub, sub instanceof Legacy);`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain("cannot be invoked without 'new'");
+    expect(out.stdout.trim().split('\n')).toEqual(['v=7 true true', 'v=9 true true']);
+    // One warning for the construct call, one for the subclass's super().
+    expect(out.stderr.match(/DeprecationWarning/g)?.length).toBe(1);
+  });
+
+  it('util.deprecate is present at module scope, so a package calling it loads', async () => {
+    // `@eslint/eslintrc` (reached by `require('eslint/universal')`) calls
+    // `util.deprecate` while its module body evaluates: an absent `deprecate`
+    // is a TypeError at REQUIRE time, so the package never loads at all.
+    const ctx = makeCtx({
+      files: {
+        '/workspace/node_modules/deprecating/package.json': JSON.stringify({
+          name: 'deprecating',
+          version: '1.0.0',
+          main: 'index.js',
+        }),
+        '/workspace/node_modules/deprecating/index.js':
+          "const util = require('util');\n" +
+          "module.exports = util.deprecate(function legacy() { return 'ran'; }, 'legacy');",
+      },
+    });
+    const out = await runCode("console.log(require('deprecating')());", ctx);
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('is not a function');
+    expect(out.stdout.trim()).toBe('ran');
+  });
 });
 
 describe('NS3: crypto.createHash is served by the pure-JS hasher bridge', () => {

--- a/packages/webapp/tests/shell/ipk/module-loader.test.ts
+++ b/packages/webapp/tests/shell/ipk/module-loader.test.ts
@@ -173,13 +173,57 @@ describe('buildModuleGraph()', () => {
     expect(paths).toEqual(['/app/a.js', '/app/b.js']);
   });
 
-  it('propagates the resolver install-hint error for an unresolvable nested require', async () => {
+  it('defers an unresolvable nested require to edgeErrors instead of sinking the graph', async () => {
     const reader = makeReader({
       '/app/index.js': "module.exports = require('not-installed');",
     });
-    await expect(
-      buildModuleGraph({ entrySpecifiers: ['./index.js'], fromDir: '/app', reader })
-    ).rejects.toThrow("Cannot find module 'not-installed' (run: ipk install not-installed)");
+    const graph = await buildModuleGraph({
+      entrySpecifiers: ['./index.js'],
+      fromDir: '/app',
+      reader,
+    });
+    // The requiring file is still in the graph — only the edge failed.
+    expect(graph.files.map((f) => f.path)).toEqual(['/app/index.js']);
+    expect(graph.edges['/app/index.js']).toEqual({});
+    expect(graph.edgeErrors['/app/index.js']['not-installed']).toBe(
+      "Cannot find module 'not-installed' (run: ipk install not-installed)"
+    );
+  });
+
+  it('keeps a package usable when only an OPTIONAL nested require is missing', async () => {
+    // The `debug/src/node.js` shape: a `try { require('supports-color') }`
+    // whose absence is by design. A hard graph failure here took out every
+    // package that transitively depends on `debug` (eslint among them).
+    const reader = makeReader({
+      '/app/node_modules/withoptional/package.json': JSON.stringify({ main: 'index.js' }),
+      '/app/node_modules/withoptional/index.js': `
+        let color = null;
+        try { color = require('supports-color'); } catch {}
+        module.exports = { color, ok: true };
+      `,
+    });
+    const graph = await buildModuleGraph({
+      entrySpecifiers: ['withoptional'],
+      fromDir: '/app',
+      reader,
+    });
+    expect(graph.entryMap.withoptional).toBe('/app/node_modules/withoptional/index.js');
+    expect(graph.edgeErrors['/app/node_modules/withoptional/index.js']['supports-color']).toContain(
+      "Cannot find module 'supports-color'"
+    );
+  });
+
+  it('records no edgeErrors entry for a file whose specifiers all resolve', async () => {
+    const reader = makeReader({
+      '/app/index.js': "module.exports = require('./dep.js');",
+      '/app/dep.js': 'module.exports = 1;',
+    });
+    const graph = await buildModuleGraph({
+      entrySpecifiers: ['./index.js'],
+      fromDir: '/app',
+      reader,
+    });
+    expect(graph.edgeErrors).toEqual({});
   });
 
   it('throws a clear error for an ESM module when no transpile hook is given', async () => {

--- a/packages/webapp/tests/shell/ipk/optional-dependency-require-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/optional-dependency-require-e2e.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Real-shell e2e for DEFERRED nested-require resolution failures.
+ *
+ * Node resolves `require()` when the call executes, so the optional-dependency
+ * idiom — `try { require('supports-color') } catch {}` — costs nothing when the
+ * package is absent. SLICC resolves the whole graph up front on the host, and
+ * that walk used to THROW on the first unresolvable nested specifier, sinking
+ * every module in the graph. Real packages depend on the Node behavior:
+ * `debug/src/node.js` has exactly that try/catch, so `require('eslint')` failed
+ * with `Cannot find module 'supports-color'` — a package eslint never needs.
+ *
+ * These run through the production `node <script.js>` path over a real
+ * `fake-indexeddb` VirtualFS, so they cover the host graph walker, the wire
+ * shape, and the realm require shim together.
+ */
+import 'fake-indexeddb/auto';
+import { describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
+
+let dbCounter = 0;
+
+async function newShell() {
+  const fs = await VirtualFS.create({ dbName: `test-optional-dep-${dbCounter++}`, wipe: true });
+  await fs.mkdir('/work', { recursive: true });
+  const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });
+  return { shell, fs };
+}
+
+async function seed(
+  fs: Awaited<ReturnType<typeof newShell>>['fs'],
+  files: Record<string, string>
+): Promise<void> {
+  for (const [path, content] of Object.entries(files)) {
+    const dir = path.slice(0, path.lastIndexOf('/'));
+    if (dir) await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path, content);
+  }
+}
+
+describe('optional-dependency require e2e: an unresolvable nested specifier is deferred, not fatal', () => {
+  it('loads a package whose optional require is caught, and reports the dependency absent', async () => {
+    const { shell, fs } = await newShell();
+    // The `debug/src/node.js` shape, reduced to its essentials.
+    await seed(fs, {
+      '/work/node_modules/loggy/package.json': JSON.stringify({ main: 'index.js' }),
+      '/work/node_modules/loggy/index.js': `
+        let color = null;
+        try { color = require('supports-color'); } catch (e) { color = null; }
+        module.exports = { color, log: (m) => 'loggy:' + m };
+      `,
+      '/work/main.js': `
+        const loggy = require('loggy');
+        console.log(loggy.log('hi'));
+        console.log('color=' + loggy.color);
+      `,
+    });
+    const run = await shell.executeCommand('node main.js');
+    expect(run.stderr).not.toContain('Cannot find module');
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('loggy:hi');
+    expect(run.stdout).toContain('color=null');
+    await fs.dispose();
+  });
+
+  it('still throws the install-hint error when the missing specifier IS required', async () => {
+    const { shell, fs } = await newShell();
+    await seed(fs, {
+      '/work/node_modules/needy/package.json': JSON.stringify({ main: 'index.js' }),
+      '/work/node_modules/needy/index.js': "module.exports = require('absent-pkg');",
+      '/work/main.js': "require('needy');",
+    });
+    const run = await shell.executeCommand('node main.js');
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("Cannot find module 'absent-pkg'");
+    expect(run.stderr).toContain('ipk install absent-pkg');
+    await fs.dispose();
+  });
+
+  it('keeps siblings of a failed edge loadable from the same file', async () => {
+    const { shell, fs } = await newShell();
+    await seed(fs, {
+      '/work/node_modules/mixed/package.json': JSON.stringify({ main: 'index.js' }),
+      '/work/node_modules/mixed/index.js': `
+        const present = require('./present.js');
+        let absent = 'none';
+        try { absent = require('nope'); } catch (e) { absent = 'caught'; }
+        module.exports = { present, absent };
+      `,
+      '/work/node_modules/mixed/present.js': "module.exports = 'here';",
+      '/work/main.js': "console.log(JSON.stringify(require('mixed')));",
+    });
+    const run = await shell.executeCommand('node main.js');
+    expect(run.exitCode).toBe(0);
+    expect(JSON.parse(run.stdout.trim())).toEqual({ present: 'here', absent: 'caught' });
+    await fs.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Two independent JS-realm `require()` gaps, each of which makes a real, correctly
installed npm package fail to load at all.

1. A nested `require()` the host cannot resolve sank the **entire** module graph
   instead of failing at require time. Before: `require('eslint/universal')` threw
   `Cannot find module 'supports-color'` from a file the caller never named. Now:
   the failure is recorded and thrown only if that specifier is actually required.
2. `util.deprecate` did not exist. Before: `TypeError: util.deprecate is not a
   function` while the package's module body evaluated. Now: `util` is a per-realm
   module and `deprecate` works, warning once on the calling realm's stderr.

## Why

Found while getting real ESLint to run in the shell (the `biome`-shim pattern).
Both are require-path bugs, not eslint-specific, and both are hit by ordinary
packages.

**Repro 1** — the optional-dependency idiom:

1. `ipk add -g eslint`
2. `node -e "require('eslint/universal')"`

Expected: the module loads.
Actual:

```
While loading '/shared/lib/node_modules/debug/src/node.js': Cannot find module 'supports-color'
```

`debug/src/node.js` wraps that require in `try {} catch {}`. It is the standard
optional-dependency idiom and Node only fails it when the line RUNS, inside the
caller's `try`. But `buildModuleGraph` walks the whole closure ahead of execution
and threw on the first unresolvable edge, so the caller got an error about a
package it does not depend on — and no `ipk add` fixes it, because the package is
genuinely optional.

**Repro 2** — after fix 1 lands:

1. `node -e "require('eslint/universal')"`

Expected: the module loads.
Actual: `TypeError: util.deprecate is not a function` (`@eslint/eslintrc` calls
`util.deprecate` at module scope, so this is a hard require-time failure).

## Approach / Implementation notes

**Deferred edge errors.** `ModuleGraph.edgeErrors` (`fromPath -> specifier ->
message`) is threaded through `RealmGraphResult` and `RealmModuleGraph`.
`buildModuleGraph.visit()` records a failed nested resolve and keeps walking;
`requireFromEdges(edgeMap, id, fromPath)` throws the recorded message on demand.

Ordering is the subtle part: `edgeErrors` is consulted **after** the edge lookup
misses. Checking it first would let a specifier one file failed to resolve shadow
another file's successfully resolved edge for the same name. Entry-point failures
still throw during the build — those are the specifiers the caller named, and they
already land in `errors[specifier]` per entry without sinking siblings.

**`util` becomes per-realm.** `deprecate`'s one-shot `DeprecationWarning` has to
reach the CALLING realm's stderr. A shared module-scope shim cannot do that: a
bare `console.error` there prints to the kernel worker, where no user sees it. So
`util` joins `os` and `readline` as a per-realm module — `createNodeUtil(warn)`
takes the sink, `js-realm-shared.ts` passes the realm's `writeStderr`, and the
sink-less default drops the warning rather than misrouting it. The wrapper
preserves the target's prototype, so a deprecated CONSTRUCTOR still constructs.

`resolveServedBuiltin` took its served objects as six positional parameters;
a seventh made the call unreadable, so it now takes one options object. No
behavior change.

## Cross-cutting impact

- **Floats exercised**: worker JS realm — the single path used by CLI, extension
  (hosted leader tab), Electron and Sliccstart alike. There is no per-float realm
  to keep in sync since the thin-bridge strip.
- **Other callers of the changed contract**: `requireFromEdges` gained a third
  parameter; both call sites (`childRequire` and the entry `require`) are updated
  in the same file, and it is not exported. `resolveServedBuiltin` is module-private.
  `RealmModuleGraph.edgeErrors` is optional at the read site (`graph.edgeErrors?.`),
  so a graph produced by an older host still resolves — it just reports
  `cannotFindModuleError` as before.
- **Error shape**: strictly narrower. A specifier that used to fail at build time
  with someone else's message now either resolves or fails at require time with
  the same message. Nothing that used to succeed now fails.
- No persisted state, no migration, no new dependency, no UI.

## Test plan

- [x] `npm run verify` — all 8 checks pass
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck` (also run on the intermediate commit, so the branch
      bisects cleanly)
- [x] `npm run test` — 20366 passing, 0 failures
- [x] `npm run test:coverage`
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size`
- [x] New behavior covered by unit tests:
      `npx vitest run packages/webapp/tests/shell/ipk/module-loader.test.ts` (16),
      `.../optional-dependency-require-e2e.test.ts` (3, over
      `AlmostBashShellHeadless` + fake-indexeddb),
      `packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts` (44)
- [x] Manual smoke against a **live harness** driven through the `slicc` CLI
      (isolated ports; production `:5710`/`:9222` untouched): `ipk add -g eslint`
      then `require('eslint/universal')` returns `Linter`, and `Linter.verify`
      produces real diagnostics. Both symptoms above were observed there before
      the fix and gone after.

**Pre-existing failures**: none.

## Documentation

- [x] `docs/pitfalls.md` — new note under the `require()` guard-rail section on
      why an unresolvable nested require must be a require-time error
- [x] `docs/node-compat-shims.md` — `util.deprecate` moved to available, with the
      per-realm rationale

## Risk & rollback

Blast radius is every `require()` in the JS realm, which is why both changes are
additive: a new optional map that only ever converts a build-time throw into a
require-time throw, and a new `util` member. Reverts cleanly as one PR; no
persisted state to undo.

CI cannot cover the thing that actually motivated this — a real npm package
graph resolved in a real realm — so the live-harness smoke above is the load-
bearing check. A reviewer can reproduce it with `ipk add -g eslint` and
`node -e "require('eslint/universal')"` in any running SLICC.

## Checklist

- [x] Commits are focused and package-local (one per fix)
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public contract changes are intentional and reflected in docs
- [x] Checked the follower/leader/worker paths: the JS realm is one shared
      implementation, so there is no float-specific wiring to mirror
