### PR TITLE
fix(webapp): recover from a torn OPFS metadata sidecar instead of failing to boot forever

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -654,6 +654,47 @@ uses real native Files and writes; its hooks only control timing. A once-overwri
 run recovers to `after!`; overwriting every snapshot still fails after three
 attempts. Unit guards live in `tests/fs/zenfs-opfs-read-retry.test.ts` in the webapp.
 
+## A Torn `/.metadata.json` Must Be Reseeded, Not Honored
+
+**Files**: `packages/webapp/src/fs/virtual-fs.ts`
+(`seedOpfsMetadataSidecarIfMissing`, `isUsableMetadataSidecar`),
+`packages/webapp/src/fs/sidecar-repair.ts`.
+
+`createWritable()` **truncates before it writes**, so a page reload landing
+inside a sidecar flush leaves a short file — a JSON document cut mid-string.
+The seed step used to check only whether the sidecar EXISTED, and a truncated
+file exists, so it was kept; ZenFS' `WebAccessFS._loadMetadata` then threw
+`SyntaxError: Unterminated string in JSON` on every later mount and the kernel
+worker failed to boot **forever**, with no user-reachable recovery:
+
+```text
+[main] Fatal error Error: Kernel worker boot failed: Unterminated string in JSON at position 47
+[kernel-worker] boot failed SyntaxError: Unterminated string in JSON at position 47
+```
+
+`repairOpfsMetadataSidecar` does not cover this class either — it needs a
+parseable document to repair and returns `null` for anything else, which the
+on-throw retry reads as "unrepairable" and rethrows.
+
+The rule: a sidecar whose bytes PARSE into something ZenFS cannot consume is
+treated as ABSENT and reseeded with an empty index. That is safe because the
+sidecar carries only
+recorded mode/mtime — never file CONTENT, which lives in separate OPFS entries —
+so ZenFS rebuilds inodes from the real tree and the files are still there. A
+parseable sidecar is still left untouched, so persisted metadata survives a
+normal reload.
+
+**A failed READ is not corruption.** This decision destroys data when it is
+wrong, so only a parse or schema failure may reach it. `getFile()` hands out a
+snapshot that a concurrent native overwrite invalidates (the `NotReadableError`
+race above), and a blanket `catch` around the read would report that as "torn"
+and reseed over an intact index. So the read retries a FRESH snapshot up to
+three times, every other error is rethrown, and the validate-then-reseed pair
+runs under `withWriteLock` so it cannot observe another context's flush
+mid-write. A boot that fails loudly is recoverable on the next reload; a reseed
+over good metadata is not. Regression:
+`tests/fs/virtual-fs-torn-sidecar.test.ts`.
+
 ## OPFS Is Evictable: Chrome Deletes It To Free Disk Space
 
 **Files**: `packages/webapp/src/ui/boot/setup-storage-persistence.ts`,

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -418,9 +418,15 @@ export class VirtualFS {
     // `resolveMountConfig()` so the file exists. The shape mirrors
     // `Index.toJSON()` in `@zenfs/core/internal/file_index.js`
     // (`{ version, maxSize, entries }`) so ZenFS can overwrite it
-    // byte-compatibly. Only seed when absent — an existing sidecar (the
-    // reload case) is left untouched so persisted metadata survives.
-    await VirtualFS.seedOpfsMetadataSidecarIfMissing(handle);
+    // byte-compatibly. Only seed when absent or unreadable by ZenFS — an
+    // existing valid sidecar (the reload case) is left untouched so persisted
+    // metadata survives.
+    //
+    // Under the write lock, because this both READS the sidecar and may
+    // replace it: another context's `writeOpfsMetadataSidecar` flush holds the
+    // same lock, so validation cannot race a half-written document and mistake
+    // it for a torn one.
+    await vfs.withWriteLock(() => VirtualFS.seedOpfsMetadataSidecarIfMissing(handle));
     const [zenfs, { WebAccess }] = await Promise.all([import('@zenfs/core'), import('@zenfs/dom')]);
     await VirtualFS.ensureRootMount(zenfs);
     const mountPoint = `/__opfs__/${vfs.dbName}`;
@@ -737,8 +743,9 @@ export class VirtualFS {
 
   /**
    * Seed `/.metadata.json` in the OPFS subdir handle with an empty-but-valid
-   * ZenFS `Index.toJSON()` payload if the file is missing. No-op when the
-   * sidecar already exists (reload case — persisted metadata must survive).
+   * ZenFS `Index.toJSON()` payload if the file is missing OR UNUSABLE. A
+   * readable, parseable sidecar (the reload case) is left untouched so
+   * persisted metadata survives.
    *
    * The shape `{ version: 1, maxSize: 0xffffffff, entries: {} }` matches
    * `Index.toJSON()` in `@zenfs/core/internal/file_index.js`; `maxSize`
@@ -748,14 +755,37 @@ export class VirtualFS {
    * created on-demand by `WebAccessFS.stat`'s ENOENT recovery path
    * (lines ~84-110 of `@zenfs/dom/access.js`), same as the no-metadata
    * boot path.
+   *
+   * Reseeding an unparseable sidecar is what makes a TORN WRITE survivable.
+   * `createWritable()` truncates before it writes, so a reload landing inside
+   * a sidecar flush leaves a short file — an unterminated JSON document. That
+   * file is not absent, so an existence check alone kept it, `_loadMetadata`
+   * threw `SyntaxError` on every subsequent mount, and the kernel worker
+   * failed to boot FOREVER with no user-reachable recovery
+   * (`Kernel worker boot failed: Unterminated string in JSON`).
+   * `repairOpfsMetadataSidecar` cannot help here either: it needs a parseable
+   * document to repair and returns `null` for this class. Dropping the
+   * sidecar costs only recorded mode/mtime, never file CONTENT — the files
+   * are separate OPFS entries and ZenFS rebuilds inodes from the real tree.
+   *
+   * Only PARSE and SCHEMA failures reseed. A read that fails propagates, so an
+   * invalidated snapshot or a transient I/O error can never be mistaken for
+   * corruption and cost a user their recorded modes; the caller holds the
+   * write lock so a concurrent flush cannot be observed mid-write either.
    */
   private static async seedOpfsMetadataSidecarIfMissing(
     handle: FileSystemDirectoryHandle
   ): Promise<void> {
     const SIDECAR_NAME = '.metadata.json';
     try {
-      await handle.getFileHandle(SIDECAR_NAME);
-      return;
+      const existing = await handle.getFileHandle(SIDECAR_NAME);
+      // A read failure propagates: it means the bytes are unknown, and
+      // reseeding on unknown bytes would discard metadata that is very likely
+      // intact. Only a document ZenFS demonstrably cannot consume is replaced.
+      if (VirtualFS.isUsableMetadataDocument(await VirtualFS.readSidecarText(existing))) return;
+      console.warn(
+        '[virtual-fs] metadata sidecar is unparseable (torn write?); reseeding an empty index'
+      );
     } catch (err) {
       const name = (err as { name?: string } | null)?.name;
       if (name !== 'NotFoundError') throw err;
@@ -769,6 +799,54 @@ export class VirtualFS {
     });
     await writable.write(initial);
     await writable.close();
+  }
+
+  /**
+   * Read the sidecar's bytes, reacquiring the `File` snapshot on a native
+   * `NotReadableError`. `getFile()` returns a SNAPSHOT, and a concurrent
+   * native overwrite invalidates it even though a fresh snapshot reads fine —
+   * the same race the `@zenfs/dom` read patch retries (#2924), matched here at
+   * three attempts. Retrying the same `File` is futile; only a fresh one can
+   * succeed.
+   *
+   * Anything other than `NotReadableError`, and a snapshot still unreadable
+   * after three tries, is thrown. That distinction is load-bearing: this
+   * function's answer decides whether the sidecar gets REPLACED, so "I could
+   * not read it" must never be reported as "it is corrupt".
+   */
+  private static async readSidecarText(fileHandle: FileSystemFileHandle): Promise<string> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await (await fileHandle.getFile()).text();
+      } catch (err) {
+        if ((err as { name?: string } | null)?.name !== 'NotReadableError') throw err;
+        lastErr = err;
+      }
+    }
+    throw lastErr;
+  }
+
+  /**
+   * True when the given bytes are a document `WebAccessFS._loadMetadata` can
+   * consume: parseable JSON carrying an `entries` object. An empty string, a
+   * truncated one, or a document without `entries` is unusable and must be
+   * reseeded rather than kept.
+   *
+   * Deliberately a pure function of the bytes, with no I/O and no catch around
+   * a read: only a PARSE or SCHEMA failure may answer `false`, because `false`
+   * means "throw this sidecar away".
+   */
+  private static isUsableMetadataDocument(text: string): boolean {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return false;
+    }
+    if (!parsed || typeof parsed !== 'object') return false;
+    const entries = (parsed as { entries?: unknown }).entries;
+    return !!entries && typeof entries === 'object';
   }
 
   /**

--- a/packages/webapp/tests/fs/virtual-fs-torn-sidecar.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-torn-sidecar.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression test: a TORN `/.metadata.json` must not brick every later boot.
+ *
+ * `createWritable()` truncates before it writes, so a reload landing inside a
+ * sidecar flush leaves a short, unterminated JSON document behind. That file
+ * is not absent, so an existence-only seed check kept it and ZenFS'
+ * `WebAccessFS._loadMetadata` threw `SyntaxError: Unterminated string in JSON`
+ * on EVERY subsequent mount — the kernel worker never booted again and there
+ * was no user-reachable recovery. `repairOpfsMetadataSidecar` cannot cover
+ * this class either: it needs a parseable document and returns `null`
+ * otherwise.
+ *
+ * The sidecar carries only recorded mode/mtime, never file content, so
+ * reseeding an empty index is the recoverable outcome: the mount succeeds and
+ * the files already in the OPFS tree are still readable.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMutableDirectoryHandle, type MutableDirectoryHandle } from './fsa-test-helpers.js';
+
+const SIDECAR = '.metadata.json';
+
+let opfs: MutableDirectoryHandle;
+
+function installOpfsStub(handle: FileSystemDirectoryHandle): void {
+  vi.stubGlobal('navigator', {
+    storage: {
+      getDirectory: async (): Promise<FileSystemDirectoryHandle> => handle,
+    },
+  });
+}
+
+/** The sidecar lives in the per-`dbName` OPFS subdirectory, not the root. */
+async function sidecarHandle(dbName: string, create = false): Promise<FileSystemFileHandle> {
+  const dir = await opfs.handle.getDirectoryHandle(dbName);
+  return dir.getFileHandle(SIDECAR, { create });
+}
+
+async function readSidecar(dbName: string): Promise<string> {
+  return (await (await sidecarHandle(dbName)).getFile()).text();
+}
+
+async function writeSidecar(dbName: string, text: string): Promise<void> {
+  const writable = await (await sidecarHandle(dbName, true)).createWritable();
+  await writable.write(text);
+  await writable.close();
+}
+
+/**
+ * Make the sidecar's `getFile()` snapshot fail. `budget` counts how many reads
+ * throw before behavior returns to normal; `Number.POSITIVE_INFINITY` never
+ * recovers. Returns the number of reads actually attempted, which is what
+ * distinguishes "retried a fresh snapshot" from "retried the same one".
+ */
+function failSidecarReads(
+  budget: number,
+  errName = 'NotReadableError'
+): { attempts: () => number } {
+  let attempts = 0;
+  const wrapDir = (dir: FileSystemDirectoryHandle): FileSystemDirectoryHandle =>
+    ({
+      ...dir,
+      kind: 'directory',
+      name: dir.name,
+      getDirectoryHandle: (...a: Parameters<FileSystemDirectoryHandle['getDirectoryHandle']>) =>
+        dir.getDirectoryHandle(...a),
+      removeEntry: (...a: Parameters<FileSystemDirectoryHandle['removeEntry']>) =>
+        dir.removeEntry(...a),
+      keys: () => dir.keys(),
+      values: () => dir.values(),
+      entries: () => dir.entries(),
+      async getFileHandle(
+        name: string,
+        opts?: FileSystemGetFileOptions
+      ): Promise<FileSystemFileHandle> {
+        const real = await dir.getFileHandle(name, opts);
+        if (name !== SIDECAR) return real;
+        return {
+          ...real,
+          kind: 'file',
+          name: real.name,
+          createWritable: (...a: Parameters<FileSystemFileHandle['createWritable']>) =>
+            real.createWritable(...a),
+          async getFile(): Promise<File> {
+            attempts += 1;
+            if (attempts <= budget) throw new DOMException('snapshot invalidated', errName);
+            return real.getFile();
+          },
+        } as unknown as FileSystemFileHandle;
+      },
+    }) as unknown as FileSystemDirectoryHandle;
+
+  vi.stubGlobal('navigator', {
+    storage: {
+      getDirectory: async (): Promise<FileSystemDirectoryHandle> =>
+        ({
+          ...opfs.handle,
+          kind: 'directory',
+          name: opfs.handle.name,
+          getFileHandle: (...a: Parameters<FileSystemDirectoryHandle['getFileHandle']>) =>
+            opfs.handle.getFileHandle(...a),
+          removeEntry: (...a: Parameters<FileSystemDirectoryHandle['removeEntry']>) =>
+            opfs.handle.removeEntry(...a),
+          async getDirectoryHandle(
+            name: string,
+            opts?: FileSystemGetDirectoryOptions
+          ): Promise<FileSystemDirectoryHandle> {
+            return wrapDir(await opfs.handle.getDirectoryHandle(name, opts));
+          },
+        }) as unknown as FileSystemDirectoryHandle,
+    },
+  });
+  return { attempts: () => attempts };
+}
+
+describe('VirtualFS — unparseable OPFS metadata sidecar is reseeded, not honored', () => {
+  beforeEach(() => {
+    opfs = createMutableDirectoryHandle({});
+    installOpfsStub(opfs.handle);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('mounts after a torn write and keeps the file content that was already on disk', async () => {
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const DB = 'slicc-fs-torn-sidecar';
+
+    const first = await VirtualFS.create({ dbName: DB, backend: 'opfs', wipe: true });
+    await first.writeFile('/survivor.txt', 'still here');
+    await first.dispose();
+
+    // Truncate the sidecar exactly the way an interrupted flush does: a
+    // prefix of a valid document, cut mid-string.
+    const intact = await readSidecar(DB);
+    expect(intact.length).toBeGreaterThan(47);
+    await writeSidecar(DB, intact.slice(0, 47));
+
+    const second = await VirtualFS.create({ dbName: DB, backend: 'opfs' });
+    expect(await second.readTextFile('/survivor.txt')).toBe('still here');
+    // The reseeded sidecar is a document ZenFS can load again.
+    const reseeded: unknown = JSON.parse(await readSidecar(DB));
+    expect((reseeded as { entries?: unknown }).entries).toBeTypeOf('object');
+    await second.dispose();
+  });
+
+  it('reseeds an empty sidecar file', async () => {
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const DB = 'slicc-fs-empty-sidecar';
+    const first = await VirtualFS.create({ dbName: DB, backend: 'opfs', wipe: true });
+    await first.dispose();
+    await writeSidecar(DB, '');
+
+    const second = await VirtualFS.create({ dbName: DB, backend: 'opfs' });
+    await second.writeFile('/after.txt', 'ok');
+    expect(await second.readTextFile('/after.txt')).toBe('ok');
+    await second.dispose();
+  });
+
+  it('retries an invalidated snapshot instead of reseeding over intact metadata', async () => {
+    // `getFile()` hands out a SNAPSHOT, and a concurrent native overwrite
+    // invalidates it even though a fresh one reads fine (#2924). Treating that
+    // as corruption would throw away a perfectly good sidecar.
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const DB = 'slicc-fs-invalidated-snapshot';
+    const first = await VirtualFS.create({ dbName: DB, backend: 'opfs', wipe: true });
+    await first.writeFile('/kept.txt', 'kept');
+    await first.dispose();
+    const before = await readSidecar(DB);
+
+    const reads = failSidecarReads(1);
+    const second = await VirtualFS.create({ dbName: DB, backend: 'opfs' });
+    // A second attempt happened, and it reacquired the snapshot rather than
+    // reusing the invalidated one.
+    expect(reads.attempts()).toBeGreaterThanOrEqual(2);
+    expect(await readSidecar(DB)).toBe(before);
+    await second.dispose();
+  });
+
+  it('propagates a persistent read failure rather than reseeding on unknown bytes', async () => {
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const DB = 'slicc-fs-unreadable-sidecar';
+    const first = await VirtualFS.create({ dbName: DB, backend: 'opfs', wipe: true });
+    await first.writeFile('/kept.txt', 'kept');
+    await first.dispose();
+    const before = await readSidecar(DB);
+
+    failSidecarReads(Number.POSITIVE_INFINITY);
+    await expect(VirtualFS.create({ dbName: DB, backend: 'opfs' })).rejects.toThrow();
+    // The sidecar is intact: a boot that fails loudly can be retried, whereas
+    // a reseed would have destroyed the recorded metadata for good.
+    installOpfsStub(opfs.handle);
+    expect(await readSidecar(DB)).toBe(before);
+    const third = await VirtualFS.create({ dbName: DB, backend: 'opfs' });
+    expect(await third.readTextFile('/kept.txt')).toBe('kept');
+    await third.dispose();
+  });
+
+  it('propagates a non-NotReadableError read failure without retrying', async () => {
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const DB = 'slicc-fs-denied-sidecar';
+    const first = await VirtualFS.create({ dbName: DB, backend: 'opfs', wipe: true });
+    await first.dispose();
+
+    const reads = failSidecarReads(Number.POSITIVE_INFINITY, 'NotAllowedError');
+    await expect(VirtualFS.create({ dbName: DB, backend: 'opfs' })).rejects.toThrow();
+    expect(reads.attempts()).toBe(1);
+  });
+
+  it('leaves a parseable sidecar untouched so persisted metadata survives', async () => {
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const DB = 'slicc-fs-intact-sidecar';
+    const first = await VirtualFS.create({ dbName: DB, backend: 'opfs', wipe: true });
+    await first.writeFile('/kept.txt', 'kept');
+    await first.dispose();
+
+    const before = await readSidecar(DB);
+    const second = await VirtualFS.create({ dbName: DB, backend: 'opfs' });
+    expect(await readSidecar(DB)).toBe(before);
+    await second.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

A page reload landing inside an OPFS metadata-sidecar flush leaves the sidecar
truncated, and SLICC then refused to boot **forever**. Before: every load failed
with `Kernel worker boot failed: Unterminated string in JSON at position 47`, with
no user-reachable recovery. Now: an unparseable sidecar is treated as absent and
reseeded, and the instance comes back on the next reload.

## Why

Hit on a live harness. `createWritable()` **truncates before it writes**, so an
interrupted flush is a JSON document cut mid-string:

```
$ cat /slicc-fs/.metadata.json          # exactly 47 bytes
{"version":1,"maxSize":4294967295,"entries":{"/
```

**Repro**

1. Reload the tab while a sidecar flush is in flight (or truncate
   `<dbName>/.metadata.json` in OPFS to a prefix of valid JSON).
2. Reload again.

Expected: SLICC boots; at worst recorded mode/mtime is lost.
Actual:

```
[main] Fatal error Error: Kernel worker boot failed: Unterminated string in JSON at position 47
[kernel-worker] boot failed SyntaxError: Unterminated string in JSON at position 47
```

Every reload after that, permanently — the terminal never opens, so there is no
shell from which to delete the file.

Two guards both declined to help:

- `seedOpfsMetadataSidecarIfMissing` checked only whether the sidecar **existed**,
  and a truncated file exists, so it was kept.
- `repairOpfsMetadataSidecar` needs a parseable document to repair and returns
  `null` for anything else, which the on-throw retry reads as "unrepairable" and
  rethrows.

## Approach / Implementation notes

`seedOpfsMetadataSidecarIfMissing` now reseeds when the sidecar is missing **or
unusable**. `isUsableMetadataSidecar` is deliberately strict but cheap: the read
must succeed, parse as JSON, and carry an `entries` object.

Discarding the sidecar is safe, and that is the whole reason this is the right
fix rather than a repair: the sidecar holds only recorded mode/mtime. File
**content** lives in separate OPFS entries, so ZenFS rebuilds inodes from the
real tree and every file is still there. The cost of a false positive is losing
recorded modes; the cost of a false negative is a permanently unbootable install.

A parseable sidecar is still left untouched, so persisted metadata survives a
normal reload — this does not reset metadata on every boot.

## Cross-cutting impact

- **Floats exercised**: every float with an OPFS-backed `slicc-fs` — CLI, hosted
  leader tab (extension mode), Electron, Sliccstart. The seed runs pre-boot in
  `VirtualFS`, one shared path.
- **Persisted state**: this deliberately DISCARDS a persisted document, but only
  one already unreadable by its consumer. No schema change, no migration.
- **Other callers**: `seedOpfsMetadataSidecarIfMissing` is called only from the
  pre-mount path; `isUsableMetadataSidecar` is new and private. The existing
  `repairOpfsMetadataSidecar` path is untouched and still handles the
  parseable-but-poisoned class it was written for.
- No UI, no new dependency, no bundle impact.

## Test plan

- [x] `npm run verify` — all 8 checks pass
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 20366 passing, 0 failures
- [x] `npm run test:coverage`
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] New behavior covered by unit tests:
      `npx vitest run packages/webapp/tests/fs/virtual-fs-torn-sidecar.test.ts`
      (3: a torn write is reseeded, an empty file is reseeded, an intact sidecar
      is left byte-identical). Note the sidecar lives in the per-`dbName`
      subdirectory, not the OPFS root — a test that writes to the root passes
      vacuously.
- [x] Manual: the live harness that had actually wedged this way recovered on the
      next reload after the fix, with `/workspace` and the ipk tree intact
      (`ipk list -g` worked again). Isolated ports; production `:5710`/`:9222`
      untouched.

**Pre-existing failures**: none.

## Documentation

- [x] `docs/pitfalls.md` — new section "A Torn `/.metadata.json` Must Be Reseeded,
      Not Honored", next to the other OPFS notes

## Risk & rollback

The risk is reseeding a sidecar that was actually fine. `isUsableMetadataSidecar`
only ever accepts more than the old existence check rejected — it cannot reseed a
document ZenFS could have loaded, since ZenFS also requires parseable JSON with
`entries`. Worst case on a false positive is losing recorded mode/mtime, which is
what a fresh install starts with anyway.

Reverts cleanly. Reverting restores the permanent-wedge behavior, so the recovery
path disappears with it.

CI cannot produce a genuinely interrupted `createWritable()`; the unit tests
write the torn bytes directly, and the live-harness recovery above is the
end-to-end evidence.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] No public API / tool / shell-command change
- [x] Checked the leader/follower/worker paths: the seed is one shared pre-mount
      step, so there is no float-specific wiring to mirror
