### PR TITLE
feat(vfs-root): add an eslint skill that runs real ESLint in the JS realm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23042,6 +23042,7 @@
         "@types/w3c-web-serial": "1.0.8",
         "fake-indexeddb": "6.2.5",
         "jsdom": "30.0.1",
+        "minimatch": "10.2.6",
         "puppeteer-core": "25.9.0",
         "v86": "0.5.451"
       }

--- a/packages/vfs-root/workspace/skills/eslint/SKILL.md
+++ b/packages/vfs-root/workspace/skills/eslint/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: eslint
+description: |
+  Use this when linting JavaScript or TypeScript with SLICC's `eslint` shell
+  command, including `.jsh` and `.bsh` scripts. Covers its ipk prerequisites,
+  flat-config discovery, global ignores, `--fix`, formatters, and exit codes.
+allowed-tools: bash
+---
+
+# ESLint
+
+The `eslint` command lints files in the VFS. It wraps the ipk-installed ESLint's
+`Linter`, not the `eslint` binary — so config discovery, target expansion,
+ignores, fixes, and reporting are this wrapper's, and the rules, parser, and
+messages are ESLint's own.
+
+## Install prerequisites
+
+```bash
+ipk add -g eslint @eslint/js esbuild-wasm
+```
+
+All three are needed: `eslint` supplies the linter, `@eslint/js` supplies the
+`js.configs.*` presets most configs extend (ESLint no longer bundles it), and
+`esbuild-wasm` is what lets an ESM `eslint.config.js` load at all. A missing
+package surfaces as a single error naming this command.
+
+`eslint --version` prints the installed ESLint version and needs no config.
+
+## Commands
+
+| Command                                  | Behavior                                              |
+| ---------------------------------------- | ----------------------------------------------------- |
+| `eslint <files...>`                      | Lint files; directories are walked recursively.       |
+| `eslint --fix <files...>`                | Lint and write fixes back.                            |
+| `eslint --fix-dry-run <files...>`        | Report which files `--fix` would rewrite; write none. |
+| `eslint --stdin --stdin-filename <path>` | Lint piped input as if it were `<path>`.              |
+
+`--stdin-filename` is a VIRTUAL name, used only to pick the config that applies.
+Nothing is written to it, and `--fix` with `--stdin` is refused for that reason —
+use `--fix-dry-run`, which prints the fixed code to stdout.
+
+Useful flags: `-c/--config <file>`, `--no-config-lookup`, `--rule '<json>'`,
+`-f/--format <stylish\|json\|compact>`, `--ext .js,.mjs`, `--max-warnings <n>`,
+`--quiet`. Run `eslint --help` for the full list.
+
+## Configuration
+
+Flat config only. Without `--config`, discovery starts at the first target's
+directory — the directory itself when the target _is_ a directory — or the
+current directory for stdin, then walks toward `/`, taking the first of
+`eslint.config.js`, `.mjs`, `.cjs`. ESM and CommonJS configs both load;
+`@eslint/js` and any other installed plugin can be imported from one.
+
+A TypeScript config (`eslint.config.ts`) is rejected: it needs a loader ESLint
+resolves through its own CLI, which is not on this path.
+
+Relative `files` and `ignores` patterns resolve against the config file's
+directory, so a target outside the shell's current directory still matches.
+
+To lint without a config file, combine `--no-config-lookup` with `--rule`:
+
+```bash
+eslint --no-config-lookup --rule '{"eqeqeq":"error"}' src/app.js
+```
+
+### Ignores
+
+Top-level `ignores`-only config entries are applied by this wrapper, because
+`Linter` does not honor global ignores on its own. `node_modules` and `.git` are
+never walked into.
+
+Patterns are evaluated in order, so a later `!` pattern re-includes what an
+earlier one ignored — `ignores: ['**/*.js', '!src/**/*.js']` lints `src` and
+nothing else.
+
+A file you name on the command line that the config ignores is reported as
+`File ignored because of a matching ignore pattern.` rather than silently
+passing, so a stale path is not mistaken for a clean one. A file reached by
+walking a directory is skipped quietly.
+
+## Linting `.jsh` and `.bsh` scripts
+
+Both run as an async function body, so top-level `await` and top-level `return`
+are valid in them. The wrapper wraps the body before ESLint parses it and maps
+line numbers back, so a bare `return` does not produce a phantom parse error and
+reported positions match the real file. Findings that belong only to that
+injected wrapper are dropped, so no rule reports against a line the file does not
+have. `--fix` writes back only when the fix left the wrapper untouched; a rule
+that reindents the whole body (`indent`) is reported as unfixable and the file is
+left alone.
+
+These scripts run with SLICC's realm globals, so give them to ESLint or
+`no-undef` flags every one of them:
+
+```js
+export default [
+  {
+    files: ['**/*.jsh', '**/*.bsh'],
+    languageOptions: {
+      globals: { require: 'readonly', process: 'readonly', console: 'readonly', fetch: 'readonly' },
+    },
+    rules: { eqeqeq: 'error' },
+  },
+];
+```
+
+## Reporters
+
+`stylish` (default) prints grouped, aligned findings and a problem summary.
+`compact` prints one line per finding. `json` prints one document on stdout with
+`summary` and `results` fields, where each result carries ESLint's own message
+objects; nothing is written to stderr and the exit code does not change.
+
+## Exit codes
+
+| Code | Meaning                                                                         |
+| ---- | ------------------------------------------------------------------------------- |
+| `0`  | No errors, and warnings within `--max-warnings`.                                |
+| `1`  | Error-severity findings, or warnings over `--max-warnings`.                     |
+| `2`  | Usage error, a missing or unusable config, a missing package, a missing target. |
+
+`--quiet` drops warnings from the report and disables the `--max-warnings`
+check, but never hides a fatal parse error.

--- a/packages/vfs-root/workspace/skills/eslint/eslint.jsh
+++ b/packages/vfs-root/workspace/skills/eslint/eslint.jsh
@@ -1,0 +1,826 @@
+// eslint — lint JavaScript/TypeScript in the VFS with the ipk-installed ESLint.
+//
+// A thin wrapper over `eslint/universal`'s `Linter`, not the `eslint` CLI: the
+// full `eslint` entry pulls in `node:worker_threads` for its multithread lint
+// path, which the browser realm does not serve. `eslint/universal` is ESLint's
+// own dependency-light entry and is the supported way to lint outside Node.
+//
+// Everything the CLI does around `Linter` — config discovery, target
+// expansion, global ignores, fix write-back, formatters, exit codes — lives
+// here.
+//
+// The linting itself runs in a generated helper script, because a realm's
+// `require()` only resolves specifiers the host extracted from the entry
+// SOURCE: a `require(configPath)` computed at runtime has no graph edge. The
+// helper is written with the discovered config path as a literal, so the host
+// resolves and transpiles the config (ESM included) before the helper runs.
+//
+// Usage:
+//   eslint [options] [files|dirs...]
+//   echo "code" | eslint --stdin --stdin-filename <path>
+//
+// Requires: ipk add -g eslint @eslint/js esbuild-wasm
+
+const { exec } = require('sliccy:exec');
+const fs = require('fs');
+
+const INSTALL_HINT = 'ipk add -g eslint @eslint/js esbuild-wasm';
+
+const CONFIG_NAMES = [
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'eslint.config.cjs',
+  'eslint.config.ts',
+  'eslint.config.mts',
+  'eslint.config.cts',
+];
+
+const DEFAULT_EXTENSIONS = [
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsx',
+  '.ts',
+  '.mts',
+  '.cts',
+  '.tsx',
+  '.jsh',
+  '.bsh',
+];
+
+// `.jsh`/`.bsh` run as an AsyncFunction body, so top-level `await` AND
+// top-level `return` are valid. Espree parses a bare body as a module and
+// reports a fatal "'return' outside of function", so the body is wrapped
+// before ESLint sees it. The prefix is exactly ONE line ending in a newline
+// and adds no indentation, so a message's column is already correct and only
+// its line needs shifting by 1. Follows `jsh-biome-source.ts`.
+//
+// The function is ANONYMOUS, unlike the biome shim's: a linter reports on the
+// scaffold, and a named declaration is a real unused binding, so `no-unused-vars`
+// (in `@eslint/js`'s `recommended`) flagged `'__slicc' is defined but never
+// used` against line 1 of an otherwise-clean script. No wrapper is entirely
+// invisible to every rule, so `isWrapperOnly` below also drops findings that
+// live only in the scaffold.
+const WRAP_PREFIX = '(async function () {\n';
+const WRAP_SUFFIX = '\n})';
+
+const HELP = `eslint - lint JavaScript/TypeScript in the VFS via ipk-installed ESLint
+
+Usage:
+  eslint [options] [files|dirs...]
+  echo "code" | eslint --stdin --stdin-filename <path>
+
+Options:
+  -c, --config <file>       Use this flat config instead of discovery
+  --no-config-lookup        Do not search for a config file
+  --rule <json>             Inline rules, e.g. --rule '{"semi":"error"}'
+  --fix                     Apply fixes to files
+  --fix-dry-run             Report what --fix would produce; write nothing
+  -f, --format <name>       stylish (default), json, or compact
+  --ext <.a,.b>             Extensions to collect when walking a directory
+  --max-warnings <n>        Exit 1 when warnings exceed n (-1 disables)
+  --quiet                   Report errors only, and ignore --max-warnings
+  --stdin                   Lint stdin
+  --stdin-filename <path>   Virtual path for stdin (selects the config entry)
+  -h, --help                Show this help
+  -v, --version             Show the installed eslint version
+
+Configuration:
+  Flat config only. Without --config, discovery starts at the first target's
+  directory (the cwd for stdin) and walks toward /, taking the first
+  ${CONFIG_NAMES.join(', ')}.
+  A .ts config needs a loader ESLint resolves itself and is not supported here.
+
+  Top-level ignores-only config entries are applied by this wrapper, because
+  Linter.verify does not honor global ignores. node_modules and .git are always
+  skipped when walking a directory.
+
+Exit codes:
+  0  No errors (and warnings within --max-warnings)
+  1  Lint errors, or warnings over --max-warnings
+  2  Usage error, missing config, missing packages, or a runtime failure
+
+Install:
+  ${INSTALL_HINT}
+`;
+
+function fail(message, code) {
+  console.error(`eslint: ${message}`);
+  process.exit(code === undefined ? 2 : code);
+}
+
+/* ------------------------------- arg parsing ------------------------------ */
+
+function valueOf(args, i, flag) {
+  const v = args[i + 1];
+  if (typeof v !== 'string' || (v.startsWith('-') && v !== '-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return v;
+}
+
+function parseArgs(args) {
+  const out = {
+    paths: [],
+    config: null,
+    configLookup: true,
+    rules: null,
+    fix: false,
+    fixDryRun: false,
+    format: 'stylish',
+    extensions: DEFAULT_EXTENSIONS,
+    maxWarnings: -1,
+    quiet: false,
+    stdin: false,
+    stdinFilename: null,
+    help: args.length === 0,
+    version: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '-h' || a === '--help') out.help = true;
+    else if (a === '-v' || a === '--version') out.version = true;
+    else if (a === '--fix') out.fix = true;
+    else if (a === '--fix-dry-run') out.fixDryRun = true;
+    else if (a === '--quiet') out.quiet = true;
+    else if (a === '--stdin') out.stdin = true;
+    else if (a === '--no-config-lookup') out.configLookup = false;
+    else if (a === '-c' || a === '--config') out.config = valueOf(args, i++, a);
+    else if (a.startsWith('--config=')) out.config = a.slice('--config='.length);
+    else if (a === '--rule') out.rules = parseRules(valueOf(args, i++, a));
+    else if (a.startsWith('--rule=')) out.rules = parseRules(a.slice('--rule='.length));
+    else if (a === '-f' || a === '--format') out.format = valueOf(args, i++, a);
+    else if (a.startsWith('--format=')) out.format = a.slice('--format='.length);
+    else if (a === '--ext') out.extensions = parseExtensions(valueOf(args, i++, a));
+    else if (a.startsWith('--ext=')) out.extensions = parseExtensions(a.slice('--ext='.length));
+    else if (a === '--max-warnings') out.maxWarnings = parseCount(valueOf(args, i++, a), a);
+    else if (a.startsWith('--max-warnings=')) {
+      out.maxWarnings = parseCount(a.slice('--max-warnings='.length), '--max-warnings');
+    } else if (a === '--stdin-filename') out.stdinFilename = valueOf(args, i++, a);
+    else if (a.startsWith('--stdin-filename=')) {
+      out.stdinFilename = a.slice('--stdin-filename='.length);
+    } else if (a.startsWith('-')) throw new Error(`unknown option: ${a}`);
+    else out.paths.push(a);
+  }
+  if (out.fix && out.fixDryRun) throw new Error('--fix and --fix-dry-run cannot be used together');
+  if (out.stdinFilename) out.stdin = true;
+  // Piped code has no file to write back to, so the real CLI refuses rather
+  // than guessing. Without this, `--fix` would target the VIRTUAL stdin
+  // filename and overwrite whatever real file it names.
+  if (out.stdin && out.fix) {
+    throw new Error(
+      'The --fix option is not available for piped-in code; use --fix-dry-run instead.'
+    );
+  }
+  if (!['stylish', 'json', 'compact'].includes(out.format)) {
+    throw new Error(`unknown formatter: ${out.format} (expected stylish, json, or compact)`);
+  }
+  return out;
+}
+
+function parseRules(json) {
+  let parsed;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    throw new Error(`--rule is not valid JSON: ${e.message}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('--rule must be a JSON object of ruleId -> severity/options');
+  }
+  return parsed;
+}
+
+function parseExtensions(value) {
+  const list = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => (s.startsWith('.') ? s : `.${s}`));
+  if (list.length === 0) throw new Error('--ext requires at least one extension');
+  return list;
+}
+
+function parseCount(value, flag) {
+  const n = Number(value);
+  if (!Number.isInteger(n)) throw new Error(`${flag} requires an integer`);
+  return n;
+}
+
+/* ------------------------------ path helpers ------------------------------ */
+
+function dirOf(path) {
+  const i = path.lastIndexOf('/');
+  if (i <= 0) return '/';
+  return path.slice(0, i);
+}
+
+function resolvePath(path) {
+  const abs = path.startsWith('/') ? path : `${process.cwd().replace(/\/$/, '')}/${path}`;
+  const parts = [];
+  for (const seg of abs.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') parts.pop();
+    else parts.push(seg);
+  }
+  return `/${parts.join('/')}`;
+}
+
+async function statOrNull(path) {
+  try {
+    return await fs.stat(path);
+  } catch {
+    return null;
+  }
+}
+
+function hasLintableExtension(path, extensions) {
+  return extensions.some((ext) => path.endsWith(ext));
+}
+
+async function walkDir(dir, extensions, out) {
+  let names;
+  try {
+    names = await fs.readdir(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (name === 'node_modules' || name === '.git') continue;
+    const full = dir === '/' ? `/${name}` : `${dir}/${name}`;
+    const st = await statOrNull(full);
+    if (!st) continue;
+    if (st.isDirectory) await walkDir(full, extensions, out);
+    else if (hasLintableExtension(full, extensions)) out.push(full);
+  }
+}
+
+/**
+ * Expand file/dir arguments into a sorted, deduped list of concrete files.
+ * `explicit` records whether a path was NAMED on the command line rather than
+ * found by walking a directory — the two are reported differently when the
+ * config ignores the file.
+ */
+async function expandTargets(paths, extensions) {
+  const explicit = new Set();
+  const walked = [];
+  const missing = [];
+  for (const raw of paths) {
+    const abs = resolvePath(raw);
+    const st = await statOrNull(abs);
+    if (!st) {
+      missing.push(raw);
+      continue;
+    }
+    if (st.isDirectory) await walkDir(abs, extensions, walked);
+    else explicit.add(abs);
+  }
+  const all = [...new Set([...explicit, ...walked])].sort();
+  return { files: all.map((path) => ({ path, explicit: explicit.has(path) })), missing };
+}
+
+/* ---------------------------- config discovery ---------------------------- */
+
+async function discoverConfig(startDir) {
+  let dir = startDir;
+  for (;;) {
+    for (const name of CONFIG_NAMES) {
+      const candidate = dir === '/' ? `/${name}` : `${dir}/${name}`;
+      const st = await statOrNull(candidate);
+      if (st && !st.isDirectory) return candidate;
+    }
+    if (dir === '/') return null;
+    dir = dirOf(dir);
+  }
+}
+
+/* ------------------------------ helper script ----------------------------- */
+
+/**
+ * Build the helper source. `configPath` is embedded as a `require()` LITERAL
+ * so the host resolves it while building the helper's module graph; a runtime
+ * path would have no graph edge and could never load.
+ */
+function helperSource(configPath) {
+  const configLine =
+    configPath === null
+      ? 'const loadedConfig = null;'
+      : `const loadedConfig = require(${JSON.stringify(configPath)});`;
+  return `${configLine}
+const { Linter } = require('eslint/universal');
+const { minimatch } = require('minimatch');
+const fs = require('fs');
+const pkg = require('eslint/package.json');
+
+const WRAP_PREFIX = ${JSON.stringify(WRAP_PREFIX)};
+const WRAP_SUFFIX = ${JSON.stringify(WRAP_SUFFIX)};
+
+const req = JSON.parse(process.argv[2]);
+
+// Answered before any config handling: reporting the version must not depend
+// on a config existing or being usable.
+if (req.op === 'version') {
+  process.stdout.write(JSON.stringify({ version: pkg.version }));
+  process.exit(0);
+}
+
+function asConfigArray(value) {
+  const unwrapped = value && value.default !== undefined ? value.default : value;
+  if (unwrapped === null || unwrapped === undefined) return [];
+  return Array.isArray(unwrapped) ? unwrapped.flat(Infinity) : [unwrapped];
+}
+
+const configArray = asConfigArray(loadedConfig);
+if (req.rules) {
+  // A file has to be matched by some entry with a NON-universal \`files\`
+  // pattern or ESLint answers "No matching configuration found". With a config
+  // file present the inline rules layer on top of its matching entries. With
+  // no config file they are all there is, so they carry the matcher — built
+  // from the extension list, because ESLint deliberately treats a
+  // match-everything pattern like \`**/*\` as universal and it would opt no
+  // file in at all.
+  configArray.push(
+    loadedConfig === null ? { files: req.filePatterns, rules: req.rules } : { rules: req.rules }
+  );
+}
+if (configArray.length === 0) {
+  process.stderr.write('empty configuration: nothing to lint with\\n');
+  process.exit(2);
+}
+
+// Flat config: an entry carrying ONLY \`ignores\` is a GLOBAL ignore.
+// \`Linter.verify\` does not apply those, so they are applied here.
+const globalIgnores = [];
+for (const entry of configArray) {
+  if (!entry || typeof entry !== 'object') continue;
+  const keys = Object.keys(entry);
+  if (keys.length === 1 && keys[0] === 'ignores' && Array.isArray(entry.ignores)) {
+    globalIgnores.push(...entry.ignores);
+  }
+}
+
+function relativeTo(base, path) {
+  const prefix = base === '/' ? '/' : base + '/';
+  return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
+// ESLint evaluates ignore patterns IN ORDER, so a later \`!\` re-includes what an
+// earlier pattern ignored (\`['**/*.js', '!src/**/*.js']\` lints \`src\`). A
+// short-circuiting \`.some()\` cannot express that: it would stop at the first
+// positive match and never reach the negation, silently skipping files the user
+// asked for — and skipped files make lint PASS, so nothing would look wrong.
+function isGloballyIgnored(path) {
+  if (globalIgnores.length === 0) return false;
+  const rel = relativeTo(req.basePath, path);
+  let ignored = false;
+  for (const pattern of globalIgnores) {
+    if (typeof pattern !== 'string') continue;
+    const negated = pattern.startsWith('!');
+    const body = negated ? pattern.slice(1) : pattern;
+    // A bare directory pattern ignores everything beneath it, as in gitignore.
+    const expanded = body.endsWith('/') ? body + '**' : body;
+    const hit =
+      minimatch(rel, expanded, { dot: true }) ||
+      minimatch(rel, expanded + '/**', { dot: true });
+    if (hit) ignored = !negated;
+  }
+  return ignored;
+}
+
+// \`files\`/\`ignores\` patterns are relative, and ESLint resolves them against
+// the config file's directory. Pass that as the Linter's cwd so a target
+// outside the shell's cwd still matches its own config's patterns.
+const linter = new Linter({ cwd: req.basePath });
+
+function shouldWrap(path) {
+  return path.endsWith('.jsh') || path.endsWith('.bsh');
+}
+
+/**
+ * Undo the wrapper by stripping the exact prefix and suffix, which is lossless:
+ * the body comes back byte-for-byte, trailing newline and all. It doubles as
+ * the safety check — a fix that rewrote the wrapper itself (an \`indent\` rule
+ * reindents the whole body, so the closing \`}\` moves) no longer matches, and
+ * \`null\` tells the caller to leave the file alone rather than write back
+ * something reconstructed by guesswork.
+ */
+function unwrap(text) {
+  if (!text.startsWith(WRAP_PREFIX) || !text.endsWith(WRAP_SUFFIX)) return null;
+  return text.slice(WRAP_PREFIX.length, text.length - WRAP_SUFFIX.length);
+}
+
+async function lintOne(file) {
+  const wrap = shouldWrap(file.path);
+  const source = wrap ? WRAP_PREFIX + file.source + WRAP_SUFFIX : file.source;
+  const result = { path: file.path, messages: [], output: null, wrapUnfixable: false };
+  // Wrapped line numbers: 1 is the injected prefix, the body follows, and the
+  // last line is the injected suffix.
+  const suffixLine = file.source.split('\\n').length + 2;
+  /**
+   * A finding that lies ENTIRELY in the injected scaffold is about code the
+   * user does not have, so reporting it at their line 1 is noise at best and
+   * misleading at worst. One that merely STARTS there (a whole-function
+   * \`indent\`, say) still concerns their code and is kept, clamped into the body.
+   * A fatal is never dropped: if the scaffold itself fails to parse, that is a
+   * bug in this command and it has to be visible.
+   */
+  const isWrapperOnly = (m) => {
+    if (m.fatal) return false;
+    const start = typeof m.line === 'number' ? m.line : 1;
+    const end = typeof m.endLine === 'number' ? m.endLine : start;
+    return (start === 1 && end === 1) || (start >= suffixLine && end >= suffixLine);
+  };
+  const shiftLines = (messages) => {
+    if (!wrap) return messages;
+    return messages.filter((m) => !isWrapperOnly(m)).map((m) => {
+      const shifted = Object.assign({}, m);
+      if (typeof shifted.line === 'number') shifted.line = Math.max(1, shifted.line - 1);
+      if (typeof shifted.endLine === 'number') shifted.endLine = Math.max(1, shifted.endLine - 1);
+      return shifted;
+    });
+  };
+
+  if (req.fix) {
+    const fixed = linter.verifyAndFix(source, configArray, file.path);
+    result.messages = shiftLines(fixed.messages);
+    if (fixed.fixed) {
+      if (!wrap) {
+        result.output = fixed.output;
+      } else {
+        const candidate = unwrap(fixed.output);
+        if (candidate === null) result.wrapUnfixable = true;
+        else result.output = candidate;
+      }
+    }
+  } else {
+    result.messages = shiftLines(linter.verify(source, configArray, file.path));
+  }
+  return result;
+}
+
+async function main() {
+  const results = [];
+  for (const file of req.files) {
+    if (isGloballyIgnored(file.path)) {
+      // A path the user NAMED is reported as ignored (ESLint does the same), so
+      // a mistyped or newly-ignored argument is not mistaken for a clean file.
+      // One found by walking a directory is skipped silently, as intended.
+      if (file.explicit) {
+        results.push({
+          path: file.path,
+          messages: [
+            {
+              ruleId: null,
+              severity: 1,
+              message: 'File ignored because of a matching ignore pattern.',
+              line: 0,
+              column: 0,
+            },
+          ],
+          output: null,
+          wrapUnfixable: false,
+        });
+      }
+      continue;
+    }
+    let source = file.source;
+    if (source === null) source = await fs.readFile(file.path);
+    results.push(await lintOne({ path: file.path, source }));
+  }
+  process.stdout.write(JSON.stringify(results));
+}
+
+await main();
+`;
+}
+
+/* -------------------------------- reporting ------------------------------- */
+
+function severityName(severity) {
+  return severity === 2 ? 'error' : 'warning';
+}
+
+function pad(value, width) {
+  const s = String(value);
+  return s.length >= width ? s : ' '.repeat(width - s.length) + s;
+}
+
+function formatStylish(results, totals) {
+  const lines = [];
+  for (const result of results) {
+    if (result.messages.length === 0) continue;
+    lines.push(result.path);
+    const posWidth = Math.max(
+      ...result.messages.map((m) => `${m.line ?? 0}:${m.column ?? 0}`.length)
+    );
+    for (const m of result.messages) {
+      const pos = `${m.line ?? 0}:${m.column ?? 0}`;
+      const kind = severityName(m.severity);
+      const rule = m.ruleId ?? '';
+      lines.push(`  ${pad(pos, posWidth)}  ${kind.padEnd(7)}  ${m.message}${rule ? `  ${rule}` : ''}`);
+    }
+    lines.push('');
+  }
+  if (totals.problems > 0) {
+    const mark = totals.errors > 0 ? '\u2716' : '\u26a0';
+    lines.push(
+      `${mark} ${totals.problems} problem${totals.problems === 1 ? '' : 's'} ` +
+        `(${totals.errors} error${totals.errors === 1 ? '' : 's'}, ` +
+        `${totals.warnings} warning${totals.warnings === 1 ? '' : 's'})`
+    );
+    if (totals.fixableErrors > 0 || totals.fixableWarnings > 0) {
+      lines.push(
+        `  ${totals.fixableErrors} error${totals.fixableErrors === 1 ? '' : 's'} and ` +
+          `${totals.fixableWarnings} warning${totals.fixableWarnings === 1 ? '' : 's'} ` +
+          'potentially fixable with the `--fix` option.'
+      );
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function formatCompact(results) {
+  const lines = [];
+  for (const result of results) {
+    for (const m of result.messages) {
+      const rule = m.ruleId ? ` (${m.ruleId})` : '';
+      lines.push(
+        `${result.path}: line ${m.line ?? 0}, col ${m.column ?? 0}, ` +
+          `${severityName(m.severity)} - ${m.message}${rule}`
+      );
+    }
+  }
+  return lines.length > 0 ? `${lines.join('\n')}\n` : '';
+}
+
+function formatJson(results, totals) {
+  return `${JSON.stringify({
+    summary: {
+      errors: totals.errors,
+      warnings: totals.warnings,
+      filesLinted: results.length,
+      fixedFiles: totals.fixedFiles,
+    },
+    results: results.map((r) => ({
+      filePath: r.path,
+      messages: r.messages,
+      errorCount: r.messages.filter((m) => m.severity === 2).length,
+      warningCount: r.messages.filter((m) => m.severity === 1).length,
+    })),
+  })}\n`;
+}
+
+function tally(results) {
+  const totals = {
+    errors: 0,
+    warnings: 0,
+    problems: 0,
+    fixableErrors: 0,
+    fixableWarnings: 0,
+    fixedFiles: 0,
+  };
+  for (const result of results) {
+    for (const m of result.messages) {
+      totals.problems++;
+      if (m.severity === 2) {
+        totals.errors++;
+        if (m.fix) totals.fixableErrors++;
+      } else {
+        totals.warnings++;
+        if (m.fix) totals.fixableWarnings++;
+      }
+    }
+    if (result.output !== null) totals.fixedFiles++;
+  }
+  return totals;
+}
+
+/* ---------------------------------- main ---------------------------------- */
+
+/** Rewrite a helper "Cannot find module 'x'" into the actionable install hint. */
+function installHintFor(stderr) {
+  const m = stderr.match(/Cannot find module '([^']+)'/);
+  if (!m) return null;
+  const spec = m[1];
+  const name = spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0];
+  return `${name} is not installed (run: ${INSTALL_HINT})`;
+}
+
+let args;
+try {
+  args = parseArgs(process.argv.slice(2));
+} catch (e) {
+  fail(e.message, 2);
+  return;
+}
+
+if (args.help) {
+  console.log(HELP);
+  process.exit(0);
+  return;
+}
+
+const tmpDir = process.env.TMPDIR || '/tmp';
+const helperPath = `${tmpDir}/.eslint-helper-${Date.now()}-${Math.random().toString(36).slice(2)}.js`;
+
+async function runHelper(request, configPath) {
+  await fs.mkdir(tmpDir, { recursive: true }).catch(() => {});
+  await fs.writeFile(helperPath, helperSource(configPath));
+  try {
+    // `exec.spawn` and NOT `exec(string)`: the request carries content this
+    // command does not control — stdin bytes and every target's path — and the
+    // shell performs command substitution inside double quotes, so a file named
+    // `$(...)` or a backtick in a linted buffer would RUN. Quoting cannot fix
+    // that (`JSON.stringify` escapes `"` and `\`, never `$` or a backtick); the
+    // argv form never builds a command line at all.
+    return await exec.spawn(['node', helperPath, JSON.stringify(request)]);
+  } finally {
+    await fs.unlink(helperPath).catch(() => {});
+  }
+}
+
+// `--version` reads the installed package and needs no config or targets, so
+// it answers before target/config resolution (which would have nothing to
+// resolve against).
+if (args.version) {
+  const versionRun = await runHelper({ op: 'version', files: [], basePath: '/' }, null);
+  if (versionRun.exitCode !== 0) {
+    fail(installHintFor(versionRun.stderr) ?? versionRun.stderr.trim(), 2);
+    return;
+  }
+  console.log(JSON.parse(versionRun.stdout).version);
+  process.exit(0);
+  return;
+}
+
+// stdin and file targets are mutually exclusive, as in the real CLI.
+if (args.stdin && args.paths.length > 0) {
+  fail('--stdin cannot be combined with file arguments', 2);
+  return;
+}
+if (!args.stdin && args.paths.length === 0) {
+  fail('no files or directories specified (use --help for usage)', 2);
+  return;
+}
+
+/**
+ * Where config discovery starts. For a DIRECTORY target that is the directory
+ * itself, not its parent — `eslint .` in a project root must find that root's
+ * own config, and starting one level up would walk straight past it.
+ */
+async function configSearchStart() {
+  if (args.stdin) {
+    return args.stdinFilename ? dirOf(resolvePath(args.stdinFilename)) : resolvePath('.');
+  }
+  const first = resolvePath(args.paths[0]);
+  const st = await statOrNull(first);
+  return st?.isDirectory ? first : dirOf(first);
+}
+
+const searchFrom = await configSearchStart();
+
+let configPath = null;
+if (args.config !== null) {
+  configPath = resolvePath(args.config);
+  const st = await statOrNull(configPath);
+  if (!st || st.isDirectory) {
+    fail(`--config ${args.config}: no such file`, 2);
+    return;
+  }
+} else if (args.configLookup) {
+  configPath = await discoverConfig(searchFrom);
+}
+
+if (configPath !== null && /\.[cm]?ts$/.test(configPath)) {
+  fail(
+    `${configPath}: TypeScript flat configs need a loader that is not available here; ` +
+      'use a .js/.mjs/.cjs config or pass --config',
+    2
+  );
+  return;
+}
+
+if (configPath === null && args.rules === null) {
+  fail(
+    `no flat config found from ${searchFrom} (looked for ${CONFIG_NAMES.join(', ')}); ` +
+      'pass --config <file>, or --no-config-lookup with --rule',
+    2
+  );
+  return;
+}
+
+const inputs = [];
+let missing = [];
+if (args.stdin) {
+  const stdinText = await new Promise((resolve) => {
+    let buf = '';
+    process.stdin.on('data', (chunk) => {
+      buf += chunk;
+    });
+    process.stdin.on('end', () => resolve(buf));
+  });
+  inputs.push({
+    path: resolvePath(args.stdinFilename ?? 'stdin.js'),
+    source: stdinText,
+    explicit: true,
+  });
+} else {
+  const expanded = await expandTargets(args.paths, args.extensions);
+  missing = expanded.missing;
+  for (const target of expanded.files) {
+    inputs.push({ path: target.path, source: null, explicit: target.explicit });
+  }
+}
+
+for (const name of missing) console.error(`eslint: ${name}: no such file or directory`);
+
+if (inputs.length === 0) {
+  if (missing.length > 0) process.exit(2);
+  console.error('eslint: no lintable files found');
+  process.exit(0);
+  return;
+}
+
+const request = {
+  op: 'lint',
+  files: inputs,
+  rules: args.rules,
+  filePatterns: args.extensions.map((ext) => `**/*${ext}`),
+  fix: args.fix || args.fixDryRun,
+  // ESLint resolves relative `files`/`ignores` against the config file's
+  // directory. With no config file the inline rules are the config, so the
+  // base is where discovery started — otherwise a target outside the shell's
+  // cwd would match nothing and lint silently clean.
+  basePath: configPath === null ? searchFrom : dirOf(configPath),
+};
+
+const run = await runHelper(request, configPath);
+if (run.exitCode !== 0) {
+  fail(installHintFor(run.stderr) ?? (run.stderr.trim() || 'helper failed with no output'), 2);
+  return;
+}
+
+let results;
+try {
+  results = JSON.parse(run.stdout);
+} catch (e) {
+  fail(`could not parse helper output: ${e.message}${run.stderr ? ` (${run.stderr.trim()})` : ''}`, 2);
+  return;
+}
+
+// A fatal parse error arrives as a message with no ruleId; keep it visible even
+// under --quiet, where it would otherwise be filtered out as a warning.
+if (args.quiet) {
+  for (const result of results) {
+    result.messages = result.messages.filter((m) => m.severity === 2 || m.ruleId === null);
+  }
+}
+
+// Write fixes back through the shell's own fs so every write passes the sudo gate.
+// Never for stdin: `result.path` is then the VIRTUAL `--stdin-filename`, chosen
+// only so config `files`/`ignores` can select a config, and writing to it would
+// overwrite a real project file with a piped buffer (or create `stdin.js`).
+// `--fix` with stdin is rejected outright; `--fix-dry-run` prints instead.
+if (args.fix && !args.stdin) {
+  for (const result of results) {
+    if (result.output !== null) await fs.writeFile(result.path, result.output);
+  }
+}
+for (const result of results) {
+  if (result.wrapUnfixable) {
+    console.error(
+      `eslint: ${result.path}: fixes rewrote the script wrapper, so the file was left unchanged`
+    );
+  }
+}
+
+const totals = tally(results);
+
+if (args.format === 'json') process.stdout.write(formatJson(results, totals));
+else if (args.format === 'compact') process.stdout.write(formatCompact(results));
+else {
+  const text = formatStylish(results, totals);
+  if (text) process.stdout.write(text);
+}
+
+if (args.fixDryRun) {
+  for (const result of results) {
+    if (result.output === null) continue;
+    // Piped code has no file to rewrite, so the fixed buffer IS the result —
+    // print it, the way the real CLI does for `--stdin --fix-dry-run`.
+    if (args.stdin) process.stdout.write(result.output);
+    else console.error(`eslint: ${result.path}: --fix would rewrite`);
+  }
+}
+
+if (missing.length > 0) process.exit(2);
+if (totals.errors > 0) process.exit(1);
+if (!args.quiet && args.maxWarnings >= 0 && totals.warnings > args.maxWarnings) {
+  console.error(
+    `eslint: ${totals.warnings} warning${totals.warnings === 1 ? '' : 's'} ` +
+      `exceeded the --max-warnings limit of ${args.maxWarnings}`
+  );
+  process.exit(1);
+}
+process.exit(0);

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -13,7 +13,7 @@
       "name": "webapp: total JS payload",
       "path": "../../dist/ui/**/*.js",
       "brotli": false,
-      "limit": "25 MB"
+      "limit": "25.1 MB"
     }
   ],
   "dependencies": {
@@ -78,6 +78,7 @@
     "@types/w3c-web-serial": "1.0.8",
     "fake-indexeddb": "6.2.5",
     "jsdom": "30.0.1",
+    "minimatch": "10.2.6",
     "puppeteer-core": "25.9.0",
     "v86": "0.5.451"
   }

--- a/packages/webapp/tests/shell/eslint-skill-jsh.test.ts
+++ b/packages/webapp/tests/shell/eslint-skill-jsh.test.ts
@@ -1,0 +1,989 @@
+/**
+ * Tests for the shipped `eslint` skill script.
+ *
+ * The SHIPPED `packages/vfs-root/workspace/skills/eslint/eslint.jsh` is loaded
+ * from the on-disk vfs-root payload and run in a real `.jsh` realm, so what is
+ * covered is the file users get, not a copy.
+ *
+ * ESLint itself is not installed in this VFS, so the linting is stood in for by
+ * a fake `exec` that answers the `node <helper> <json>` call the script makes.
+ * That is the seam worth testing: everything the CLI does AROUND `Linter` lives
+ * in this script — argument parsing, flat-config discovery, target expansion,
+ * fix write-back, the formatters, and the exit codes — while the rules and
+ * messages are ESLint's.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { CommandContext, FsStat, IFileSystem } from 'just-bash';
+import { unsafeBytesFromLatin1 } from 'just-bash';
+import { describe, expect, it } from 'vitest';
+import { createInProcessJsRealmFactory } from '../../src/kernel/realm/realm-inprocess.js';
+import { executeJshFile } from '../../src/shell/jsh-executor.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..', '..');
+const ESLINT_JSH = resolve(repoRoot, 'packages/vfs-root/workspace/skills/eslint/eslint.jsh');
+const SCRIPT_PATH = '/workspace/skills/eslint/eslint.jsh';
+
+const source = readFileSync(ESLINT_JSH, 'utf-8');
+
+/** Minimal in-memory `IFileSystem` with real directory semantics. */
+function makeFs(files: Record<string, string>, dirs: string[] = []): IFileSystem {
+  const store = new Map<string, string>(Object.entries(files));
+  const directories = new Set<string>(dirs);
+  for (const path of store.keys()) {
+    let dir = path.slice(0, path.lastIndexOf('/'));
+    while (dir !== '') {
+      directories.add(dir);
+      dir = dir.slice(0, dir.lastIndexOf('/'));
+    }
+    directories.add('/');
+  }
+  const statFor = (p: string): FsStat => ({
+    isFile: store.has(p),
+    isDirectory: directories.has(p) && !store.has(p),
+    isSymbolicLink: false,
+    mode: 0o644,
+    size: (store.get(p) ?? '').length,
+    mtime: new Date(),
+  });
+  const fs: IFileSystem = {
+    async readFile(p) {
+      const v = store.get(p);
+      if (v === undefined) throw new Error(`ENOENT: ${p}`);
+      return v;
+    },
+    async readFileBuffer(p) {
+      return new TextEncoder().encode(await fs.readFile(p));
+    },
+    async writeFile(p, c) {
+      store.set(p, typeof c === 'string' ? c : new TextDecoder().decode(c));
+    },
+    async appendFile(p, c) {
+      store.set(
+        p,
+        (store.get(p) ?? '') + (typeof c === 'string' ? c : new TextDecoder().decode(c))
+      );
+    },
+    async exists(p) {
+      return store.has(p) || directories.has(p);
+    },
+    async stat(p) {
+      if (!store.has(p) && !directories.has(p)) throw new Error(`ENOENT: ${p}`);
+      return statFor(p);
+    },
+    async mkdir(p) {
+      directories.add(p);
+    },
+    async readdir(p) {
+      const prefix = p === '/' ? '/' : `${p}/`;
+      const names = new Set<string>();
+      for (const key of [...store.keys(), ...directories]) {
+        if (!key.startsWith(prefix) || key === p) continue;
+        names.add(key.slice(prefix.length).split('/')[0]);
+      }
+      return [...names];
+    },
+    async rm(p) {
+      store.delete(p);
+    },
+    async cp() {},
+    async mv() {},
+    resolvePath(base, p) {
+      if (p.startsWith('/')) return p;
+      if (p === '.') return base;
+      return base === '/' ? `/${p}` : `${base}/${p}`;
+    },
+    getAllPaths() {
+      return [...store.keys()];
+    },
+    async chmod() {},
+    async symlink() {},
+    async link() {},
+    async readlink() {
+      return '';
+    },
+    async lstat(p) {
+      return fs.stat(p);
+    },
+    async realpath(p) {
+      return p;
+    },
+    async utimes() {},
+  };
+  return { fs, store } as unknown as IFileSystem & { store: Map<string, string> };
+}
+
+type ExecFn = NonNullable<CommandContext['exec']>;
+type HelperReply = { stdout: string; stderr: string; exitCode: number };
+
+interface Harness {
+  ctx: CommandContext;
+  /** Every command the script handed to `exec`, in order. */
+  calls: string[];
+  /**
+   * Every invocation as the argv array the shell actually received. The helper
+   * MUST arrive this way: a command string would let a target path or a stdin
+   * buffer containing `$(...)` run as a command substitution.
+   */
+  argvCalls: string[][];
+  /** The parsed request JSON of the last `node <helper> <json>` call. */
+  lastRequest: () => Record<string, unknown> | null;
+  read: (path: string) => string | undefined;
+  helperSource: () => string | undefined;
+}
+
+function makeHarness(
+  files: Record<string, string>,
+  reply: (request: Record<string, unknown>) => HelperReply,
+  opts: { cwd?: string; dirs?: string[]; stdin?: string } = {}
+): Harness {
+  const wrapped = makeFs({ [SCRIPT_PATH]: source, ...files }, opts.dirs) as IFileSystem & {
+    fs: IFileSystem;
+    store: Map<string, string>;
+  };
+  const fs = wrapped.fs;
+  const store = wrapped.store;
+  const calls: string[] = [];
+  const argvCalls: string[][] = [];
+  let request: Record<string, unknown> | null = null;
+  let capturedHelper: string | undefined;
+
+  // `exec.spawn(argv)` reaches `ctx.exec` as `(argv[0], { args: argv.slice(1) })`
+  // — see `dispatchExec` in `realm-host.ts`. The string form is still accepted
+  // here so a regression back to it is visible as an empty `argvCalls`.
+  const exec = (async (command: string, opts?: { args?: string[] }) => {
+    const argv = opts?.args ? [command, ...opts.args] : null;
+    if (argv) argvCalls.push(argv);
+    calls.push(argv ? argv.join(' ') : command);
+    const parts = argv ?? /^node (\S+) (.*)$/s.exec(command)?.slice(1).map(String);
+    if (!parts) return { stdout: '', stderr: '', exitCode: 127 };
+    const [helperPath, payload] = argv ? [parts[1], parts[2]] : [parts[0], parts[1]];
+    if (helperPath === undefined || payload === undefined) {
+      return { stdout: '', stderr: '', exitCode: 127 };
+    }
+    // The helper is written to the VFS before the call and removed after, so
+    // snapshot it here — this is the only moment it exists.
+    capturedHelper = store.get(helperPath);
+    request = JSON.parse(argv ? payload : (JSON.parse(payload) as string)) as Record<
+      string,
+      unknown
+    >;
+    return reply(request);
+  }) as ExecFn;
+
+  const ctx: CommandContext = {
+    fs,
+    cwd: opts.cwd ?? '/workspace/proj',
+    env: new Map<string, string>([['TMPDIR', '/tmp']]),
+    stdin: unsafeBytesFromLatin1(opts.stdin ?? ''),
+    exec,
+  };
+  return {
+    ctx,
+    calls,
+    argvCalls,
+    lastRequest: () => request,
+    read: (path) => store.get(path),
+    helperSource: () => capturedHelper,
+  };
+}
+
+function run(harness: Harness, args: string[]) {
+  return executeJshFile(SCRIPT_PATH, args, harness.ctx, undefined, {
+    realmFactory: createInProcessJsRealmFactory(),
+  });
+}
+
+/** A helper reply with no findings for every requested file. */
+const clean = (request: Record<string, unknown>): HelperReply => ({
+  stdout: JSON.stringify(
+    (request.files as { path: string }[]).map((f) => ({
+      path: f.path,
+      messages: [],
+      output: null,
+      wrapUnfixable: false,
+    }))
+  ),
+  stderr: '',
+  exitCode: 0,
+});
+
+const FLAT_CONFIG = 'export default [{ files: ["**/*.js"], rules: { semi: "error" } }];\n';
+
+describe('eslint skill: usage surface', () => {
+  it('--help prints usage and the install line, and exits 0', async () => {
+    const harness = makeHarness({}, clean);
+    const result = await run(harness, ['--help']);
+    expect(result.stderr).not.toContain('ReferenceError');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('ipk add -g eslint @eslint/js esbuild-wasm');
+    // Nothing was linted, so the helper was never invoked.
+    expect(harness.calls).toEqual([]);
+  });
+
+  it('no arguments prints help rather than failing', async () => {
+    const harness = makeHarness({}, clean);
+    const result = await run(harness, []);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+  });
+
+  it('an unknown option exits 2 and names the option', async () => {
+    const harness = makeHarness({}, clean);
+    const result = await run(harness, ['--nope', 'a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('unknown option: --nope');
+  });
+
+  it('an unknown formatter exits 2 and lists the supported ones', async () => {
+    const harness = makeHarness({}, clean);
+    const result = await run(harness, ['-f', 'checkstyle', 'a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('unknown formatter: checkstyle');
+    expect(result.stderr).toContain('stylish');
+  });
+
+  it('--fix and --fix-dry-run together exit 2', async () => {
+    const harness = makeHarness({}, clean);
+    const result = await run(harness, ['--fix', '--fix-dry-run', 'a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('cannot be used together');
+  });
+
+  it('--rule with invalid JSON exits 2 instead of throwing', async () => {
+    const harness = makeHarness({}, clean);
+    const result = await run(harness, ['--rule', '{oops', 'a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('--rule is not valid JSON');
+    expect(result.stderr).not.toContain('SyntaxError');
+  });
+
+  it('--stdin with file arguments exits 2', async () => {
+    const harness = makeHarness({}, clean);
+    const result = await run(harness, ['--stdin', 'a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('--stdin cannot be combined with file arguments');
+  });
+
+  it('--version asks the helper and needs no config at all', async () => {
+    const harness = makeHarness({}, () => ({
+      stdout: JSON.stringify({ version: '10.10.0' }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    const result = await run(harness, ['--version']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('10.10.0');
+    expect(harness.lastRequest()?.op).toBe('version');
+  });
+});
+
+describe('eslint skill: config discovery', () => {
+  it('walks toward / from the target file and reports the config it found', async () => {
+    const harness = makeHarness(
+      {
+        '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+        '/workspace/proj/src/a.js': 'var a = 1\n',
+      },
+      clean
+    );
+    const result = await run(harness, ['src/a.js']);
+    expect(result.exitCode).toBe(0);
+    // The discovered config is a require() LITERAL in the helper, because a
+    // runtime path would have no module-graph edge and could never load.
+    expect(harness.helperSource()).toContain('require("/workspace/proj/eslint.config.js")');
+    expect(harness.lastRequest()?.basePath).toBe('/workspace/proj');
+  });
+
+  it('starts at a DIRECTORY target itself, not its parent', async () => {
+    // Starting one level up would walk straight past the project's own config.
+    const harness = makeHarness(
+      {
+        '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+        '/workspace/proj/a.js': 'var a = 1\n',
+      },
+      clean,
+      { cwd: '/workspace' }
+    );
+    const result = await run(harness, ['proj']);
+    expect(result.exitCode).toBe(0);
+    expect(harness.helperSource()).toContain('require("/workspace/proj/eslint.config.js")');
+  });
+
+  it('exits 2 with the searched names when no config is found', async () => {
+    const harness = makeHarness({ '/workspace/proj/a.js': 'var a = 1\n' }, clean);
+    const result = await run(harness, ['a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('no flat config found');
+    expect(result.stderr).toContain('eslint.config.js');
+    expect(result.stderr).toContain('--no-config-lookup');
+  });
+
+  it('exits 2 when an explicit --config does not exist', async () => {
+    const harness = makeHarness({ '/workspace/proj/a.js': 'var a = 1\n' }, clean);
+    const result = await run(harness, ['--config', 'missing.js', 'a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('no such file');
+  });
+
+  it('rejects a TypeScript config rather than failing obscurely inside the helper', async () => {
+    const harness = makeHarness(
+      {
+        '/workspace/proj/eslint.config.ts': FLAT_CONFIG,
+        '/workspace/proj/a.js': 'var a = 1\n',
+      },
+      clean
+    );
+    const result = await run(harness, ['a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('TypeScript flat configs');
+    expect(harness.calls).toEqual([]);
+  });
+
+  it('--no-config-lookup with --rule lints with no config file present', async () => {
+    const harness = makeHarness({ '/workspace/proj/a.js': 'var a = 1\n' }, clean);
+    const result = await run(harness, ['--no-config-lookup', '--rule', '{"semi":"error"}', 'a.js']);
+    expect(result.exitCode).toBe(0);
+    expect(harness.lastRequest()?.rules).toEqual({ semi: 'error' });
+    // With no config file the inline rules must carry a NON-universal `files`
+    // matcher, so the patterns come from the extension list.
+    expect(harness.lastRequest()?.filePatterns).toContain('**/*.js');
+    expect(harness.lastRequest()?.filePatterns).toContain('**/*.jsh');
+    expect(harness.helperSource()).toContain('const loadedConfig = null;');
+  });
+});
+
+describe('eslint skill: target expansion', () => {
+  const tree = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/a.js': 'var a = 1\n',
+    '/workspace/proj/b.mjs': 'var b = 1\n',
+    '/workspace/proj/notes.md': '# notes\n',
+    '/workspace/proj/nested/c.ts': 'var c = 1\n',
+    '/workspace/proj/node_modules/dep/index.js': 'var d = 1\n',
+    '/workspace/proj/.git/hooks/pre-commit.js': 'var e = 1\n',
+  };
+
+  it('walks a directory, skipping node_modules, .git, and non-lintable extensions', async () => {
+    const harness = makeHarness(tree, clean);
+    await run(harness, ['.']);
+    const paths = (harness.lastRequest()?.files as { path: string }[]).map((f) => f.path);
+    // The config file is itself lintable and is collected, as ESLint does.
+    expect(paths).toEqual([
+      '/workspace/proj/a.js',
+      '/workspace/proj/b.mjs',
+      '/workspace/proj/eslint.config.js',
+      '/workspace/proj/nested/c.ts',
+    ]);
+  });
+
+  it('--ext narrows what a directory walk collects', async () => {
+    const harness = makeHarness(tree, clean);
+    await run(harness, ['--ext', '.mjs', '.']);
+    const paths = (harness.lastRequest()?.files as { path: string }[]).map((f) => f.path);
+    expect(paths).toEqual(['/workspace/proj/b.mjs']);
+  });
+
+  it('marks a NAMED file explicit and a walked file not, so ignores report differently', async () => {
+    const harness = makeHarness(tree, clean);
+    await run(harness, ['a.js', 'nested']);
+    const files = harness.lastRequest()?.files as { path: string; explicit: boolean }[];
+    expect(files.find((f) => f.path === '/workspace/proj/a.js')?.explicit).toBe(true);
+    expect(files.find((f) => f.path === '/workspace/proj/nested/c.ts')?.explicit).toBe(false);
+  });
+
+  it('reports a missing target on stderr and exits 2', async () => {
+    const harness = makeHarness(tree, clean);
+    const result = await run(harness, ['a.js', 'ghost.js']);
+    expect(result.stderr).toContain('ghost.js: no such file or directory');
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('exits 0 with a note when a walk finds nothing lintable', async () => {
+    // The config lives outside the walked directory, so nothing under it is
+    // lintable at all.
+    const harness = makeHarness(
+      { '/workspace/eslint.config.js': FLAT_CONFIG, '/workspace/proj/docs/notes.md': '# n\n' },
+      clean
+    );
+    const result = await run(harness, ['docs']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('no lintable files found');
+    expect(harness.calls).toEqual([]);
+  });
+
+  it('lints stdin under --stdin-filename and sends the piped text, not a read', async () => {
+    const harness = makeHarness({ '/workspace/proj/eslint.config.js': FLAT_CONFIG }, clean, {
+      stdin: 'var piped = 1\n',
+    });
+    const result = await run(harness, ['--stdin-filename', 'piped.js']);
+    expect(result.exitCode).toBe(0);
+    const files = harness.lastRequest()?.files as { path: string; source: string }[];
+    expect(files).toEqual([
+      { path: '/workspace/proj/piped.js', source: 'var piped = 1\n', explicit: true },
+    ]);
+  });
+});
+
+describe('eslint skill: reporting and exit codes', () => {
+  const files = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/a.js': 'var a = 1\n',
+  };
+  const findings = (): HelperReply => ({
+    stdout: JSON.stringify([
+      {
+        path: '/workspace/proj/a.js',
+        messages: [
+          {
+            ruleId: 'semi',
+            severity: 2,
+            message: 'Missing semicolon.',
+            line: 1,
+            column: 10,
+            fix: { range: [9, 9], text: ';' },
+          },
+          {
+            ruleId: 'no-unused-vars',
+            severity: 1,
+            message: "'a' is assigned a value but never used.",
+            line: 1,
+            column: 5,
+          },
+        ],
+        output: null,
+        wrapUnfixable: false,
+      },
+    ]),
+    stderr: '',
+    exitCode: 0,
+  });
+
+  it('stylish groups by file, tallies problems, and exits 1 on an error', async () => {
+    const harness = makeHarness(files, findings);
+    const result = await run(harness, ['a.js']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('/workspace/proj/a.js');
+    expect(result.stdout).toContain('error');
+    expect(result.stdout).toContain('Missing semicolon.');
+    expect(result.stdout).toContain('semi');
+    expect(result.stdout).toContain('2 problems (1 error, 1 warning)');
+    expect(result.stdout).toContain('potentially fixable with the `--fix` option');
+  });
+
+  it('compact prints one line per finding', async () => {
+    const harness = makeHarness(files, findings);
+    const result = await run(harness, ['-f', 'compact', 'a.js']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain(
+      '/workspace/proj/a.js: line 1, col 10, error - Missing semicolon. (semi)'
+    );
+    expect(result.stdout.trim().split('\n')).toHaveLength(2);
+  });
+
+  it('json emits one parseable document and writes no diagnostics to stderr', async () => {
+    const harness = makeHarness(files, findings);
+    const result = await run(harness, ['--format', 'json', 'a.js']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
+    const report = JSON.parse(result.stdout);
+    expect(report.summary).toEqual({
+      errors: 1,
+      warnings: 1,
+      filesLinted: 1,
+      fixedFiles: 0,
+    });
+    expect(report.results[0].filePath).toBe('/workspace/proj/a.js');
+    expect(report.results[0].errorCount).toBe(1);
+    expect(report.results[0].warningCount).toBe(1);
+  });
+
+  it('--quiet drops warnings and exits 0 when only warnings remain', async () => {
+    const warningsOnly = (): HelperReply => ({
+      stdout: JSON.stringify([
+        {
+          path: '/workspace/proj/a.js',
+          messages: [
+            { ruleId: 'no-unused-vars', severity: 1, message: 'unused', line: 1, column: 5 },
+          ],
+          output: null,
+          wrapUnfixable: false,
+        },
+      ]),
+      stderr: '',
+      exitCode: 0,
+    });
+    const harness = makeHarness(files, warningsOnly);
+    const result = await run(harness, ['--quiet', 'a.js']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('unused');
+  });
+
+  it('--quiet keeps a fatal parse error, which has no ruleId', async () => {
+    const fatal = (): HelperReply => ({
+      stdout: JSON.stringify([
+        {
+          path: '/workspace/proj/a.js',
+          messages: [
+            { ruleId: null, severity: 1, message: 'Parsing error: boom', line: 1, column: 1 },
+          ],
+          output: null,
+          wrapUnfixable: false,
+        },
+      ]),
+      stderr: '',
+      exitCode: 0,
+    });
+    const harness = makeHarness(files, fatal);
+    const result = await run(harness, ['--quiet', 'a.js']);
+    expect(result.stdout).toContain('Parsing error: boom');
+  });
+
+  it('--max-warnings turns warnings into a failure', async () => {
+    const twoWarnings = (): HelperReply => ({
+      stdout: JSON.stringify([
+        {
+          path: '/workspace/proj/a.js',
+          messages: [
+            { ruleId: 'a', severity: 1, message: 'one', line: 1, column: 1 },
+            { ruleId: 'b', severity: 1, message: 'two', line: 2, column: 1 },
+          ],
+          output: null,
+          wrapUnfixable: false,
+        },
+      ]),
+      stderr: '',
+      exitCode: 0,
+    });
+    const under = await run(makeHarness(files, twoWarnings), ['--max-warnings', '2', 'a.js']);
+    expect(under.exitCode).toBe(0);
+    const over = await run(makeHarness(files, twoWarnings), ['--max-warnings', '1', 'a.js']);
+    expect(over.exitCode).toBe(1);
+    expect(over.stderr).toContain('exceeded the --max-warnings limit of 1');
+  });
+});
+
+describe('eslint skill: fixes', () => {
+  const files = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/a.js': 'var a = 1\n',
+  };
+  const fixed = (): HelperReply => ({
+    stdout: JSON.stringify([
+      {
+        path: '/workspace/proj/a.js',
+        messages: [],
+        output: 'var a = 1;\n',
+        wrapUnfixable: false,
+      },
+    ]),
+    stderr: '',
+    exitCode: 0,
+  });
+
+  it('--fix writes the fixed output back through the shell fs', async () => {
+    const harness = makeHarness(files, fixed);
+    const result = await run(harness, ['--fix', 'a.js']);
+    expect(result.exitCode).toBe(0);
+    expect(harness.read('/workspace/proj/a.js')).toBe('var a = 1;\n');
+    expect(harness.lastRequest()?.fix).toBe(true);
+  });
+
+  it('--fix-dry-run reports the rewrite and leaves the file alone', async () => {
+    const harness = makeHarness(files, fixed);
+    const result = await run(harness, ['--fix-dry-run', 'a.js']);
+    expect(result.exitCode).toBe(0);
+    expect(harness.read('/workspace/proj/a.js')).toBe('var a = 1\n');
+    expect(result.stderr).toContain('--fix would rewrite');
+    // The helper still computes the fix; only the write-back is skipped.
+    expect(harness.lastRequest()?.fix).toBe(true);
+  });
+
+  it('reports a .jsh whose fix rewrote the script wrapper, and does not write it', async () => {
+    const harness = makeHarness(
+      {
+        '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+        '/workspace/proj/s.jsh': 'const x = 1\nreturn x\n',
+      },
+      () => ({
+        stdout: JSON.stringify([
+          {
+            path: '/workspace/proj/s.jsh',
+            messages: [],
+            output: null,
+            wrapUnfixable: true,
+          },
+        ]),
+        stderr: '',
+        exitCode: 0,
+      })
+    );
+    const result = await run(harness, ['--fix', 's.jsh']);
+    expect(result.stderr).toContain('rewrote the script wrapper');
+    expect(harness.read('/workspace/proj/s.jsh')).toBe('const x = 1\nreturn x\n');
+  });
+});
+
+describe('eslint skill: helper failures', () => {
+  const files = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/a.js': 'var a = 1\n',
+  };
+
+  it('rewrites a missing-module failure into the ipk install line', async () => {
+    const harness = makeHarness(files, () => ({
+      stdout: '',
+      stderr: "Error: Cannot find module 'eslint/universal' (run: ipk install eslint)\n",
+      exitCode: 1,
+    }));
+    const result = await run(harness, ['a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('eslint is not installed');
+    expect(result.stderr).toContain('ipk add -g eslint @eslint/js esbuild-wasm');
+  });
+
+  it('names the scoped package when a scoped module is missing', async () => {
+    const harness = makeHarness(files, () => ({
+      stdout: '',
+      stderr: "Error: Cannot find module '@eslint/js' (run: ipk install @eslint/js)\n",
+      exitCode: 1,
+    }));
+    const result = await run(harness, ['a.js']);
+    expect(result.stderr).toContain('@eslint/js is not installed');
+  });
+
+  it('surfaces unparseable helper output with the helper stderr attached', async () => {
+    const harness = makeHarness(files, () => ({
+      stdout: 'not json',
+      stderr: 'something went sideways',
+      exitCode: 0,
+    }));
+    const result = await run(harness, ['a.js']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('could not parse helper output');
+    expect(result.stderr).toContain('something went sideways');
+  });
+
+  it('removes the generated helper from the VFS after the run', async () => {
+    const harness = makeHarness(files, clean);
+    await run(harness, ['a.js']);
+    const helperPath = /^node (\S+) /.exec(harness.calls[0])?.[1];
+    expect(helperPath).toBeTruthy();
+    // It existed while the helper ran, and is gone now.
+    expect(harness.helperSource()).toContain("require('eslint/universal')");
+    expect(harness.read(helperPath as string)).toBeUndefined();
+  });
+});
+
+describe('eslint skill: the helper request never reaches a shell', () => {
+  const files = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/a.js': 'var a = 1\n',
+  };
+
+  it('passes the request as argv, not interpolated into a command string', async () => {
+    const harness = makeHarness(files, clean);
+    await run(harness, ['a.js']);
+    // One argv invocation, and the JSON sits in its own entry where the shell
+    // never parses it.
+    expect(harness.argvCalls.length).toBe(1);
+    const [bin, helper, payload] = harness.argvCalls[0];
+    expect(bin).toBe('node');
+    expect(helper).toMatch(/^\/tmp\/\.eslint-helper-/);
+    expect(JSON.parse(payload)).toMatchObject({ op: 'lint' });
+  });
+
+  it('carries a command-substitution payload through untouched', async () => {
+    // A filename or a piped buffer is attacker-influenced when linting a repo
+    // the user did not write. `$(...)`/backticks survive `JSON.stringify`, and
+    // the shell expands them inside double quotes — so the argv form is the
+    // only safe carrier.
+    const nasty = 'const x = `$(touch /workspace/pwned)`;\n';
+    const harness = makeHarness(files, clean, { stdin: nasty });
+    await run(harness, ['--stdin', '--stdin-filename', 'src/$(id).js']);
+    const payload = harness.argvCalls[0][2];
+    const request = JSON.parse(payload) as { files: { path: string; source: string }[] };
+    expect(request.files[0].source).toBe(nasty);
+    expect(request.files[0].path).toBe('/workspace/proj/src/$(id).js');
+    // Nothing was written, and no second command ran.
+    expect(harness.read('/workspace/pwned')).toBeUndefined();
+    expect(harness.argvCalls.length).toBe(1);
+  });
+
+  it('generates a helper that parses as JavaScript', async () => {
+    // The helper is a template literal, so an unescaped backtick or a real
+    // newline where `\\n` was meant produces a syntactically broken script that
+    // only shows up as an opaque helper failure at runtime.
+    const harness = makeHarness(files, clean);
+    await run(harness, ['a.js']);
+    const helper = harness.helperSource() as string;
+    expect(helper).toBeTruthy();
+    // The helper ends in a top-level `await`, so it only compiles as an async
+    // function body — which is exactly how the realm runs it.
+    expect(() => compileHelper(helper)).not.toThrow();
+  });
+});
+
+/**
+ * Compile a generated helper the way the realm does: as an async function body,
+ * with its `require`, `process` and `console` supplied by the caller.
+ */
+function compileHelper(src: string) {
+  const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor as new (
+    ...a: string[]
+  ) => (...a: unknown[]) => Promise<unknown>;
+  return new AsyncFunction('require', 'process', 'console', src);
+}
+
+type FakeMessage = {
+  ruleId: string | null;
+  severity: number;
+  message: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  fatal?: boolean;
+};
+
+type HelperResult = {
+  path: string;
+  messages: FakeMessage[];
+  output: string | null;
+  wrapUnfixable: boolean;
+};
+
+/**
+ * Run a generated helper against a stub `Linter`, so the helper's OWN logic —
+ * global-ignore evaluation and wrapper-message filtering — is exercised for
+ * real. `minimatch` is the genuine package, since ignore semantics are the
+ * thing under test.
+ */
+async function runGeneratedHelper(
+  helper: string,
+  request: Record<string, unknown>,
+  verify: (source: string, path: string) => FakeMessage[],
+  config: unknown[] = [{ files: ['**/*'], rules: {} }]
+): Promise<HelperResult[]> {
+  const { minimatch } = await import('minimatch');
+  class FakeLinter {
+    verify(source: string, _config: unknown, path: string): FakeMessage[] {
+      return verify(source, path);
+    }
+    verifyAndFix(source: string, _config: unknown, path: string) {
+      return { output: source, fixed: false, messages: verify(source, path) };
+    }
+  }
+  let out = '';
+  const stubRequire = (id: string): unknown => {
+    if (id === 'eslint/universal') return { Linter: FakeLinter };
+    if (id === 'minimatch') return { minimatch };
+    if (id === 'eslint/package.json') return { version: '9.9.9' };
+    if (id === 'fs') return { readFile: async () => '' };
+    return config;
+  };
+  const stubProcess = {
+    argv: ['node', 'helper.js', JSON.stringify(request)],
+    stdout: {
+      write: (s: string) => {
+        out += s;
+      },
+    },
+    stderr: { write: () => {} },
+    exit: (code: number) => {
+      throw new Error(`helper exited ${code}`);
+    },
+  };
+  await compileHelper(helper)(stubRequire, stubProcess, console);
+  return JSON.parse(out) as HelperResult[];
+}
+
+describe('eslint skill: helper global-ignore evaluation', () => {
+  const files = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/a.js': 'var a = 1\n',
+  };
+  const noFindings = () => [];
+
+  async function helperFor(): Promise<string> {
+    const harness = makeHarness(files, clean);
+    await run(harness, ['a.js']);
+    return harness.helperSource() as string;
+  }
+
+  it('re-includes a path restored by a later negated pattern', async () => {
+    // ESLint evaluates ignores in order, so `!src/**/*.js` after `**/*.js`
+    // means `src` IS linted. A short-circuiting matcher skipped it — and a
+    // skipped file makes lint pass, so the gap is invisible.
+    const results = await runGeneratedHelper(
+      await helperFor(),
+      {
+        op: 'lint',
+        basePath: '/workspace/proj',
+        files: [
+          { path: '/workspace/proj/src/app.js', source: 'var a = 1\n', explicit: false },
+          { path: '/workspace/proj/lib/other.js', source: 'var b = 1\n', explicit: false },
+        ],
+      },
+      noFindings,
+      [{ ignores: ['**/*.js', '!src/**/*.js'] }, { files: ['**/*.js'], rules: {} }]
+    );
+    expect(results.map((r) => r.path)).toEqual(['/workspace/proj/src/app.js']);
+  });
+
+  it('still ignores a path re-ignored by a pattern after the negation', async () => {
+    const results = await runGeneratedHelper(
+      await helperFor(),
+      {
+        op: 'lint',
+        basePath: '/workspace/proj',
+        files: [{ path: '/workspace/proj/src/app.js', source: 'var a = 1\n', explicit: false }],
+      },
+      noFindings,
+      [{ ignores: ['**/*.js', '!src/**/*.js', 'src/app.js'] }, { files: ['**/*.js'], rules: {} }]
+    );
+    expect(results).toEqual([]);
+  });
+});
+
+describe('eslint skill: helper drops wrapper-only findings', () => {
+  const files = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/a.js': 'var a = 1\n',
+  };
+
+  async function helperFor(): Promise<string> {
+    const harness = makeHarness(files, clean);
+    await run(harness, ['a.js']);
+    return harness.helperSource() as string;
+  }
+
+  const jshRequest = (source: string) => ({
+    op: 'lint',
+    basePath: '/workspace/proj',
+    files: [{ path: '/workspace/proj/s.jsh', source, explicit: true }],
+  });
+
+  it('drops a finding that lives entirely in the injected prefix', async () => {
+    // This is what `no-unused-vars` did to the old named wrapper: a report on
+    // line 1 of a file whose line 1 is the user's first real statement.
+    const results = await runGeneratedHelper(await helperFor(), jshRequest('const x = 1\n'), () => [
+      {
+        ruleId: 'no-unused-vars',
+        severity: 2,
+        message: "'__slicc' is defined",
+        line: 1,
+        endLine: 1,
+      },
+    ]);
+    expect(results[0].messages).toEqual([]);
+  });
+
+  it('keeps a finding that starts in the wrapper but spans the body', async () => {
+    const results = await runGeneratedHelper(
+      await helperFor(),
+      jshRequest('const x = 1\nconst y = 2\n'),
+      () => [
+        { ruleId: 'indent', severity: 2, message: 'Expected indentation', line: 1, endLine: 3 },
+      ]
+    );
+    expect(results[0].messages).toHaveLength(1);
+    expect(results[0].messages[0].ruleId).toBe('indent');
+  });
+
+  it('drops a finding on the injected suffix line', async () => {
+    // Wrapped: 1 is the prefix, 2-3 the two statements, 4 the empty line left
+    // by the trailing newline, 5 the closing `})`.
+    const results = await runGeneratedHelper(
+      await helperFor(),
+      jshRequest('const x = 1\nconst y = 2\n'),
+      () => [{ ruleId: 'eol-last', severity: 1, message: 'Newline required', line: 5, endLine: 5 }]
+    );
+    expect(results[0].messages).toEqual([]);
+  });
+
+  it('never drops a fatal parse error, even on a wrapper line', async () => {
+    const results = await runGeneratedHelper(await helperFor(), jshRequest('const x = (\n'), () => [
+      {
+        ruleId: null,
+        severity: 2,
+        message: 'Parsing error: Unexpected token',
+        line: 1,
+        fatal: true,
+      },
+    ]);
+    expect(results[0].messages).toHaveLength(1);
+    expect(results[0].messages[0].fatal).toBe(true);
+  });
+
+  it('keeps ordinary body findings and shifts them back by the prefix line', async () => {
+    const results = await runGeneratedHelper(await helperFor(), jshRequest('var a = 1\n'), () => [
+      {
+        ruleId: 'semi',
+        severity: 2,
+        message: 'Missing semicolon',
+        line: 2,
+        column: 10,
+        endLine: 2,
+      },
+    ]);
+    expect(results[0].messages[0].line).toBe(1);
+    expect(results[0].messages[0].column).toBe(10);
+  });
+});
+
+describe('eslint skill: stdin never gets written back', () => {
+  const files = {
+    '/workspace/proj/eslint.config.js': FLAT_CONFIG,
+    '/workspace/proj/src/app.js': 'const real = 1;\n',
+  };
+
+  it('rejects --fix with stdin instead of writing the virtual filename', async () => {
+    // `--stdin-filename` picks a config; it is not a target. Writing to it would
+    // replace a real file with the piped buffer.
+    const harness = makeHarness(files, clean, { stdin: 'var piped = 1\n' });
+    const result = await run(harness, ['--stdin', '--stdin-filename', 'src/app.js', '--fix']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('not available for piped-in code');
+    expect(harness.read('/workspace/proj/src/app.js')).toBe('const real = 1;\n');
+    // It never even reached the helper.
+    expect(harness.argvCalls).toEqual([]);
+  });
+
+  it('prints the fixed buffer for --fix-dry-run with stdin and writes nothing', async () => {
+    const harness = makeHarness(
+      files,
+      (request) => ({
+        stdout: JSON.stringify(
+          (request.files as { path: string }[]).map((f) => ({
+            path: f.path,
+            messages: [],
+            output: 'var piped = 1;\n',
+            wrapUnfixable: false,
+          }))
+        ),
+        stderr: '',
+        exitCode: 0,
+      }),
+      { stdin: 'var piped = 1\n' }
+    );
+    const result = await run(harness, [
+      '--stdin',
+      '--stdin-filename',
+      'src/app.js',
+      '--fix-dry-run',
+    ]);
+    expect(result.stdout).toContain('var piped = 1;');
+    expect(harness.read('/workspace/proj/src/app.js')).toBe('const real = 1;\n');
+  });
+
+  it('does not create the default stdin.js placeholder', async () => {
+    const harness = makeHarness(files, clean, { stdin: 'var piped = 1\n' });
+    await run(harness, ['--stdin']);
+    expect(harness.read('/workspace/proj/stdin.js')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- Depends on #2932. That PR makes `require('eslint/universal')` resolve at all;
     merge it first, or this skill is inert. -->

## Summary

Adds an `eslint` workspace skill that runs **real ESLint** against the VFS, the
way the `biome` command runs real Biome: `ipk`-installed packages, no CDN
fallback, no reimplemented rules. `eslint.jsh` + `SKILL.md`, plus 33 unit tests
that load the shipped script into a real JS realm.

```
$ ipk add -g eslint @eslint/js esbuild-wasm
$ eslint src/
/workspace/src/app.js
  3:18  error  Missing semicolon  semi
  7:1   error  'foo' is not defined  no-undef

✖ 2 problems (2 errors, 0 warnings)
```

## Why

Requested as a peer to the `biome` shim: a second, differently-shaped linter that
agents can actually run on the code they write, including `.jsh`/`.bsh` scripts.

## Approach / Implementation notes

**It builds on `eslint/universal` (`Linter`), not the `eslint` package entry.**
The entry pulls `node:worker_threads` for its multithread lint path, which the
realm does not serve — it is a hard require failure, not a slow path. `Linter` is
the supported browser surface, but it is only the rule engine, so the wrapper has
to own everything the CLI normally does. Each of these was a real, observed
failure against a live harness, not a precaution:

- **Flat-config discovery** (`eslint.config.{js,mjs,cjs}`) walking toward `/`.
  A **directory** target starts the search AT itself — starting at the parent made
  `eslint .` walk straight past the project's own config. TS configs are rejected
  with a precise message rather than a parse error.
- **Global `ignores` are applied by the wrapper.** `Linter.verify` does not apply
  them at all. An explicitly-named file that an ignore pattern covers gets the
  CLI's "ignored because of a matching ignore pattern" warning instead of exiting
  silently, which is the distinction between `explicit` and walked targets.
- **`new Linter({ cwd: basePath })`**, because config `files`/`ignores` resolve
  against the config's directory, not the shell's cwd. Without it every
  out-of-cwd target matched nothing.
- **Concrete `filePatterns` derived from the extension list** for `--rule` with
  `--no-config-lookup`. ESLint treats a bare `**/*` as universal and opts no file
  in, so the honest-looking pattern reports "No matching configuration found".
- **`--version` answers before any target or config resolution**, so it works in
  an unconfigured tree (it exited 2 there while the branch sat after resolution).
- **`.jsh`/`.bsh` support** mirrors the biome shim: the AsyncFunction body is
  wrapped before parsing and spans shift back. `--fix` output is unwrapped by
  stripping the exact prefix/suffix rather than by lines, so a fix is
  byte-lossless even with top-level `await`/`return` — a line-based unwrap added a
  stray newline. The same exactness doubles as the safety check: if the prefix or
  suffix is gone, the wrapper rewrote its own scaffold and the unwrap returns
  `null` instead of writing a corrupted file.
- The generated realm helper embeds the discovered config path as a `require()`
  **literal**; a runtime path string has no module-graph edge and would not
  resolve.

stylish/json/compact reporters, `--fix`, `--fix-dry-run`, `--quiet`,
`--max-warnings`, `--ext`, and stdin all behave like the CLI. Temp helper files
are cleaned up. `node_modules`/`.git` are skipped when walking.

**Bundle budget**: the webapp total-JS limit goes 25 -> 25.1 MB. The skill is
inlined into the kernel-worker graph and the previous ceiling had no headroom
left (it failed by 2.64 kB). The first-load delta gate passes unchanged, so this
is payload, not boot cost.

## Cross-cutting impact

- **Floats exercised**: all of them. The skill is a `.jsh` script in
  `packages/vfs-root/workspace/skills/`, bundled into the VFS and executed in the
  kernel-worker JS realm — the one shared dynamic-code path, so CLI, hosted leader
  tab, Electron and Sliccstart get identical behavior with no per-float wiring.
- **Depends on #2932.** Without the deferred nested-require fix,
  `require('eslint/universal')` dies on `debug`'s optional `supports-color`;
  without `util.deprecate`, `@eslint/eslintrc` throws at module scope. This PR
  adds no runtime code of its own.
- **Additive only**: a new skill directory and a new test file. No existing
  command, tool, or contract changes. `eslint` is not registered as a shell
  built-in, so nothing shadows an `ipk`-installed `eslint` bin.
- **`@eslint/js` must be installed separately** — ESLint 10 no longer bundles it.
  `SKILL.md` states that in the install line, because the failure otherwise
  surfaces as `Cannot find module '@eslint/js'` from the user's own config.
- No persisted state, no migration, no UI, no new repo dependency.

## Test plan

- [x] `npm run verify` — all 8 checks pass (incl. `lint:skills` over the new
      `SKILL.md`)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 20366 passing, 0 failures
- [x] `npm run test:coverage`
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — passes with the 25.1 MB limit; first-load delta OK
- [x] New behavior covered by unit tests:
      `npx vitest run packages/webapp/tests/shell/eslint-skill-jsh.test.ts` — 33
      tests that load the **shipped** `eslint.jsh` into a real realm with a fake
      `exec` standing in for the helper (arg parsing, config discovery from files
      and directories, TS-config rejection, target expansion, ignore handling,
      the three reporters, `--fix` write-back, `.jsh` wrap/unwrap, exit codes)
- [x] Manual smoke against a **live harness** driven through the `slicc` CLI, with
      eslint@10.10.0 / `@eslint/js`@10.0.1 / esbuild-wasm@0.28.2 installed via
      `ipk add -g` (isolated ports; production `:5710`/`:9222` untouched):
      real diagnostics with byte ranges, real fixes written back through the VFS,
      flat ESM and `.cjs` configs, `--rule` with `--no-config-lookup`, stdin,
      `--quiet`, `--max-warnings`, `--fix-dry-run`, global ignores, an
      explicitly-named ignored file, and `--fix` on a real `.jsh`
      (`x_search.jsh`) verified byte-exact.

**Pre-existing failures**: none.

## Documentation

- [x] `packages/vfs-root/workspace/skills/eslint/SKILL.md` — install
      prerequisites, commands, flat-config discovery, ignore semantics,
      `.jsh`/`.bsh` guidance (including the recommended `languageOptions.globals`
      block for the shell builtins), reporters, and exit codes

`docs/shell-reference.md` is deliberately untouched: `eslint` is an installed
skill, not a registered shell command, so it does not belong in the per-command
table.

## Risk & rollback

Contained. Deleting the skill directory removes the feature; nothing else reads
it. The skill is inert until the user runs `ipk add`, so an install that never
does is unaffected apart from the bundled bytes.

The one thing a reviewer should check by hand is the `.jsh` `--fix` path, since a
bad unwrap would corrupt a user's script. The wrapper refuses to write when its
scaffold markers are missing, and the byte-exact `x_search.jsh` fix above is the
evidence, but it is worth confirming against a `.jsh` of your own.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] New agent-facing surface is documented in its `SKILL.md`
- [x] Checked the leader/follower/worker paths: one bundled skill on the shared
      realm path, no float-specific handler to mirror
