### PR TITLE
fix(git): reset index and worktree on checkout -b start-point

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -234,6 +234,11 @@ git fetch origin feature
 git checkout -b feature origin/feature
 ```
 
+`git checkout -b <new> <start-point>` and `git checkout <branch>` reset the index and
+working tree to the start-point, matching real git: files tracked on the previous branch
+and absent from the target are removed, so they cannot ride along on the next commit
+(issue #2928). `git checkout -- <paths>` is file restoration and does not switch branches.
+
 Use `--depth <n>` to request a different history depth.
 
 ### Git revision resolution

--- a/packages/webapp/src/git/commands/checkout.ts
+++ b/packages/webapp/src/git/commands/checkout.ts
@@ -44,15 +44,31 @@ export async function checkout(
     const afterB = args.slice(bIdx + 1).filter((a) => !a.startsWith('-'));
     const startPoint = afterB.length > 1 ? afterB[1] : undefined;
     try {
+      // isomorphic-git's `branch({ checkout: true })` only moves HEAD — it
+      // leaves the previous branch's index and worktree in place, so the next
+      // commit silently includes those files (#2928). Create the ref, then
+      // materialize the start-point through checkoutRef().
       await git.branch({
         fs: ctx.lfs,
         dir: cwd,
         ref,
         object: startPoint,
-        checkout: true,
+        checkout: false,
         force,
       });
     } catch (err: unknown) {
+      return formatCheckoutError(err, ref);
+    }
+    try {
+      await checkoutRef(ctx, cwd, ref, force);
+    } catch (err: unknown) {
+      if (!force) {
+        try {
+          await git.deleteBranch({ fs: ctx.lfs, dir: cwd, ref });
+        } catch {
+          // Keep the checkout error; an unused ref is less surprising.
+        }
+      }
       return formatCheckoutError(err, ref);
     }
     await ctx.fs.flush();
@@ -64,7 +80,7 @@ export async function checkout(
   }
 
   try {
-    await git.checkout({ fs: ctx.lfs, cache: ctx.cache, dir: cwd, ref, force });
+    await checkoutRef(ctx, cwd, ref, force);
   } catch (err: unknown) {
     return formatCheckoutError(err, ref);
   }
@@ -79,6 +95,94 @@ export async function checkout(
     stderr: '',
     exitCode: 0,
   };
+}
+
+/**
+ * Switch HEAD to `ref` and make the index + worktree match that tree.
+ * isomorphic-git checkout updates HEAD (and often the index) but can leave
+ * paths from the previous branch staged as additions, and can skip rewriting
+ * a worktree file whose size did not change. Drop leftovers and, when the
+ * target commit differs, write the target blobs so the next commit cannot
+ * absorb the old tree (#2928).
+ */
+async function checkoutRef(
+  ctx: GitCommandContext,
+  cwd: string,
+  ref: string,
+  force: boolean
+): Promise<void> {
+  let previousHead: string | undefined;
+  try {
+    previousHead = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: 'HEAD' });
+  } catch {
+    previousHead = undefined;
+  }
+  const previous = new Set(await git.listFiles({ fs: ctx.lfs, cache: ctx.cache, dir: cwd }));
+  await git.checkout({ fs: ctx.lfs, cache: ctx.cache, dir: cwd, ref, force });
+  const targetOid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
+  const target = new Set(
+    await git.listFiles({ fs: ctx.lfs, cache: ctx.cache, dir: cwd, ref: targetOid })
+  );
+  await dropPathsAbsentFromTarget(ctx, cwd, previous, target);
+  // Same commit (`checkout -b feat` with no start-point): keep local edits.
+  if (!force && previousHead === targetOid) return;
+  await materializeWorktree(ctx, cwd, targetOid, previous, target);
+}
+
+async function dropPathsAbsentFromTarget(
+  ctx: GitCommandContext,
+  cwd: string,
+  previous: Set<string>,
+  target: Set<string>
+): Promise<void> {
+  for (const filepath of previous) {
+    if (target.has(filepath)) continue;
+    try {
+      await git.remove({ fs: ctx.lfs, cache: ctx.cache, dir: cwd, filepath });
+    } catch {
+      // already unindexed
+    }
+    try {
+      await ctx.fs.rm(`${cwd}/${filepath}`);
+    } catch {
+      // already unlinked
+    }
+  }
+}
+
+async function materializeWorktree(
+  ctx: GitCommandContext,
+  cwd: string,
+  oid: string,
+  previous: Set<string>,
+  files: Set<string>
+): Promise<void> {
+  for (const filepath of files) {
+    // Paths git.checkout created (including symlinks) already have the right
+    // type. Only rewrite files that existed on the previous tree — those are
+    // the same-size blobs isomorphic-git can skip.
+    if (!previous.has(filepath)) continue;
+    const full = `${cwd}/${filepath}`;
+    try {
+      const st = await ctx.fs.lstat(full);
+      if (st.type === 'symlink' || st.type === 'directory') continue;
+    } catch {
+      continue;
+    }
+    const { blob } = await git.readBlob({
+      fs: ctx.lfs,
+      cache: ctx.cache,
+      dir: cwd,
+      oid,
+      filepath,
+    });
+    const slashIdx = filepath.lastIndexOf('/');
+    if (slashIdx !== -1) {
+      await ctx.fs.mkdir(`${cwd}/${filepath.slice(0, slashIdx)}`, { recursive: true });
+    }
+    await ctx.fs.writeFile(full, blob);
+    await git.resetIndex({ fs: ctx.lfs, cache: ctx.cache, dir: cwd, filepath, ref: oid });
+  }
 }
 
 /**

--- a/packages/webapp/tests/git/git-checkout-start-point.test.ts
+++ b/packages/webapp/tests/git/git-checkout-start-point.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #2928 — `git checkout -b <new> <start-point>` (and `git checkout <branch>`)
+ * must reset the index and working tree to the start-point. isomorphic-git's
+ * branch+checkout only moves HEAD, so files from the previous branch used to
+ * stay staged and ride along on the next commit.
+ */
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GitCommands } from '../../src/git/git-commands.js';
+
+describe('git checkout start-point tree (#2928)', () => {
+  let git: GitCommands;
+  let fs: VirtualFS;
+  let id = 0;
+
+  beforeEach(async () => {
+    const suffix = id++;
+    fs = await VirtualFS.create({ dbName: `git-checkout-sp-${suffix}`, wipe: true });
+    git = new GitCommands({
+      fs,
+      authorName: 'Test User',
+      authorEmail: 'test@example.com',
+      globalDbName: `git-checkout-sp-global-${suffix}`,
+    });
+  });
+
+  /** Issue repro: commit `base.txt` on main, `feature.txt` on feature. */
+  async function seedFeatureOffMain(): Promise<void> {
+    await git.execute(['init'], '/project');
+    await fs.writeFile('/project/base.txt', 'base\n');
+    await git.execute(['add', 'base.txt'], '/project');
+    await git.execute(['commit', '-m', 'base'], '/project');
+    await git.execute(['checkout', '-b', 'feature'], '/project');
+    await fs.writeFile('/project/feature.txt', 'f\n');
+    await git.execute(['add', 'feature.txt'], '/project');
+    await git.execute(['commit', '-m', 'feat'], '/project');
+  }
+
+  async function expectCleanMainTree(): Promise<void> {
+    const status = await git.execute(['status', '-s'], '/project');
+    expect(status.exitCode).toBe(0);
+    expect(status.stdout.trim()).toBe('');
+    expect(await fs.exists('/project/feature.txt')).toBe(false);
+    expect(await fs.readTextFile('/project/base.txt')).toBe('base\n');
+    expect((await git.execute(['ls-files'], '/project')).stdout).toBe('base.txt\n');
+  }
+
+  /** A commit that stages only `base.txt` must not absorb `feature.txt`. */
+  async function expectScopedBaseCommit(): Promise<void> {
+    await fs.writeFile('/project/base.txt', 'base\nmore\n');
+    await git.execute(['add', 'base.txt'], '/project');
+    const commit = await git.execute(['commit', '-m', 'only base.txt'], '/project');
+    expect(commit.exitCode).toBe(0);
+
+    const names = (await git.execute(['ls-tree', '-r', '--name-only', 'HEAD'], '/project')).stdout;
+    expect(names).toBe('base.txt\n');
+    expect(names).not.toContain('feature.txt');
+
+    const show = await git.execute(['show', '--stat', '--format=%s', 'HEAD'], '/project');
+    expect(show.stdout).toContain('only base.txt');
+    expect(show.stdout).not.toContain('feature.txt');
+  }
+
+  it('checkout -b fix main from feature leaves a clean start-point tree', async () => {
+    await seedFeatureOffMain();
+
+    const result = await git.execute(['checkout', '-b', 'fix', 'main'], '/project');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Switched to a new branch 'fix'");
+    expect((await git.execute(['branch', '--show-current'], '/project')).stdout.trim()).toBe('fix');
+
+    await expectCleanMainTree();
+    await expectScopedBaseCommit();
+  });
+
+  it('checkout main from feature leaves a clean start-point tree', async () => {
+    await seedFeatureOffMain();
+
+    const result = await git.execute(['checkout', 'main'], '/project');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Switched to branch 'main'");
+    expect((await git.execute(['branch', '--show-current'], '/project')).stdout.trim()).toBe(
+      'main'
+    );
+
+    await expectCleanMainTree();
+    await expectScopedBaseCommit();
+  });
+
+  it('checkout to another branch keeps tracked symlinks as links', async () => {
+    await git.execute(['init'], '/project');
+    await fs.writeFile('/project/data.bin', 'payload\n');
+    await fs.symlink('data.bin', '/project/link.bin');
+    await git.execute(['add', 'data.bin', 'link.bin'], '/project');
+    await git.execute(['commit', '-m', 'main'], '/project');
+    await git.execute(['checkout', '-b', 'feature'], '/project');
+    await fs.writeFile('/project/extra.txt', 'x\n');
+    await git.execute(['add', 'extra.txt'], '/project');
+    await git.execute(['commit', '-m', 'feat'], '/project');
+
+    const result = await git.execute(['checkout', 'main'], '/project');
+    expect(result.exitCode).toBe(0);
+    const st = await fs.lstat('/project/link.bin');
+    expect(st.type).toBe('symlink');
+    expect(await fs.readlink('/project/link.bin')).toBe('data.bin');
+    expect(await fs.exists('/project/extra.txt')).toBe(false);
+  });
+
+  it('checkout -b without a start-point keeps uncommitted edits', async () => {
+    await git.execute(['init'], '/project');
+    await fs.writeFile('/project/base.txt', 'base\n');
+    await git.execute(['add', 'base.txt'], '/project');
+    await git.execute(['commit', '-m', 'base'], '/project');
+    await fs.writeFile('/project/base.txt', 'dirty\n');
+
+    const result = await git.execute(['checkout', '-b', 'topic'], '/project');
+    expect(result.exitCode).toBe(0);
+    expect(await fs.readTextFile('/project/base.txt')).toBe('dirty\n');
+    expect((await git.execute(['status', '-s'], '/project')).stdout).toContain('base.txt');
+  });
+});

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -160,6 +160,11 @@ describe('GitCommands', () => {
     // Branch HEAD should point at the start point, not at current main
     const headResult = await git.execute(['log', '--format', '%H', '-1'], '/project');
     expect(headResult.stdout.trim()).toBe(firstCommit);
+
+    // Index and worktree match the start-point tree (no leftover `new.txt`).
+    expect(await vfs.readTextFile('/project/file.txt')).toBe('v1');
+    expect(await vfs.exists('/project/new.txt')).toBe(false);
+    expect((await git.execute(['status', '-s'], '/project')).stdout.trim()).toBe('');
   });
 
   it('sets and gets config', async () => {


### PR DESCRIPTION
Closes #2928

## Summary

`git checkout -b <new> <start-point>` moved HEAD to the start-point but left files from the previous branch in the working tree **and staged in the index**. The next `git commit` silently included them even when `git add` named other paths. Checkout now materializes the start-point tree so status is empty and a later commit of only `base.txt` contains only `base.txt`. The same reconcile runs for `git checkout <branch>`.

## Why

Real-world: a slicc-website one-line lint PR absorbed ~14 unrelated files / ~5,400 lines because the branch was created this way. `git add <explicit path>` and a green CI check both looked scoped; only the merged commit's file list showed the extras.

### Repro

1. Init, commit `base.txt` on `main`, `checkout -b feature`, commit `feature.txt`.
2. `git checkout -b fix main`.
3. Expected: `git status -s` empty, `feature.txt` absent.
4. Actual: `A  feature.txt`. Then `echo more >> base.txt && git add base.txt && git commit -m "only base.txt"` still contains `feature.txt`.

## Approach / Implementation notes

- isomorphic-git's `branch({ checkout: true })` only updates HEAD. Create the ref without switching, then `git.checkout` the new branch so the start-point tree is written.
- After checkout, drop index/worktree paths that were tracked on the old HEAD and are absent from the target (the leftover staged additions).
- When the target commit differs, rewrite previously tracked regular files from the target blobs. isomorphic-git can skip a same-size content change (`v1` vs `v2`), leaving a dirty worktree that `status` also misses.
- Same-commit `checkout -b feat` (no start-point) still keeps uncommitted edits.
- Tracked symlinks are left as links; `git checkout -- <paths>` is unchanged.
- `#2863` (`commit -F`) and `rev-parse <ref>^{tree}` are out of scope.

## Cross-cutting impact

- **Floats exercised**: CLI and Chrome extension share `packages/webapp/src/git/commands/checkout.ts` (kernel worker). No float-specific fork.
- **Shell contexts**: the git shim is the same in side panel, offscreen, and sandbox.
- **Other callers**: `rebase` / `merge` / `clone` call isomorphic-git `checkout` directly, not this command wrapper.
- **Bundle size**: worker first-load +1.0 kB vs merge-base (under the 5 kB allowance).

## Test plan

- [x] `npm run verify` (pre-push lint gate, including boy-scout-debt)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/git` — 586 passing, including new `#2928` repros and existing `git-corpus-harness` `checkout -b`
- [x] Isolated re-runs of full-suite timeouts (rebase, pyodide `slicc-fs-module`, exemptions) — those were 5s budget exhaustion under parallel Swift compile, not this change
- [x] `npm run test:coverage:webapp` — floors held
- [x] `npm run build` (includes chrome-extension)
- [x] `npm run bundle-size`
- [x] New behavior covered in `packages/webapp/tests/git/git-checkout-start-point.test.ts`
- [x] N/A — no UI change; git shim only

**Pre-existing failures** (unrelated, load-sensitive 5s timeouts when the full suite ran next to `npm run build`): `slicc-fs-module` pyodide writes, two rebase cases, two `check-touched-exemptions` float-probe cases. All pass in isolation.

## Documentation

- [x] `docs/shell-reference.md` — `checkout -b <new> <start-point>` resets index + worktree
- [x] No README / CLAUDE.md / skill changes needed (matches real git)

## Risk & rollback

- Blast radius: virtual `git checkout` / `checkout -b` in every float. Wrong-tree commits were the production failure mode; this makes checkout match real git.
- Rollback: revert this PR. No persisted-state migration.