### PR TITLE
fix(ipk): honor existing dep sections and --save-dev on install

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -409,6 +409,13 @@ global prefix at `/shared/lib/node_modules`, records direct dependencies in
 global executable wins even when the invoking cwd has a same-named local package).
 Local project installs are unchanged: without `-g`,
 packages still land in `<cwd>/node_modules` and update the nearest project
+`package.json`. Named installs write to the section the package already occupies
+(`dependencies`, `devDependencies`, `optionalDependencies`, or `peerDependencies`)
+instead of always adding a `dependencies` entry. `-D` / `--save-dev` records new
+packages in `devDependencies`. A bare `ipk install <pkg>` that is already
+declared is resolved against that existing range, not latest. Unknown install
+flags are rejected (`ipk: unknown flag: --x`) rather than dropped. The no-arg
+form (`ipk install`) still installs declared ranges without rewriting
 `package.json`. Module resolution and `ipx`/`npx` also search the global tree after
 the cwd-relative `node_modules` walk.
 

--- a/packages/vfs-root/workspace/skills/package-execution/SKILL.md
+++ b/packages/vfs-root/workspace/skills/package-execution/SKILL.md
@@ -25,10 +25,12 @@ Already-installed packages, locally resolved bins, and unmapped package names ke
 
 ## Installing and removing packages
 
-`ipk install <pkg>` (also `npm install`, `npm i`, `ipk add`) installs into `<cwd>/node_modules` and records the package in the nearest `package.json`. `ipk install -g <pkg>` installs into the shared global prefix at `/shared/lib/node_modules`, records direct dependencies in `/shared/lib/package.json`, and publishes PATH-visible `.jsh` delegators under `/shared/bin` for package bins.
+`ipk install <pkg>` (also `npm install`, `npm i`, `ipk add`) installs into `<cwd>/node_modules` and records the package in the nearest `package.json` — in the section it already occupies, or in `dependencies` if it is new. `ipk install -D <pkg>` / `npm install --save-dev <pkg>` records new packages in `devDependencies`. A bare name that is already declared is resolved against that existing range, not latest. Unknown install flags fail instead of being ignored. `ipk install` with no package names installs declared `dependencies` and `devDependencies` without rewriting `package.json`. `ipk install -g <pkg>` installs into the shared global prefix at `/shared/lib/node_modules`, records direct dependencies in `/shared/lib/package.json`, and publishes PATH-visible `.jsh` delegators under `/shared/bin` for package bins.
 
 ```bash
 ipk install lodash              # local project install
+ipk install -D eslint           # record in devDependencies
+npm install --save-dev eslint@8.57.1
 ipk install -g typescript       # global install (shared prefix + PATH bin)
 npm uninstall -g typescript     # remove from global manifest and reconcile tree
 npm list -g                     # list direct global dependencies

--- a/packages/webapp/src/shell/ipk/installer.ts
+++ b/packages/webapp/src/shell/ipk/installer.ts
@@ -606,8 +606,8 @@ export async function installPackages(
 
   const rootDependencies: Record<string, string> = {};
   if (globalInstall) {
-    for (const [name, range] of Object.entries(existingManifest.dependencies ?? {})) {
-      rootDependencies[name] = range;
+    for (const entry of collectManagedEntries(existingManifest)) {
+      rootDependencies[entry.name] = entry.range;
     }
   }
   for (const direct of directs) {
@@ -691,24 +691,41 @@ interface ManifestEntry {
   range: string;
 }
 
+function addNamedRanges(
+  combined: Map<string, string>,
+  bag: Record<string, string> | undefined
+): void {
+  if (!bag || typeof bag !== 'object') return;
+  for (const [name, range] of Object.entries(bag)) {
+    if (typeof name === 'string' && typeof range === 'string') {
+      combined.set(name, range);
+    }
+  }
+}
+
+/**
+ * No-arg `ipk install` still reads only dependencies + devDependencies so that
+ * path stays non-destructive and does not start installing optional/peer.
+ * Later bags overwrite earlier ones (dependencies win over devDependencies).
+ */
 function collectManifestEntries(manifest: ProjectManifest): ManifestEntry[] {
   const combined = new Map<string, string>();
-  const devDeps = manifest.devDependencies;
-  if (devDeps && typeof devDeps === 'object') {
-    for (const [name, range] of Object.entries(devDeps)) {
-      if (typeof name === 'string' && typeof range === 'string') {
-        combined.set(name, range);
-      }
-    }
-  }
-  const deps = manifest.dependencies;
-  if (deps && typeof deps === 'object') {
-    for (const [name, range] of Object.entries(deps)) {
-      if (typeof name === 'string' && typeof range === 'string') {
-        combined.set(name, range);
-      }
-    }
-  }
+  addNamedRanges(combined, manifest.devDependencies);
+  addNamedRanges(combined, manifest.dependencies);
+  return Array.from(combined.entries()).map(([name, range]) => ({ name, range }));
+}
+
+/**
+ * Direct ranges for tree planning and listing: every section named installs
+ * may write to. Preference matches `chooseSaveSection` (dev > optional >
+ * peer > dependencies) so a later bag overwrites an earlier one.
+ */
+function collectManagedEntries(manifest: ProjectManifest): ManifestEntry[] {
+  const combined = new Map<string, string>();
+  addNamedRanges(combined, manifest.dependencies);
+  addNamedRanges(combined, manifest.peerDependencies);
+  addNamedRanges(combined, manifest.optionalDependencies);
+  addNamedRanges(combined, manifest.devDependencies);
   return Array.from(combined.entries()).map(([name, range]) => ({ name, range }));
 }
 
@@ -856,7 +873,7 @@ export async function syncGlobalInstallTree(
 ): Promise<void> {
   const manifest =
     manifestOverride ?? (await readJsonOr<ProjectManifest>(fs, GLOBAL_PACKAGE_JSON, {}));
-  const entries = collectManifestEntries(manifest);
+  const entries = collectManagedEntries(manifest);
 
   if (entries.length === 0) {
     await removeIfExists(fs, GLOBAL_NODE_MODULES);
@@ -961,7 +978,7 @@ async function syncLocalInstallTree(
 ): Promise<void> {
   const manifestPath = joinPath(cwd, 'package.json');
   const manifest = manifestOverride ?? (await readJsonOr<ProjectManifest>(fs, manifestPath, {}));
-  const entries = collectManifestEntries(manifest);
+  const entries = collectManagedEntries(manifest);
   const modulesDir = joinPath(cwd, 'node_modules');
 
   if (entries.length === 0) {
@@ -993,16 +1010,15 @@ export interface GlobalPackageListing {
 
 export async function listGlobalPackages(fs: VirtualFS): Promise<GlobalPackageListing[]> {
   const manifest = await readJsonOr<ProjectManifest>(fs, GLOBAL_PACKAGE_JSON, {});
-  const deps = manifest.dependencies ?? {};
+  const entries = collectManagedEntries(manifest);
   const out: GlobalPackageListing[] = [];
-  for (const [name, range] of Object.entries(deps)) {
-    if (typeof name !== 'string' || typeof range !== 'string') continue;
-    const installedPath = joinPath(packageDirIn(GLOBAL_NODE_MODULES, name), 'package.json');
+  for (const entry of entries) {
+    const installedPath = joinPath(packageDirIn(GLOBAL_NODE_MODULES, entry.name), 'package.json');
     const installed = await readJsonOr<{ version?: string }>(fs, installedPath, {});
     out.push({
-      name,
+      name: entry.name,
       version: typeof installed.version === 'string' ? installed.version : '?',
-      range,
+      range: entry.range,
     });
   }
   out.sort((a, b) => a.name.localeCompare(b.name));
@@ -1016,7 +1032,7 @@ export async function listLocalPackages(
   const manifestPath = joinPath(cwd, 'package.json');
   if (!(await fs.exists(manifestPath))) return [];
   const manifest = await readJsonOr<ProjectManifest>(fs, manifestPath, {});
-  const entries = collectManifestEntries(manifest);
+  const entries = collectManagedEntries(manifest);
   const modulesDir = joinPath(cwd, 'node_modules');
   const out: GlobalPackageListing[] = [];
   for (const entry of entries) {

--- a/packages/webapp/src/shell/ipk/installer.ts
+++ b/packages/webapp/src/shell/ipk/installer.ts
@@ -8,7 +8,8 @@
  * dependent's own `node_modules`), creates `node_modules/.bin` shims for every
  * declared bin (direct AND transitive) without leaving phantom entries for
  * bin-less packages, and records only the directly-requested packages in the
- * project `package.json` (transitive dependencies are NOT promoted).
+ * package.json section they already occupy (or `devDependencies` with
+ * `--save-dev`). Transitive dependencies are NOT promoted.
  *
  * Pure and individually testable: takes an injected `SecureFetch` and
  * `VirtualFS`, so it works in the worker realm across all floats and
@@ -38,6 +39,8 @@ export interface InstallOptions {
   timeoutMs?: number;
   /** Install into `/shared/lib/node_modules` instead of `<cwd>/node_modules`. */
   global?: boolean;
+  /** Record named installs in `devDependencies` (npm `--save-dev` / `-D`). */
+  saveDev?: boolean;
 }
 
 export interface InstallResult {
@@ -164,7 +167,86 @@ interface ProjectManifest {
   version?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
   [key: string]: unknown;
+}
+
+type DependencySection =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'optionalDependencies'
+  | 'peerDependencies';
+
+const DEPENDENCY_SECTIONS: readonly DependencySection[] = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+];
+
+function bagHasName(
+  bag: Record<string, string> | undefined,
+  name: string
+): bag is Record<string, string> {
+  return bag !== undefined && Object.hasOwn(bag, name);
+}
+
+/**
+ * Section a named install should update. Prefer the more specific existing
+ * section so a package already in `devDependencies` is not duplicated under
+ * `dependencies` (#2925). `--save-dev` always targets `devDependencies`.
+ */
+function chooseSaveSection(
+  manifest: ProjectManifest,
+  name: string,
+  saveDev: boolean
+): DependencySection {
+  if (saveDev) return 'devDependencies';
+  if (bagHasName(manifest.devDependencies, name)) return 'devDependencies';
+  if (bagHasName(manifest.optionalDependencies, name)) return 'optionalDependencies';
+  if (bagHasName(manifest.peerDependencies, name)) return 'peerDependencies';
+  return 'dependencies';
+}
+
+function declaredRange(manifest: ProjectManifest, name: string): string | undefined {
+  const section = chooseSaveSection(manifest, name, false);
+  const range = manifest[section]?.[name];
+  return typeof range === 'string' && range.trim() !== '' ? range : undefined;
+}
+
+function applyDeclaredRange(parsed: ParsedSpec, manifest: ProjectManifest): ParsedSpec {
+  if (parsed.range.trim() !== '') return parsed;
+  const existing = declaredRange(manifest, parsed.name);
+  if (existing === undefined) return parsed;
+  return { name: parsed.name, range: existing };
+}
+
+function writeDirectDependencies(
+  existing: ProjectManifest,
+  entries: Array<{ name: string; range: string; section: DependencySection }>
+): ProjectManifest {
+  const bags: Record<DependencySection, Record<string, string>> = {
+    dependencies: { ...(existing.dependencies ?? {}) },
+    devDependencies: { ...(existing.devDependencies ?? {}) },
+    optionalDependencies: { ...(existing.optionalDependencies ?? {}) },
+    peerDependencies: { ...(existing.peerDependencies ?? {}) },
+  };
+  const written = new Set<DependencySection>();
+  for (const entry of entries) {
+    for (const section of DEPENDENCY_SECTIONS) {
+      delete bags[section][entry.name];
+    }
+    bags[entry.section][entry.name] = entry.range;
+    written.add(entry.section);
+  }
+  const next: ProjectManifest = { ...existing };
+  for (const section of DEPENDENCY_SECTIONS) {
+    if (existing[section] !== undefined || written.has(section)) {
+      next[section] = bags[section];
+    }
+  }
+  return next;
 }
 
 interface InstalledPackageManifest {
@@ -195,7 +277,8 @@ interface ResolvedDirect {
 
 async function stageResolveRoots(
   specs: string[],
-  supplier: PackumentSupplier
+  supplier: PackumentSupplier,
+  existingManifest?: ProjectManifest
 ): Promise<{ directs: ResolvedDirect[]; errors: InstallFailure[] }> {
   const directs: ResolvedDirect[] = [];
   const errors: InstallFailure[] = [];
@@ -208,6 +291,9 @@ async function stageResolveRoots(
     } catch (err) {
       errors.push({ spec, error: toError(err) });
       continue;
+    }
+    if (existingManifest) {
+      parsed = applyDeclaredRange(parsed, existingManifest);
     }
     if (seen.has(parsed.name)) {
       // Later specs for the same name override earlier ones.
@@ -483,16 +569,11 @@ async function reconcileRootBinShims(fs: VirtualFS, modulesDir: string): Promise
 async function recordDirectDependencies(
   fs: VirtualFS,
   cwd: string,
-  entries: Array<{ name: string; range: string }>
+  entries: Array<{ name: string; range: string; section: DependencySection }>
 ): Promise<string> {
   const manifestPath = joinPath(cwd, 'package.json');
   const existing = await readJsonOr<ProjectManifest>(fs, manifestPath, {});
-  const next: ProjectManifest = { ...existing };
-  const deps = { ...(existing.dependencies ?? {}) };
-  for (const entry of entries) {
-    deps[entry.name] = entry.range;
-  }
-  next.dependencies = deps;
+  const next = writeDirectDependencies(existing, entries);
   await fs.writeFile(manifestPath, `${JSON.stringify(next, null, 2)}\n`);
   return manifestPath;
 }
@@ -501,21 +582,31 @@ export async function installPackages(
   specs: string[],
   options: InstallOptions
 ): Promise<InstallPackagesResult> {
-  const { fs, fetch, cwd, timeoutMs, global: globalInstall = false } = options;
+  const { fs, fetch, cwd, timeoutMs, global: globalInstall = false, saveDev = false } = options;
   if (specs.length === 0) {
     return { results: [], errors: [] };
   }
 
+  const manifestRoot = globalInstall ? GLOBAL_NPM_PREFIX : cwd;
+  const existingManifest = await readJsonOr<ProjectManifest>(
+    fs,
+    joinPath(manifestRoot, 'package.json'),
+    {}
+  );
+
   const { supplier } = buildPackumentSupplier(fetch, timeoutMs);
-  const { directs, errors: stageErrors } = await stageResolveRoots(specs, supplier);
+  const { directs, errors: stageErrors } = await stageResolveRoots(
+    specs,
+    supplier,
+    existingManifest
+  );
   if (directs.length === 0) {
     return { results: [], errors: stageErrors };
   }
 
   const rootDependencies: Record<string, string> = {};
   if (globalInstall) {
-    const existingGlobal = await readJsonOr<ProjectManifest>(fs, GLOBAL_PACKAGE_JSON, {});
-    for (const [name, range] of Object.entries(existingGlobal.dependencies ?? {})) {
+    for (const [name, range] of Object.entries(existingManifest.dependencies ?? {})) {
       rootDependencies[name] = range;
     }
   }
@@ -544,9 +635,12 @@ export async function installPackages(
   const records = directs.map((d) => {
     const node = plan.root[d.parsed.name];
     if (!node) throw new Error(`installer: resolved node missing for ${d.parsed.name}`);
-    return { name: d.parsed.name, range: chooseSavedRange(d.parsed, node.version) };
+    return {
+      name: d.parsed.name,
+      range: chooseSavedRange(d.parsed, node.version),
+      section: chooseSaveSection(existingManifest, d.parsed.name, saveDev),
+    };
   });
-  const manifestRoot = globalInstall ? GLOBAL_NPM_PREFIX : cwd;
   const manifestPath = await recordDirectDependencies(fs, manifestRoot, records);
 
   const results: InstallResult[] = directs.map((d) => {
@@ -683,20 +777,24 @@ export async function installFromManifest(
 }
 
 function packageListedInManifest(manifest: ProjectManifest, name: string): boolean {
-  return name in (manifest.dependencies ?? {}) || name in (manifest.devDependencies ?? {});
+  return DEPENDENCY_SECTIONS.some((section) => bagHasName(manifest[section], name));
 }
 
 function manifestWithoutPackages(
   manifest: ProjectManifest,
   names: ReadonlySet<string>
 ): ProjectManifest {
-  const dependencies = { ...(manifest.dependencies ?? {}) };
-  const devDependencies = { ...(manifest.devDependencies ?? {}) };
-  for (const name of names) {
-    delete dependencies[name];
-    delete devDependencies[name];
+  const next: ProjectManifest = { ...manifest };
+  for (const section of DEPENDENCY_SECTIONS) {
+    const bag = { ...(manifest[section] ?? {}) };
+    for (const name of names) {
+      delete bag[name];
+    }
+    if (manifest[section] !== undefined) {
+      next[section] = bag;
+    }
   }
-  return { ...manifest, dependencies, devDependencies };
+  return next;
 }
 
 async function writeManifest(

--- a/packages/webapp/src/shell/supplemental-commands/ipk-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ipk-command.ts
@@ -6,7 +6,9 @@
  * Supports both named installs (`ipk install <pkg>...`) and the no-arg
  * install-from-manifest path (`ipk install` with no further arguments), which
  * reads `dependencies` + `devDependencies` from the cwd `package.json` and
- * installs them via the transitive installer.
+ * installs them via the transitive installer. Named installs that already
+ * live in `devDependencies` (or optional/peer) update that section in place;
+ * `-D` / `--save-dev` writes new entries there. Unknown install flags error.
  *
  * Script running (`npm run <script>`, `npm run-script`, and the `npm test` /
  * `start` / `stop` / `restart` lifecycle shortcuts) lives in `npm-run.ts`.
@@ -27,6 +29,7 @@ import {
 } from '../ipk/installer.js';
 import type { ScriptCatalog } from '../script-catalog.js';
 import { LIFECYCLE_SHORTCUTS, RUN_ALIASES, runNpmScript } from './npm-run.js';
+import { parseKnownFlags } from './subcommand-flags.js';
 
 export interface IpkCommandDeps {
   fs: VirtualFS;
@@ -41,15 +44,16 @@ const INSTALL_ALIASES = new Set(['install', 'i', 'add']);
 const UNINSTALL_ALIASES = new Set(['uninstall', 'remove', 'rm', 'un']);
 const LIST_ALIASES = new Set(['list', 'ls']);
 const GLOBAL_INSTALL_FLAGS = new Set(['-g', '--global', '--location=global']);
+const INSTALL_BOOL_FLAGS = ['-g', '--global', '-D', '--save-dev'] as const;
 
 function usage(name: string): string {
   return `${name} - install packages from the npm registry into node_modules
        and run package.json scripts
 
 Usage:
-  ${name} install [<pkg>[@<spec>] ...]
+  ${name} install [-D|--save-dev] [<pkg>[@<spec>] ...]
   ${name} install -g <pkg>[@<spec>] ...
-  ${name} i       [<pkg>[@<spec>] ...]
+  ${name} i       [-D|--save-dev] [<pkg>[@<spec>] ...]
   ${name} run     [<script> [-- <args>...]]
   ${name} test | start | stop | restart
 
@@ -97,28 +101,54 @@ Spec forms:
 
 Options:
   -g, --global     install packages into the shared global prefix (/shared/lib)
+  -D, --save-dev   record named installs in devDependencies
   -h, --help       Show this help message
 
-Installed packages are extracted into <cwd>/node_modules and named installs
-are recorded in <cwd>/package.json under dependencies. With -g, packages go
-to /shared/lib/node_modules and deps are recorded in /shared/lib/package.json.
-Existing fields are preserved. Idempotent: re-installing an already-satisfied
-package is a clean no-op.
+Installed packages are extracted into <cwd>/node_modules. Named installs are
+recorded in the package.json section they already occupy (dependencies,
+devDependencies, optionalDependencies, or peerDependencies). New packages go
+under dependencies, or under devDependencies with -D / --save-dev. A bare
+name that is already declared is resolved against that existing range, not
+latest. Unknown install flags are rejected. The no-arg form reads the
+manifest without rewriting it. With -g, packages go to /shared/lib/node_modules
+and deps are recorded in /shared/lib/package.json. Existing fields are
+preserved. Idempotent: re-installing an already-satisfied package is a clean
+no-op.
 `;
 }
 
-export interface ParsedInstallArgs {
+export interface ParsedGlobalFlagArgs {
   global: boolean;
   specs: string[];
 }
 
-/** Split install flags from package specs (supports `-g` anywhere before specs). */
-export function parseInstallArgs(args: string[]): ParsedInstallArgs {
-  return parseGlobalFlagArgs(args);
+export interface ParsedInstallArgs extends ParsedGlobalFlagArgs {
+  saveDev: boolean;
+}
+
+/**
+ * Split install flags from package specs. Unknown dash tokens fail loudly so a
+ * dropped `--save-dev` cannot look like it was honoured (#2925).
+ */
+export function parseInstallArgs(args: string[]): ParsedInstallArgs | { error: string } {
+  const parsed = parseKnownFlags(args, {
+    bool: INSTALL_BOOL_FLAGS,
+    value: ['--location'],
+  });
+  if ('error' in parsed) return parsed;
+  const location = parsed.values.get('--location');
+  if (location !== undefined && location !== 'global') {
+    return { error: `unknown flag: --location=${location}` };
+  }
+  return {
+    global: parsed.bools.has('-g') || parsed.bools.has('--global') || location === 'global',
+    saveDev: parsed.bools.has('-D') || parsed.bools.has('--save-dev'),
+    specs: parsed.positionals,
+  };
 }
 
 /** Split global flags from positional args (supports `-g` anywhere before names). */
-export function parseGlobalFlagArgs(args: string[]): ParsedInstallArgs {
+export function parseGlobalFlagArgs(args: string[]): ParsedGlobalFlagArgs {
   let global = false;
   const specs: string[] = [];
   for (const arg of args) {
@@ -207,7 +237,15 @@ async function runInstall(
   ctx: CommandContext,
   deps: IpkCommandDeps
 ): Promise<ExecResult> {
-  const { global, specs } = parseInstallArgs(args);
+  const parsed = parseInstallArgs(args);
+  if ('error' in parsed) {
+    return {
+      stdout: '',
+      stderr: `${name}: ${parsed.error}\n`,
+      exitCode: 1,
+    };
+  }
+  const { global, saveDev, specs } = parsed;
   if (global && specs.length === 0) {
     return {
       stdout: '',
@@ -226,6 +264,7 @@ async function runInstall(
       fetch: deps.fetch,
       cwd: ctx.cwd,
       global,
+      saveDev,
     });
   } catch (err) {
     return {

--- a/packages/webapp/tests/shell/ipk/discoverability.test.ts
+++ b/packages/webapp/tests/shell/ipk/discoverability.test.ts
@@ -64,6 +64,8 @@ describe('ipk/ipx discoverability (VAL-CROSS-014)', () => {
     expect(help.stdout).toMatch(/install/);
     expect(help.stdout).toMatch(/\bi\b/);
     expect(help.stdout).toContain('Usage:');
+    expect(help.stdout).toMatch(/--save-dev/);
+    expect(help.stdout).toMatch(/-D/);
     await fs.dispose();
   });
 
@@ -75,6 +77,8 @@ describe('ipk/ipx discoverability (VAL-CROSS-014)', () => {
     expect(help.stdout).toContain('npm');
     expect(help.stdout).toMatch(/install/);
     expect(help.stdout).toContain('Usage:');
+    expect(help.stdout).toMatch(/--save-dev/);
+    expect(help.stdout).toMatch(/-D/);
     await fs.dispose();
   });
 

--- a/packages/webapp/tests/shell/ipk/installer.test.ts
+++ b/packages/webapp/tests/shell/ipk/installer.test.ts
@@ -3,7 +3,12 @@ import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { VirtualFS } from '../../../src/fs/index.js';
-import { installPackage, installPackages } from '../../../src/shell/ipk/installer.js';
+import { GLOBAL_NODE_MODULES, GLOBAL_PACKAGE_JSON } from '../../../src/shell/ipk/global-prefix.js';
+import {
+  installPackage,
+  installPackages,
+  uninstallPackages,
+} from '../../../src/shell/ipk/installer.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -383,6 +388,68 @@ describe('installPackage (single-package path)', () => {
     );
     expect(opt.version).toBe('1.0.0');
     expect(peer.version).toBe('1.0.0');
+  });
+
+  it('uninstall of an unrelated dependency keeps optional and peer packages on disk', async () => {
+    const reg = makeRegistry([
+      { name: 'keep-opt', version: '1.0.0' },
+      { name: 'keep-peer', version: '1.0.0' },
+      { name: 'drop-me', version: '1.0.0' },
+    ]);
+    const fetch = fakeFetch(reg);
+    await fs.mkdir('/work', { recursive: true });
+    await fs.writeFile(
+      '/work/package.json',
+      JSON.stringify(
+        {
+          name: 'demo',
+          dependencies: { 'drop-me': '1.0.0' },
+          optionalDependencies: { 'keep-opt': '1.0.0' },
+          peerDependencies: { 'keep-peer': '1.0.0' },
+        },
+        null,
+        2
+      )
+    );
+    const installed = await installPackages(['keep-opt', 'keep-peer', 'drop-me'], {
+      fs,
+      fetch,
+      cwd: '/work',
+    });
+    expect(installed.errors).toEqual([]);
+    const removed = await uninstallPackages(['drop-me'], { fs, fetch, cwd: '/work' });
+    expect(removed.errors).toEqual([]);
+    expect(await fs.exists('/work/node_modules/keep-opt/package.json')).toBe(true);
+    expect(await fs.exists('/work/node_modules/keep-peer/package.json')).toBe(true);
+    expect(await fs.exists('/work/node_modules/drop-me')).toBe(false);
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.optionalDependencies['keep-opt']).toBe('1.0.0');
+    expect(root.peerDependencies['keep-peer']).toBe('1.0.0');
+    expect(root.dependencies?.['drop-me']).toBeUndefined();
+  });
+
+  it('a later global install keeps a prior -g -D package instead of pruning it', async () => {
+    const reg = makeRegistry([
+      { name: 'dev-cli', version: '1.0.0' },
+      { name: 'prod-cli', version: '1.0.0' },
+    ]);
+    const fetch = fakeFetch(reg);
+    const first = await installPackage('dev-cli', {
+      fs,
+      fetch,
+      cwd: '/work',
+      global: true,
+      saveDev: true,
+    });
+    expect(first.ok).toBe(true);
+    const second = await installPackage('prod-cli', { fs, fetch, cwd: '/tmp/other', global: true });
+    expect(second.ok).toBe(true);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/dev-cli/package.json`)).toBe(true);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/prod-cli/package.json`)).toBe(true);
+    const globalManifest = JSON.parse((await fs.readFile(GLOBAL_PACKAGE_JSON)) as string);
+    expect(globalManifest.devDependencies['dev-cli']).toBeDefined();
+    expect(globalManifest.dependencies['prod-cli']).toBeDefined();
+    expect(globalManifest.dependencies?.['dev-cli']).toBeUndefined();
   });
 
   it('heals a duplicate dependencies+devDependencies declaration by keeping devDependencies', async () => {

--- a/packages/webapp/tests/shell/ipk/installer.test.ts
+++ b/packages/webapp/tests/shell/ipk/installer.test.ts
@@ -3,7 +3,7 @@ import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { VirtualFS } from '../../../src/fs/index.js';
-import { installPackage } from '../../../src/shell/ipk/installer.js';
+import { installPackage, installPackages } from '../../../src/shell/ipk/installer.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -278,6 +278,136 @@ describe('installPackage (single-package path)', () => {
     expect(merged.dependencies['pre-existing']).toBe('^1.0.0');
     expect(merged.dependencies['is-number']).toBeDefined();
     expect(merged.devDependencies['dev-pre']).toBe('^2.0.0');
+  });
+
+  it('updates an existing devDependencies entry in place and does not duplicate it under dependencies (#2925)', async () => {
+    const reg = makeRegistry([
+      { name: 'eslint', version: '8.57.1' },
+      { name: 'eslint', version: '10.10.0' },
+    ]);
+    await fs.mkdir('/work', { recursive: true });
+    await fs.writeFile(
+      '/work/package.json',
+      JSON.stringify(
+        { name: 'ipk-repro', version: '1.0.0', devDependencies: { eslint: '8.57.1' } },
+        null,
+        2
+      )
+    );
+
+    const result = await installPackage('eslint', { fs, fetch: fakeFetch(reg), cwd: '/work' });
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe('8.57.1');
+    const installed = JSON.parse(
+      (await fs.readFile('/work/node_modules/eslint/package.json')) as string
+    );
+    expect(installed.version).toBe('8.57.1');
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.devDependencies).toEqual({ eslint: '8.57.1' });
+    expect(root.dependencies?.eslint).toBeUndefined();
+  });
+
+  it('records --save-dev installs under devDependencies', async () => {
+    const reg = makeRegistry([
+      { name: 'eslint', version: '8.57.1' },
+      { name: 'eslint', version: '10.10.0' },
+    ]);
+    const result = await installPackage('eslint', {
+      fs,
+      fetch: fakeFetch(reg),
+      cwd: '/work',
+      saveDev: true,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe('10.10.0');
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.devDependencies.eslint).toMatch(/10\.10\.0/);
+    expect(root.dependencies?.eslint).toBeUndefined();
+  });
+
+  it('moves a production dependency into devDependencies when saveDev is set', async () => {
+    const reg = makeRegistry([{ name: 'left-pad', version: '1.3.0' }]);
+    await fs.mkdir('/work', { recursive: true });
+    await fs.writeFile(
+      '/work/package.json',
+      JSON.stringify({ name: 'demo', dependencies: { 'left-pad': '^1.0.0' } }, null, 2)
+    );
+    const result = await installPackage('left-pad', {
+      fs,
+      fetch: fakeFetch(reg),
+      cwd: '/work',
+      saveDev: true,
+    });
+    expect(result.ok).toBe(true);
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.devDependencies['left-pad']).toMatch(/1\./);
+    expect(root.dependencies?.['left-pad']).toBeUndefined();
+  });
+
+  it('updates optionalDependencies and peerDependencies in place', async () => {
+    const reg = makeRegistry([
+      { name: 'opt-pkg', version: '1.0.0' },
+      { name: 'opt-pkg', version: '2.0.0' },
+      { name: 'peer-pkg', version: '1.0.0' },
+      { name: 'peer-pkg', version: '2.0.0' },
+    ]);
+    await fs.mkdir('/work', { recursive: true });
+    await fs.writeFile(
+      '/work/package.json',
+      JSON.stringify(
+        {
+          name: 'demo',
+          optionalDependencies: { 'opt-pkg': '1.0.0' },
+          peerDependencies: { 'peer-pkg': '1.0.0' },
+        },
+        null,
+        2
+      )
+    );
+    const out = await installPackages(['opt-pkg', 'peer-pkg'], {
+      fs,
+      fetch: fakeFetch(reg),
+      cwd: '/work',
+    });
+    expect(out.errors).toEqual([]);
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.optionalDependencies['opt-pkg']).toBe('1.0.0');
+    expect(root.peerDependencies['peer-pkg']).toBe('1.0.0');
+    expect(root.dependencies?.['opt-pkg']).toBeUndefined();
+    expect(root.dependencies?.['peer-pkg']).toBeUndefined();
+    const opt = JSON.parse(
+      (await fs.readFile('/work/node_modules/opt-pkg/package.json')) as string
+    );
+    const peer = JSON.parse(
+      (await fs.readFile('/work/node_modules/peer-pkg/package.json')) as string
+    );
+    expect(opt.version).toBe('1.0.0');
+    expect(peer.version).toBe('1.0.0');
+  });
+
+  it('heals a duplicate dependencies+devDependencies declaration by keeping devDependencies', async () => {
+    const reg = makeRegistry([
+      { name: 'eslint', version: '8.57.1' },
+      { name: 'eslint', version: '10.10.0' },
+    ]);
+    await fs.mkdir('/work', { recursive: true });
+    await fs.writeFile(
+      '/work/package.json',
+      JSON.stringify(
+        {
+          name: 'ipk-repro',
+          devDependencies: { eslint: '8.57.1' },
+          dependencies: { eslint: '^10.10.0' },
+        },
+        null,
+        2
+      )
+    );
+    const result = await installPackage('eslint', { fs, fetch: fakeFetch(reg), cwd: '/work' });
+    expect(result.version).toBe('8.57.1');
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.devDependencies).toEqual({ eslint: '8.57.1' });
+    expect(root.dependencies?.eslint).toBeUndefined();
   });
 
   it('installs an exact version pin', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
@@ -784,6 +784,27 @@ describe('createIpkCommand', () => {
     expect(depNested.version).toBe('3.0.0');
   });
 
+  it('incremental global install after -g -D keeps the earlier devDependency', async () => {
+    const reg = buildRegistry([
+      { name: 'eslint', version: '8.57.1' },
+      { name: 'left-pad', version: '1.3.0' },
+    ]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const first = await cmd.execute(['install', '-g', '-D', 'eslint'], ctxOf(fs) as never);
+    expect(first.exitCode).toBe(0);
+    const second = await cmd.execute(['install', '-g', 'left-pad'], ctxOf(fs) as never);
+    expect(second.exitCode).toBe(0);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/eslint/package.json`)).toBe(true);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/left-pad/package.json`)).toBe(true);
+    const globalManifest = JSON.parse((await fs.readFile(GLOBAL_PACKAGE_JSON)) as string);
+    expect(globalManifest.devDependencies.eslint).toBeDefined();
+    expect(globalManifest.dependencies['left-pad']).toBeDefined();
+    const listed = await cmd.execute(['list', '-g'], ctxOf(fs) as never);
+    expect(listed.exitCode).toBe(0);
+    expect(listed.stdout).toMatch(/eslint@/);
+    expect(listed.stdout).toMatch(/left-pad@/);
+  });
+
   it('global upgrade prunes orphaned transitive bins from PATH', async () => {
     const reg = buildRegistry([
       {

--- a/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
@@ -250,6 +250,114 @@ describe('createIpkCommand', () => {
     expect(root.dependencies['is-number']).toBeDefined();
   });
 
+  it('ipk install of a package already in devDependencies updates that section in place (#2925)', async () => {
+    const reg = buildRegistry([
+      { name: 'eslint', version: '8.57.1' },
+      { name: 'eslint', version: '10.10.0' },
+    ]);
+    await fs.writeFile(
+      '/work/package.json',
+      `${JSON.stringify({ name: 'ipk-repro', version: '1.0.0', devDependencies: { eslint: '8.57.1' } }, null, 2)}\n`
+    );
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', 'eslint'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    const installed = JSON.parse(
+      (await fs.readFile('/work/node_modules/eslint/package.json')) as string
+    );
+    expect(installed.version).toBe('8.57.1');
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.devDependencies).toEqual({ eslint: '8.57.1' });
+    expect(root.dependencies?.eslint).toBeUndefined();
+  });
+
+  it('npm install --save-dev writes the package to devDependencies', async () => {
+    const reg = buildRegistry([
+      { name: 'eslint', version: '8.57.1' },
+      { name: 'eslint', version: '10.10.0' },
+    ]);
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', '--save-dev', 'eslint@8.57.1'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    const installed = JSON.parse(
+      (await fs.readFile('/work/node_modules/eslint/package.json')) as string
+    );
+    expect(installed.version).toBe('8.57.1');
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.devDependencies.eslint).toBe('8.57.1');
+    expect(root.dependencies?.eslint).toBeUndefined();
+  });
+
+  it('ipk install -D writes the package to devDependencies', async () => {
+    const reg = buildRegistry([{ name: 'eslint', version: '8.57.1' }]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', '-D', 'eslint'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.devDependencies.eslint).toBeDefined();
+    expect(root.dependencies?.eslint).toBeUndefined();
+  });
+
+  it('unknown install flags error instead of being dropped', async () => {
+    const reg = buildRegistry([{ name: 'eslint', version: '8.57.1' }]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', '--legacy-peer-deps', 'eslint'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/unknown flag: --legacy-peer-deps/);
+    expect(await fs.exists('/work/node_modules/eslint')).toBe(false);
+    expect(await fs.exists('/work/package.json')).toBe(false);
+  });
+
+  it('npm install rejects unknown flags the same way', async () => {
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(buildRegistry([])) });
+    const r = await cmd.execute(['install', '--save-exact', 'eslint'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/unknown flag: --save-exact/);
+  });
+
+  it('bare ipk install (no args) installs declared ranges and does not rewrite package.json', async () => {
+    const manifest = {
+      name: 'demo',
+      dependencies: { 'is-number': '^7.0.0' },
+      devDependencies: { 'is-odd': '^3.0.0' },
+    };
+    await fs.writeFile('/work/package.json', `${JSON.stringify(manifest, null, 2)}\n`);
+    const reg = buildRegistry([
+      { name: 'is-number', version: '7.0.0' },
+      { name: 'is-odd', version: '3.0.1' },
+    ]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    expect(await fs.exists('/work/node_modules/is-number/package.json')).toBe(true);
+    expect(await fs.exists('/work/node_modules/is-odd/package.json')).toBe(true);
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root.dependencies).toEqual({ 'is-number': '^7.0.0' });
+    expect(root.devDependencies).toEqual({ 'is-odd': '^3.0.0' });
+  });
+
+  it('bare npm install is the same non-destructive no-arg path', async () => {
+    const manifest = {
+      name: 'demo',
+      devDependencies: { eslint: '8.57.1' },
+    };
+    await fs.writeFile('/work/package.json', `${JSON.stringify(manifest, null, 2)}\n`);
+    const reg = buildRegistry([
+      { name: 'eslint', version: '8.57.1' },
+      { name: 'eslint', version: '10.10.0' },
+    ]);
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    const installed = JSON.parse(
+      (await fs.readFile('/work/node_modules/eslint/package.json')) as string
+    );
+    expect(installed.version).toBe('8.57.1');
+    const root = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(root).toEqual(manifest);
+    expect(root.dependencies).toBeUndefined();
+  });
+
   it('installs multiple packages in one invocation', async () => {
     const reg = buildRegistry([
       { name: 'is-number', version: '7.0.0' },
@@ -348,6 +456,17 @@ describe('createIpkCommand', () => {
     const r = await cmd.execute(['--help'], ctxOf(fs) as never);
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toMatch(/install/i);
+    expect(r.stdout).toMatch(/--save-dev/);
+    expect(r.stdout).toMatch(/-D/);
+  });
+
+  it('npm --help lists --save-dev / -D', async () => {
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(buildRegistry([])) });
+    const r = await cmd.execute(['--help'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('npm');
+    expect(r.stdout).toMatch(/--save-dev/);
+    expect(r.stdout).toMatch(/-D/);
   });
 
   it('prints clear error and exits non-zero when no subcommand is given', async () => {
@@ -496,12 +615,62 @@ describe('createIpkCommand', () => {
   });
 
   it('parseInstallArgs recognizes -g / --global and collects specs', () => {
-    expect(parseInstallArgs(['-g', 'left-pad'])).toEqual({ global: true, specs: ['left-pad'] });
+    expect(parseInstallArgs(['-g', 'left-pad'])).toEqual({
+      global: true,
+      saveDev: false,
+      specs: ['left-pad'],
+    });
     expect(parseInstallArgs(['--global', '@acme/util'])).toEqual({
       global: true,
+      saveDev: false,
       specs: ['@acme/util'],
     });
-    expect(parseInstallArgs(['is-number'])).toEqual({ global: false, specs: ['is-number'] });
+    expect(parseInstallArgs(['is-number'])).toEqual({
+      global: false,
+      saveDev: false,
+      specs: ['is-number'],
+    });
+    expect(parseInstallArgs(['--location=global', 'left-pad'])).toEqual({
+      global: true,
+      saveDev: false,
+      specs: ['left-pad'],
+    });
+  });
+
+  it('parseInstallArgs recognizes --save-dev / -D', () => {
+    expect(parseInstallArgs(['--save-dev', 'eslint'])).toEqual({
+      global: false,
+      saveDev: true,
+      specs: ['eslint'],
+    });
+    expect(parseInstallArgs(['-D', 'eslint@8.57.1'])).toEqual({
+      global: false,
+      saveDev: true,
+      specs: ['eslint@8.57.1'],
+    });
+    expect(parseInstallArgs(['eslint', '-D'])).toEqual({
+      global: false,
+      saveDev: true,
+      specs: ['eslint'],
+    });
+    expect(parseInstallArgs(['-g', '-D', 'say'])).toEqual({
+      global: true,
+      saveDev: true,
+      specs: ['say'],
+    });
+  });
+
+  it('parseInstallArgs rejects unknown install flags instead of dropping them', () => {
+    expect(parseInstallArgs(['--legacy-peer-deps', 'eslint'])).toEqual({
+      error: 'unknown flag: --legacy-peer-deps',
+    });
+    expect(parseInstallArgs(['--save-exact', 'eslint'])).toEqual({
+      error: 'unknown flag: --save-exact',
+    });
+    expect(parseInstallArgs(['-E', 'eslint'])).toEqual({ error: 'unknown flag: -E' });
+    expect(parseInstallArgs(['--location=user', 'eslint'])).toEqual({
+      error: 'unknown flag: --location=user',
+    });
   });
 
   it('ipk install -g installs into /shared/lib/node_modules, not cwd', async () => {


### PR DESCRIPTION
Closes #2925

## Summary

`ipk install <pkg>` (and the `npm` alias) always wrote the package into `dependencies`, even when it already lived in `devDependencies`. `--save-dev` / `-D` were accepted and silently dropped. Named installs of a bare name also resolved latest instead of the declared range.

Named installs now update the section the package already occupies, `-D` / `--save-dev` write new packages to `devDependencies`, a bare already-declared name honours the existing range, and unknown install flags fail loudly. The no-arg `ipk install` path is unchanged.

## Why

Repro from #2925: `devDependencies.eslint: 8.57.1` then `ipk install eslint` produced `dependencies.eslint: ^10.10.0` while 8.57.1 stayed in `devDependencies`. That silently swapped the installed linter *and* left two conflicting ranges in `package.json`. `npm install --save-dev eslint@8.57.1` installed the right version but still wrote `dependencies`.

### Repro

1. `package.json` with `devDependencies.eslint: 8.57.1`
2. `ipk install eslint` (or `npm install eslint`)
3. Expected: `devDependencies.eslint` stays `8.57.1`, no `dependencies.eslint`, tree is 8.57.1
4. Actual (before): `dependencies.eslint: ^10.10.0` added, 8.57.1 left in place, tree is 10.x

## Approach / Implementation notes

- `parseInstallArgs` uses `parseKnownFlags` so unknown dash tokens fail (`ipk: unknown flag: --x`) instead of being skipped. `--save-dev` / `-D` are boolean flags; `--location=global` remains a value flag.
- The installer picks a save section in this order: `--save-dev` → existing `devDependencies` / `optionalDependencies` / `peerDependencies` → `dependencies`. Writing to one section removes the name from the others, which also heals an already-duplicated declaration.
- A bare name that is already declared is resolved against that existing range (so `ipk install eslint` with `eslint: 8.57.1` in `devDependencies` installs 8.57.1, not latest).
- `installFromManifest` (no-arg `ipk install`) is untouched: it still installs declared `dependencies` + `devDependencies` without rewriting `package.json`.

## Cross-cutting impact

- **Floats exercised**: CLI / Chrome extension / Electron / worker share this webapp shell command. No native/iOS change.
- **Other callers of `installPackages`**: `ipx` auto-install and speech-asset bootstrap do not pass `saveDev` and install packages that are not already in a project manifest, so they still record under `dependencies`.
- **Uninstall / list / root**: still use `parseGlobalFlagArgs`, which continues to ignore unknown flags. Out of scope for #2925.
- **Bundle size**: worker first-load +1.7 kB vs merge-base (allowance 5 kB).

## Test plan

- [x] `npm run verify` — lint gate + autofix-drift
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 20355 passing
- [x] `npm run test:coverage:webapp` — floors held (lines 85.1% / statements 83.14% / functions 83.21% / branches 74.89%)
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size`
- [x] New / changed behavior covered in `packages/webapp/tests/shell/ipk/installer.test.ts` and `packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts`
- [x] N/A for UI screencast — shell command only

Pinned coverage:

- existing `devDependencies` entry updated in place, not duplicated (`#2925` repro, including the `npm` alias)
- `--save-dev` / `-D` write `devDependencies`
- unknown flags error
- bare `ipk install` / `npm install` still install declared ranges and do not rewrite `package.json`

## Documentation

- [x] `docs/shell-reference.md`
- [x] `packages/vfs-root/workspace/skills/package-execution/SKILL.md` (agent-facing)
- [x] `ipk --help` / `npm --help` list `-D` / `--save-dev`

## Risk & rollback

Blast radius is the ipk/npm install command across every float that runs the webapp shell. Revert this PR to restore the old always-`dependencies` write. No persisted-state migration.