### PR TITLE
fix(oauth): stop the boot bootstrap wiping token masks, and check Adobe tokens upstream

### DIFF
--- a/.agents/skills/adding-slicc-features/SKILL.md
+++ b/.agents/skills/adding-slicc-features/SKILL.md
@@ -923,6 +923,11 @@ with ONE cheap authenticated call (GitHub uses `GET /user`) so `oauth-token
   (401). Statuses a healthy token also produces — GitHub answers 403 for rate
   limits — must be `unknown`, or a throttled caller gets sent through a consent
   window that cannot fix anything.
+- **Read the verdict where the provider puts it.** Adobe IMS
+  (`POST {imsHost}/ims/validate_token/v1`) answers HTTP 200 for BOTH verdicts
+  and reports `{"valid":false,"reason":"…"}` in the body, so treating the
+  status as the answer would call every revoked token valid. A non-2xx there is
+  the check failing, not a refusal — `unknown`.
 - Return `unknown` for 5xx, transport failures, and "nothing stored". `unknown`
   says nothing about the token; only `rejected` costs the user a re-login.
 - Bound the request (`AbortSignal.timeout`) — `--check` must always answer.

--- a/docs/oauth-intercept.md
+++ b/docs/oauth-intercept.md
@@ -206,6 +206,14 @@ alone would call every revoked token valid; GitHub (`GET /user`) puts it in the
 status. The per-provider table is in
 [`shell-reference.md`](shell-reference.md#oauth-token-held-vs-working).
 
+When the verdict lives in the body, require it **explicitly**. A 200 whose body
+has no boolean `valid` — an error envelope, a truncated response — must be
+`unknown`; falling through to `rejected` claims a refusal the provider never
+issued. Resolve any per-account settings the call needs (IMS environment,
+client ID) from _that account's_ endpoint rather than a first-value read of a
+session cache, or a staging account gets asked about production. Bound those
+lookups too: everything `--check` awaits is on the path to it answering.
+
 `oauth-token --check [<id>]` is the only surface that calls this hook, and it
 falls back to any registered provider that implements it when the selected one
 does not.

--- a/docs/oauth-intercept.md
+++ b/docs/oauth-intercept.md
@@ -181,3 +181,31 @@ short-circuits to "session expired — please log in again" without re-hitting
 IMS, then re-probes once the cooldown elapses (recovering if the user re-authed
 elsewhere). That error is classified non-retryable in `scoop-context/error-classification.ts` so a
 dead-session turn fails fast with one clean error.
+
+## Upstream token validation (`onValidateToken`)
+
+Renewal answers "can I get a fresh token"; validation answers "is the one I
+hold still honoured". They fail independently, so a provider with
+`onSilentRenew` still wants `onValidateToken`: `--renew` returning `null`
+collapses a dead session and a network blip into the same answer, and the
+check is what tells them apart before `oauth-token` sends anyone to a consent
+window.
+
+Implement it as **one cheap, time-bounded call** returning
+`{ status: 'accepted' | 'rejected' | 'unknown', userName?, detail? }`, and be
+strict about the middle status: only a response that _proves_ refusal is
+`rejected`. Everything else — 5xx, transport failure, a throttling status a
+healthy token also produces — is `unknown`, which says nothing about the token
+and costs the caller nothing. Bound the call with `AbortSignal.timeout` so
+`--check` always answers.
+
+Read the verdict from wherever the provider actually puts it. Adobe IMS
+(`POST {imsHost}/ims/validate_token/v1`) answers **HTTP 200 for both
+verdicts** and reports `{"valid":false,"reason":"…"}` in the body, so status
+alone would call every revoked token valid; GitHub (`GET /user`) puts it in the
+status. The per-provider table is in
+[`shell-reference.md`](shell-reference.md#oauth-token-held-vs-working).
+
+`oauth-token --check [<id>]` is the only surface that calls this hook, and it
+falls back to any registered provider that implements it when the selected one
+does not.

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -793,6 +793,14 @@ Two rules come out of it:
   twice is idempotent; setting it late is not. `ui/main.ts` now wires it ahead
   of the OAuth bootstrap, guarded by
   `packages/webapp/tests/ui/main-oauth-bridge-wiring.test.ts`.
+- **The launch query string is attacker input, not configuration.** Because the
+  page is served from the hosted origin, anything reached via a link can carry
+  `?bridge=…`, and `apiBaseUrl` is derived straight from that host —
+  so an unchecked bridge aims the whole local `/api` surface, OAuth replica push
+  included, at a remote server that need only permit the request via CORS.
+  `parseBridgeLaunchParams` enforces the loopback contract its own type already
+  documented, at the parser rather than at each consumer, so the SW
+  registration, `/api` base, lick socket, and CDP dial are covered by one check.
 - **A fail-open sync must leave the state recoverable.** Clearing a cached
   value up front and restoring it only on success turns every transport hiccup
   into data loss. Prefer re-deriving over carrying the old value forward:

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -770,6 +770,43 @@ because its `prompt=none` page JS-redirects after load. Keep the
 `packages/chrome-extension/src/oauth-flow-options.ts`. See
 `docs/oauth-intercept.md` "Silent token renewal".
 
+## A 200 From the Hosted Origin Is Not a Successful `/api` Call
+
+An unconfigured `resolveApiUrl('/api/…')` returns a **bare relative path**. On a
+thin-bridge leader the page is served from `www.sliccy.ai`, so that path
+resolves against the tray hub instead of the local node-server — and the hub
+answers **200 with its route catalog** for any unmatched path. `r.ok` is true,
+the JSON parses, and only the missing field says anything went wrong.
+
+That combination cost days of a confusing bug (#2929). `bootstrapOAuthReplicas`
+runs on every page load and re-pushes each stored OAuth token to the secrets
+replica, but the bridge wiring (`setLocalApiBaseUrl` / `setBridgeToken`) only
+happened later, in `setupStandalonePrelude`. Every boot therefore POSTed real
+access tokens to the hosted origin, read a 200 back, found no `maskedValue`,
+and wiped the mask each account already had — after which `oauth-token <id>`
+reported no usable token and demanded a `--force-login` popup. Paired with a
+crash-reload loop it looked exactly like tokens expiring every few minutes.
+
+Two rules come out of it:
+
+- **Wire the API base before anything in the realm calls `/api`.** Setting it
+  twice is idempotent; setting it late is not. `ui/main.ts` now wires it ahead
+  of the OAuth bootstrap, guarded by
+  `packages/webapp/tests/ui/main-oauth-bridge-wiring.test.ts`.
+- **A fail-open sync must leave the state recoverable.** Clearing a cached
+  value up front and restoring it only on success turns every transport hiccup
+  into data loss. Prefer re-deriving over carrying the old value forward:
+  `ensureOAuthMaskReplica` (#2921) remasks on the next `oauth-token` read, so a
+  lost mask costs one round-trip rather than a login. Carrying the previous
+  `maskedValue` forward would also work for the boot re-push, where the token
+  is unchanged, but it makes `saveOAuthAccount` a second writer of that field
+  and risks pinning a stale mask to a rotated token — the hazard
+  `attachMaskIfTokenUnchanged` exists to prevent.
+
+When a masked secret goes missing, log the resolved URL before suspecting the
+masking pipeline: a misrouted push and a replica that declined look identical
+at the call site.
+
 ## Local Bridge Keep-Alive: The 5 s Default Races Bursty Fan-Outs
 
 `TypeError: Failed to fetch` against `http://localhost:5710` does **not** mean

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -196,10 +196,13 @@ the two shipped hooks differ in where the verdict lives:
 Adobe's shape is the trap worth knowing: reading the status as the answer would
 call every revoked IMS token valid, and a non-2xx there means the check itself
 did not run (a 400 `bad_request` for a malformed call), so it is `UNKNOWN` and
-must never send a caller with a good token through a consent window. The
-`client_id` the call requires is read back from the access token's own JWT
-claims, so `--check adobe` works on a cold page, before anything has fetched the
-proxy's `/v1/config`.
+must never send a caller with a good token through a consent window. Only an
+explicit `valid: false` is a refusal — a 200 with no boolean verdict is
+`UNKNOWN` too. The `client_id` the call requires is read back from the access
+token's own JWT claims, so `--check adobe` works even when the proxy's
+`/v1/config` is unreachable, and the IMS environment comes from the config of
+the proxy endpoint **that account** uses, so a `stg1` account is not asked
+about production.
 
 `oauth-token <id>` (no flags) and `skill.token('<id>')` print the secrets-pipeline
 **replica** (`account.maskedValue`), never `accessToken`. `--check` is the

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -179,11 +179,27 @@ they report which token is **held** (`token held for <user>, local expiry in
 
 `oauth-token --check [<id>]` is the surface that answers whether the token still
 **works**: it calls the provider's optional `onValidateToken` hook — one cheap,
-time-bounded authenticated call, `GET /user` for GitHub — and reports
-`ACCEPTED`, `REJECTED`, or `UNKNOWN`. Only a response that proves refusal (401)
-is `REJECTED`; statuses a healthy token also produces (GitHub answers 403 when
-throttling), 5xx, and transport failures are `UNKNOWN`, which says nothing about
-the token. Providers without the hook say so rather than guessing.
+time-bounded call — and reports `ACCEPTED`, `REJECTED`, or `UNKNOWN`. Only a
+response that proves refusal is `REJECTED`; statuses a healthy token also
+produces (GitHub answers 403 when throttling), 5xx, and transport failures are
+`UNKNOWN`, which says nothing about the token. Providers without the hook say so
+rather than guessing.
+
+Each provider asks in whatever way its identity service answers honestly, and
+the two shipped hooks differ in where the verdict lives:
+
+| Provider | Call                                                         | Where the verdict is                                                                                 |
+| -------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| GitHub   | `GET https://api.github.com/user`                            | The HTTP status. 401 is a refusal; a 403 with rate-limit headers is `UNKNOWN`.                       |
+| Adobe    | `POST {imsHost}/ims/validate_token/v1` (`type=access_token`) | The **body**. IMS answers 200 either way, with `{"valid":true}` or `{"valid":false,"reason":"..."}`. |
+
+Adobe's shape is the trap worth knowing: reading the status as the answer would
+call every revoked IMS token valid, and a non-2xx there means the check itself
+did not run (a 400 `bad_request` for a malformed call), so it is `UNKNOWN` and
+must never send a caller with a good token through a consent window. The
+`client_id` the call requires is read back from the access token's own JWT
+claims, so `--check adobe` works on a cold page, before anything has fetched the
+proxy's `/v1/config`.
 
 `oauth-token <id>` (no flags) and `skill.token('<id>')` print the secrets-pipeline
 **replica** (`account.maskedValue`), never `accessToken`. `--check` is the

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -52,7 +52,12 @@ import { findFamilyCost } from '../src/providers/family-cost.js';
 import { getOAuthPageOrigin } from '../src/providers/oauth-service.js';
 import { createSilentRenewBackoff } from '../src/providers/silent-renew-backoff.js';
 import { withSupportedTemperature } from '../src/providers/temperature-support.js';
-import type { OAuthLauncher, OAuthLoginOptions, ProviderConfig } from '../src/providers/types.js';
+import type {
+  OAuthLauncher,
+  OAuthLoginOptions,
+  OAuthTokenValidation,
+  ProviderConfig,
+} from '../src/providers/types.js';
 import { getDailyAdobeUuid } from '../src/scoops/llm-session-id.js';
 import {
   getAccounts,
@@ -195,6 +200,30 @@ function imsHost(env?: string): string {
   return IMS_HOSTS[env ?? adobeConfig.imsEnvironment ?? 'prod'] ?? IMS_HOSTS.prod;
 }
 
+/** Bound the validation call: `--check` must always answer, never hang. */
+const VALIDATE_TIMEOUT_MS = 10_000;
+
+/**
+ * IMS access tokens are JWTs carrying the `client_id` they were minted for.
+ * Reading it back beats `proxyConfigCache` for {@link validateAdobeToken}:
+ * `/ims/validate_token/v1` rejects a request with no `client_id` outright
+ * (400 `bad_request`), and the cache is empty until something has fetched
+ * `/v1/config` this session — which on a cold page it has not. Returns
+ * undefined for a token that is not a readable JWT; the caller falls back.
+ */
+function readTokenClientId(accessToken: string): string | undefined {
+  try {
+    const payload = accessToken.split('.')[1];
+    if (!payload) return undefined;
+    const b64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(b64 + '='.repeat((4 - (b64.length % 4)) % 4));
+    const claims = JSON.parse(json) as { client_id?: unknown };
+    return typeof claims.client_id === 'string' ? claims.client_id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // ── Runtime detection ───────────────────────────────────────────────
 
 const isExtension =
@@ -206,37 +235,109 @@ function getAdobeAccount() {
   return getAccounts().find((a) => a.providerId === 'adobe');
 }
 
-async function fetchUserProfile(
-  accessToken: string,
-  imsEnv?: string
-): Promise<{ name?: string; avatar?: string }> {
+interface AdobeUserProfile {
+  name?: string;
+  avatar?: string;
+}
+
+/**
+ * IMS profile endpoints, in the order worth asking.
+ *
+ * `/ims/userinfo/v2` is the OIDC endpoint, and it answers with nothing but
+ * `sub` unless the token carries the `profile` / `email` scopes — which the
+ * proxy's scope set does not, so it left every Adobe account with no display
+ * name at all (#2929). `/ims/profile/v1` returns `displayName` / `name` /
+ * `email` for that same token. Ask it first, and keep the OIDC endpoint as
+ * the fallback for a client whose scopes make it the richer of the two.
+ */
+const IMS_PROFILE_PATHS = ['/ims/profile/v1', '/ims/userinfo/v2'] as const;
+
+/** One profile call. Returns undefined when it fails or names nobody. */
+async function fetchImsProfile(
+  url: string,
+  accessToken: string
+): Promise<AdobeUserProfile | undefined> {
   try {
-    const res = await fetch(`${imsHost(imsEnv)}/ims/userinfo/v2`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    if (res.ok) {
-      const profile = (await res.json()) as {
-        name?: string;
-        email?: string;
-        displayName?: string;
-        picture?: string;
-        avatar_url?: string;
-      };
-      return {
-        name: profile.displayName || profile.name || profile.email,
-        avatar: profile.picture || profile.avatar_url,
-      };
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!res.ok) {
+      console.warn(`[adobe] Profile fetch ${url} returned ${res.status}`);
+      return undefined;
     }
-    console.warn(
-      `[adobe] User profile fetch returned ${res.status}, account will have no display name`
-    );
+    const profile = (await res.json()) as {
+      name?: string;
+      email?: string;
+      displayName?: string;
+      picture?: string;
+      avatar_url?: string;
+    };
+    const name = profile.displayName || profile.name || profile.email;
+    return name ? { name, avatar: profile.picture || profile.avatar_url } : undefined;
   } catch (err) {
     console.warn(
-      '[adobe] Failed to fetch user profile:',
+      `[adobe] Profile fetch ${url} failed:`,
       err instanceof Error ? err.message : String(err)
     );
+    return undefined;
   }
+}
+
+async function fetchUserProfile(accessToken: string, imsEnv?: string): Promise<AdobeUserProfile> {
+  for (const path of IMS_PROFILE_PATHS) {
+    const profile = await fetchImsProfile(`${imsHost(imsEnv)}${path}`, accessToken);
+    if (profile) return profile;
+  }
+  console.warn('[adobe] No IMS profile endpoint named the user; account will have no display name');
   return {};
+}
+
+/**
+ * Ask IMS whether it still accepts the stored token.
+ *
+ * `POST /ims/validate_token/v1` is built for exactly this question, and it
+ * asks it about the token itself rather than about one API's authorization.
+ * Worth asking because local expiry is not proof of validity: a token well
+ * inside its recorded 24h window is routinely dead upstream after a revoked
+ * grant or an ended IMS session, and `--list` / `--renew` can only report
+ * what is stored.
+ *
+ * IMS answers **200 for both verdicts** and puts the verdict in the body
+ * (`{"valid":true}` vs `{"valid":false,"reason":"bad_signature"}`), so the
+ * status must never be read as the answer. A non-2xx means the check itself
+ * did not run — `unknown`, which says nothing about the token, rather than a
+ * rejection that would send the caller through a consent window it does not
+ * need.
+ */
+async function validateAdobeToken(): Promise<OAuthTokenValidation> {
+  const account = getAdobeAccount();
+  const accessToken = account?.accessToken;
+  if (!accessToken) return { status: 'unknown', detail: 'no stored token' };
+
+  const lastConfig = proxyConfigCache.values().next().value ?? {};
+  const clientId =
+    readTokenClientId(accessToken) || lastConfig.clientId || adobeConfig.clientId || '';
+  if (!clientId) return { status: 'unknown', detail: 'no IMS client ID available' };
+
+  const host = imsHost(resolveImsEnvironment(lastConfig));
+  try {
+    const res = await fetch(`${host}/ims/validate_token/v1`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ client_id: clientId, token: accessToken, type: 'access_token' }),
+      signal: AbortSignal.timeout(VALIDATE_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const detail = `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ''}`;
+      return { status: 'unknown', detail };
+    }
+    const body = (await res.json()) as { valid?: unknown; reason?: unknown };
+    // IMS's own answer names the identity only as an opaque user id, so the
+    // display name we stored at login is the readable form of the same one.
+    if (body.valid === true) return { status: 'accepted', userName: account?.userName };
+    const reason = typeof body.reason === 'string' ? body.reason : 'no reason given';
+    return { status: 'rejected', detail: `IMS reported the token invalid (${reason})` };
+  } catch (err) {
+    return { status: 'unknown', detail: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 /** Extract token details exactly as reported in the OAuth URL fragment. */
@@ -471,6 +572,8 @@ export const config: ProviderConfig = {
     if (!account?.accessToken) return null;
     return silentRenewToken();
   },
+
+  onValidateToken: validateAdobeToken,
 
   // Fetch + cache the proxy model list, then persist the enriched list to
   // localStorage so a cold consumer (the cloud cone's kernel worker) reads the

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -203,13 +203,52 @@ function imsHost(env?: string): string {
 /** Bound the validation call: `--check` must always answer, never hang. */
 const VALIDATE_TIMEOUT_MS = 10_000;
 
+/** Same promise for the `/v1/config` lookup `--check` needs first. */
+const VALIDATE_CONFIG_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolve the proxy config for the endpoint THIS account uses.
+ *
+ * `proxyConfigCache` is keyed by proxy endpoint, so taking the first value out
+ * of it returns whichever endpoint happened to be fetched first this session —
+ * the stale one after a proxy switch, and nothing at all on a cold page, which
+ * then falls back to the PRODUCTION IMS host. For an account on `stg1` that
+ * sends the token to an IMS that never minted it and reports a verdict about
+ * the wrong environment. Ask for the account's own endpoint instead, fetching
+ * it when the cache is cold.
+ *
+ * Bounded, and `{}` on any failure: `fetchProxyConfig` carries no timeout of
+ * its own, and `--check` must always answer. Falling back to the build-time
+ * defaults is the same position this code was in before the fetch existed.
+ */
+async function resolveValidationConfig(): Promise<ProxyConfig> {
+  let endpoint: string;
+  try {
+    endpoint = getProxyEndpoint();
+  } catch {
+    // Nothing configured anywhere — build-time defaults are all there is.
+    return {};
+  }
+  const cached = proxyConfigCache.get(endpoint);
+  if (cached) return cached;
+  return new Promise<ProxyConfig>((resolve) => {
+    const timer = setTimeout(() => resolve({}), VALIDATE_CONFIG_TIMEOUT_MS);
+    const settle = (config: ProxyConfig) => {
+      clearTimeout(timer);
+      resolve(config);
+    };
+    fetchProxyConfig(endpoint).then(settle, () => settle({}));
+  });
+}
+
 /**
  * IMS access tokens are JWTs carrying the `client_id` they were minted for.
- * Reading it back beats `proxyConfigCache` for {@link validateAdobeToken}:
- * `/ims/validate_token/v1` rejects a request with no `client_id` outright
- * (400 `bad_request`), and the cache is empty until something has fetched
- * `/v1/config` this session — which on a cold page it has not. Returns
- * undefined for a token that is not a readable JWT; the caller falls back.
+ * Reading it back is the first choice for {@link validateAdobeToken}, which
+ * must supply one — `/ims/validate_token/v1` answers 400 `bad_request`
+ * without it. The token's own claim is also the *right* client to ask about,
+ * and it needs no network call, so `--check` still works when the proxy's
+ * `/v1/config` is unreachable. Returns undefined for a token that is not a
+ * readable JWT; the caller falls back to the proxy / build-time config.
  */
 function readTokenClientId(accessToken: string): string | undefined {
   try {
@@ -302,22 +341,23 @@ async function fetchUserProfile(accessToken: string, imsEnv?: string): Promise<A
  *
  * IMS answers **200 for both verdicts** and puts the verdict in the body
  * (`{"valid":true}` vs `{"valid":false,"reason":"bad_signature"}`), so the
- * status must never be read as the answer. A non-2xx means the check itself
- * did not run — `unknown`, which says nothing about the token, rather than a
- * rejection that would send the caller through a consent window it does not
- * need.
+ * status must never be read as the answer. Only an explicit verdict decides:
+ * a non-2xx, or a 200 whose body carries no boolean `valid`, means the check
+ * itself did not run — `unknown`, which says nothing about the token, rather
+ * than a rejection that would send the caller through a consent window it does
+ * not need.
  */
 async function validateAdobeToken(): Promise<OAuthTokenValidation> {
   const account = getAdobeAccount();
   const accessToken = account?.accessToken;
   if (!accessToken) return { status: 'unknown', detail: 'no stored token' };
 
-  const lastConfig = proxyConfigCache.values().next().value ?? {};
+  const proxyConfig = await resolveValidationConfig();
   const clientId =
-    readTokenClientId(accessToken) || lastConfig.clientId || adobeConfig.clientId || '';
+    readTokenClientId(accessToken) || proxyConfig.clientId || adobeConfig.clientId || '';
   if (!clientId) return { status: 'unknown', detail: 'no IMS client ID available' };
 
-  const host = imsHost(resolveImsEnvironment(lastConfig));
+  const host = imsHost(resolveImsEnvironment(proxyConfig));
   try {
     const res = await fetch(`${host}/ims/validate_token/v1`, {
       method: 'POST',
@@ -333,8 +373,14 @@ async function validateAdobeToken(): Promise<OAuthTokenValidation> {
     // IMS's own answer names the identity only as an opaque user id, so the
     // display name we stored at login is the readable form of the same one.
     if (body.valid === true) return { status: 'accepted', userName: account?.userName };
-    const reason = typeof body.reason === 'string' ? body.reason : 'no reason given';
-    return { status: 'rejected', detail: `IMS reported the token invalid (${reason})` };
+    if (body.valid === false) {
+      const reason = typeof body.reason === 'string' ? body.reason : 'no reason given';
+      return { status: 'rejected', detail: `IMS reported the token invalid (${reason})` };
+    }
+    // A 200 carrying no boolean verdict proves nothing was refused — an IMS
+    // error envelope or a truncated body would otherwise read as a refusal and
+    // push the caller into a consent window its token never needed.
+    return { status: 'unknown', detail: 'IMS answered 200 without a boolean `valid` verdict' };
   } catch (err) {
     return { status: 'unknown', detail: err instanceof Error ? err.message : String(err) };
   }

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -1185,7 +1185,13 @@ async function persistCliMaskReplica(
   accessToken: string,
   domains: string[]
 ): Promise<OAuthMaskWriteResult> {
-  const r = await fetch(resolveApiUrl('/api/secrets/oauth-update'), {
+  // Logged on both failure paths below: a 2xx from the WRONG origin is
+  // indistinguishable here from a real replica that declined, because the tray
+  // hub answers 200 with a route catalog for any unmatched path. Without the
+  // resolved target in the breadcrumb, a misrouted push reads as a server-side
+  // fault on a node-server that never saw the request (#2929).
+  const url = resolveApiUrl('/api/secrets/oauth-update');
+  const r = await fetch(url, {
     method: 'POST',
     headers: apiHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ providerId, accessToken, domains }),
@@ -1195,14 +1201,14 @@ async function persistCliMaskReplica(
     // The local Account is saved either way (fail-open per spec), but
     // without surfacing this the user gets a confusing "no masked replica"
     // error from oauth-token / git-token-write later with no breadcrumb.
-    log.warn('OAuth replica POST non-ok', { providerId, status: r.status });
+    log.warn('OAuth replica POST non-ok', { providerId, status: r.status, url });
     return { error: `OAuth replica POST HTTP ${r.status}` };
   }
   const data = await r.json();
   if (typeof data.maskedValue !== 'string') {
     // 2xx with no string maskedValue is the EXT7-triage silent-pass
     // defect. Surface it; bootstrap retries on reload; oauth-token remasks.
-    log.warn('OAuth replica POST ok but missing maskedValue', { providerId });
+    log.warn('OAuth replica POST ok but missing maskedValue', { providerId, url });
     return { error: 'OAuth replica POST ok but missing maskedValue' };
   }
   if (!isUsableOAuthMaskReplica(data.maskedValue, accessToken)) {

--- a/packages/webapp/src/ui/boot/bridge-launch-params.ts
+++ b/packages/webapp/src/ui/boot/bridge-launch-params.ts
@@ -19,6 +19,7 @@ import {
   BRIDGE_TOKEN_QUERY_PARAM,
   BRIDGE_WS_QUERY_PARAM,
   type BridgeRole,
+  isLoopbackHostname,
 } from '@slicc/shared-ts';
 
 export type { BridgeRole };
@@ -105,9 +106,10 @@ export function deriveBridgeLickWsUrl(bridgeWsUrl: string): string | null {
 
 /**
  * Extract bridge coordinates from a launch URL's query string. Returns
- * `null` unless BOTH `bridge` and `bridgeToken` are present and the URL
- * uses a `ws://` or `wss://` scheme — partial / malformed inputs degrade
- * to the legacy bundled-UI path (no bridge) rather than throwing.
+ * `null` unless BOTH `bridge` and `bridgeToken` are present, the URL uses a
+ * `ws://` or `wss://` scheme, and its host is loopback — partial / malformed
+ * inputs degrade to the legacy bundled-UI path (no bridge) rather than
+ * throwing.
  */
 export function parseBridgeLaunchParams(search: string): BridgeLaunchParams | null {
   let params: URLSearchParams;
@@ -121,6 +123,27 @@ export function parseBridgeLaunchParams(search: string): BridgeLaunchParams | nu
   const token = params.get(BRIDGE_TOKEN_QUERY_PARAM);
   if (!url || !token) return null;
   if (!/^wss?:\/\//.test(url)) return null;
+
+  // The bridge is by construction a LOCAL node-server / swift-server —
+  // `ws://localhost:<cdpPort>/cdp`, which is what every producer emits — and
+  // `apiBaseUrl` below is derived straight from this host. The query string
+  // that carries it, however, is attacker-suppliable: the page is served from
+  // the hosted origin, so a crafted link
+  // (`https://www.sliccy.ai/?bridge=wss://attacker.example/cdp&bridgeToken=x`)
+  // aims the whole local /api surface at a remote host, and a server that
+  // permits the request via CORS reads whatever is sent. That includes the
+  // boot-time OAuth replica push, which carries raw access tokens. Enforce the
+  // documented loopback contract here rather than at each consumer, so the SW
+  // registration, the /api base, the lick socket, and the CDP dial are all
+  // covered by one check. A non-loopback bridge is malformed, and degrades to
+  // the no-bridge path like any other malformed input.
+  let bridgeHostname: string;
+  try {
+    bridgeHostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+  if (!isLoopbackHostname(bridgeHostname)) return null;
 
   const rawRole = params.get(BRIDGE_ROLE_QUERY_PARAM);
   const role: BridgeRole | null = rawRole === 'leader' || rawRole === 'follower' ? rawRole : null;

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -23,6 +23,7 @@ import { initTelemetry } from '../kernel/telemetry.js';
 // IMPORTANT: This import must also appear in packages/chrome-extension/src/offscreen.ts
 // — the extension agent engine runs in the offscreen document, not in this file.
 import { registerProviders } from '../providers/index.js';
+import { setBridgeToken, setLocalApiBaseUrl } from '../shell/proxied-fetch.js';
 import { parseBridgeLaunchParams } from './boot/bridge-launch-params.js';
 import { installExtensionFetchDelegate } from './boot/setup-extension-fetch-delegate.js';
 import { setupFeatureFlagsForPage } from './boot/setup-feature-flags.js';
@@ -156,6 +157,20 @@ async function main(): Promise<void> {
   // resolved provider list. See `providers/index.ts:registerProviders`.
   await registerProviders();
   applyProviderDefaults();
+
+  // Wire the local /api base + bridge token for THIS realm before the OAuth
+  // bootstrap below, not just later in `setupStandalonePrelude`. The bootstrap
+  // pushes every stored token to the secrets replica, and with the base
+  // unset `resolveApiUrl` yields a bare relative path — which on a thin-bridge
+  // leader resolves against the hosted origin (sliccy.ai) instead of the local
+  // node-server. The tray hub answers 200 with its route catalog for any
+  // unmatched path, so the push looked like a success while no mask came back
+  // and the token was handed to an origin that never needed it (#2929).
+  // Mirrors the prelude's own condition; setting it twice is idempotent.
+  if (bridge?.apiBaseUrl && !extensionDelegate) {
+    setLocalApiBaseUrl(bridge.apiBaseUrl);
+    setBridgeToken(bridge.token);
+  }
 
   // Pre-warm OAuth replicas so the kernel-worker starts with fresh tokens;
   // bounded so a hung IMS popup doesn't deadlock the UI.

--- a/packages/webapp/tests/providers/adobe-token-validation.test.ts
+++ b/packages/webapp/tests/providers/adobe-token-validation.test.ts
@@ -45,17 +45,54 @@ function imsToken(clientId = 'ims-client'): string {
   return `header.${payload}.signature`;
 }
 
-function seedAdobeAccount(account: { accessToken?: string; userName?: string }): void {
+function seedAdobeAccount(account: {
+  accessToken?: string;
+  userName?: string;
+  /** Overrides the build-time proxy endpoint, and keys `proxyConfigCache`. */
+  baseUrl?: string;
+}): void {
   storage.set('slicc_accounts', JSON.stringify([{ providerId: 'adobe', apiKey: '', ...account }]));
 }
 
 /** A fetch stub whose recorded calls stay typed, so `init` is inspectable. */
 function stubFetch(
-  answer: () => Response
+  answer: (url: string) => Response
 ): ReturnType<typeof vi.fn<(url: unknown, init?: RequestInit) => Promise<Response>>> {
-  const spy = vi.fn(async (_url: unknown, _init?: RequestInit) => answer());
+  const spy = vi.fn(async (url: unknown, _init?: RequestInit) => answer(String(url)));
   globalThis.fetch = spy as unknown as typeof globalThis.fetch;
   return spy;
+}
+
+/**
+ * Route by URL rather than answering everything alike.
+ *
+ * `--check` asks the account's proxy for `/v1/config` before it asks IMS, so a
+ * stub that answers both with the same body makes the verdict call's position
+ * in the call list depend on whether `proxyConfigCache` was already warm — and
+ * therefore on test order. Naming the two endpoints separately keeps each
+ * assertion about the call it means.
+ */
+function stubImsFetch(answers: {
+  config?: Response | (() => Response);
+  validate: Response | (() => Response);
+}): ReturnType<typeof vi.fn<(url: unknown, init?: RequestInit) => Promise<Response>>> {
+  const pick = (a: Response | (() => Response)) => (typeof a === 'function' ? a() : a);
+  return stubFetch((url) => {
+    if (url.includes('/v1/config')) {
+      return answers.config
+        ? pick(answers.config)
+        : new Response(JSON.stringify({}), { status: 200 });
+    }
+    if (url.includes('/ims/validate_token/v1')) return pick(answers.validate);
+    return new Response('unexpected', { status: 500 });
+  });
+}
+
+/** The `validate_token` call, found by URL so config calls cannot shift it. */
+function validateCall(
+  spy: ReturnType<typeof vi.fn<(url: unknown, init?: RequestInit) => Promise<Response>>>
+): [url: unknown, init?: RequestInit] | undefined {
+  return spy.mock.calls.find((c) => String(c[0]).includes('/ims/validate_token/v1'));
 }
 
 /** The request `onValidateToken` sent, decoded from the form body. */
@@ -90,24 +127,86 @@ describe('adobe onValidateToken (does IMS still accept the token?)', () => {
   });
 
   it('asks the endpoint built for the question, with the token’s own client_id', async () => {
-    const fetchSpy = stubFetch(
-      () => new Response(JSON.stringify({ valid: true }), { status: 200 })
-    );
+    const fetchSpy = stubImsFetch({
+      validate: () => new Response(JSON.stringify({ valid: true }), { status: 200 }),
+    });
     const token = imsToken('experience-catalyst-prod');
     seedAdobeAccount({ accessToken: token });
 
     const { config } = await import('../../providers/adobe.js');
     await config.onValidateToken?.();
 
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe(IMS_VALIDATE_URL);
-    const form = sentForm(fetchSpy.mock.calls[0]?.[1]);
+    const call = validateCall(fetchSpy);
+    expect(call?.[0]).toBe(IMS_VALIDATE_URL);
+    const form = sentForm(call?.[1]);
     expect(form.get('token')).toBe(token);
     expect(form.get('type')).toBe('access_token');
-    // Read back from the JWT rather than `proxyConfigCache`, which is empty
-    // until something has fetched /v1/config this session. IMS answers 400
-    // when `client_id` is missing, which would make every cold-page check
-    // report UNKNOWN.
+    // Read back from the JWT rather than the proxy config: the token's own
+    // claim is the client the question is about, and it needs no network call,
+    // so the check still works when /v1/config is unreachable. IMS answers 400
+    // when `client_id` is missing, which would make that case report UNKNOWN.
     expect(form.get('client_id')).toBe('experience-catalyst-prod');
+  });
+
+  it('treats a 200 with no boolean verdict as unknown, not a refusal', async () => {
+    // An IMS error envelope or a truncated body can arrive with HTTP 200.
+    // Falling through to `rejected` there would claim IMS refused a credential
+    // it never ruled on, and push the caller into a consent window that cannot
+    // fix anything (#2939 review).
+    for (const body of [
+      { error: 'server_error' },
+      { valid: 'true' },
+      { valid: null },
+      {},
+    ] as const) {
+      stubImsFetch({ validate: () => new Response(JSON.stringify(body), { status: 200 }) });
+      seedAdobeAccount({ accessToken: imsToken() });
+
+      const { config } = await import('../../providers/adobe.js');
+      const result = await config.onValidateToken?.();
+      expect(result?.status, JSON.stringify(body)).toBe('unknown');
+    }
+  });
+
+  it('asks the IMS environment the account’s own proxy names, not the first cached one', async () => {
+    // `proxyConfigCache` is keyed by endpoint, so reading the first value out of
+    // it returns whichever proxy was fetched first this session, and on a cold
+    // page returns nothing — silently falling back to PRODUCTION IMS. For a
+    // stg1 account that asks an IMS which never minted the token (#2939
+    // review). A distinct `baseUrl` also gives this test its own cache key.
+    const fetchSpy = stubImsFetch({
+      config: () =>
+        new Response(JSON.stringify({ imsEnvironment: 'stg1', clientId: 'stg-client' }), {
+          status: 200,
+        }),
+      validate: () => new Response(JSON.stringify({ valid: true }), { status: 200 }),
+    });
+    seedAdobeAccount({ accessToken: imsToken(), baseUrl: 'https://adobe-proxy.stg1.test' });
+
+    const { config } = await import('../../providers/adobe.js');
+    await expect(config.onValidateToken?.()).resolves.toMatchObject({ status: 'accepted' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://adobe-proxy.stg1.test/v1/config',
+      expect.anything()
+    );
+    expect(validateCall(fetchSpy)?.[0]).toBe(
+      'https://ims-na1-stg1.adobelogin.com/ims/validate_token/v1'
+    );
+  });
+
+  it('still answers when the proxy config lookup fails', async () => {
+    // The config call is best-effort: a dead proxy must degrade to the
+    // build-time defaults, not stop `--check` from reaching IMS at all.
+    const fetchSpy = stubFetch((url) => {
+      if (url.includes('/v1/config')) throw new Error('proxy down');
+      return new Response(JSON.stringify({ valid: true }), { status: 200 });
+    });
+    seedAdobeAccount({ accessToken: imsToken(), baseUrl: 'https://adobe-proxy.dead.test' });
+
+    const { config } = await import('../../providers/adobe.js');
+    await expect(config.onValidateToken?.()).resolves.toMatchObject({ status: 'accepted' });
+    expect(validateCall(fetchSpy)?.[0]).toBe(IMS_VALIDATE_URL);
   });
 
   it('reads the verdict from the body — IMS answers 200 for a dead token too', async () => {
@@ -184,9 +283,9 @@ describe('adobe onValidateToken (does IMS still accept the token?)', () => {
   });
 
   it('bounds the call so --check always answers', async () => {
-    const fetchSpy = stubFetch(
-      () => new Response(JSON.stringify({ valid: true }), { status: 200 })
-    );
+    const fetchSpy = stubImsFetch({
+      validate: () => new Response(JSON.stringify({ valid: true }), { status: 200 }),
+    });
     seedAdobeAccount({ accessToken: imsToken() });
 
     const { config } = await import('../../providers/adobe.js');
@@ -194,7 +293,7 @@ describe('adobe onValidateToken (does IMS still accept the token?)', () => {
 
     // Without a signal, a stalled IMS would hang the command forever and the
     // caller would get neither a verdict nor an exit code.
-    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(validateCall(fetchSpy)?.[1]?.signal).toBeInstanceOf(AbortSignal);
   });
 });
 

--- a/packages/webapp/tests/providers/adobe-token-validation.test.ts
+++ b/packages/webapp/tests/providers/adobe-token-validation.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Coverage for Adobe's upstream token check (`oauth-token adobe --check`) and
+ * for the IMS profile endpoint an account's display name comes from (#2929).
+ *
+ * Why the check exists: a stored Adobe token well inside its recorded 24h
+ * expiry says nothing about whether IMS still honours it. Before
+ * `onValidateToken`, `--check adobe` could only answer "cannot be checked
+ * upstream", so a healthy token and a revoked one looked identical from the
+ * outside and both ended at a `--force-login` popup.
+ *
+ * The load-bearing detail these tests pin: `/ims/validate_token/v1` answers
+ * **HTTP 200 for both verdicts** and puts the verdict in the body. Reading the
+ * status as the answer would call every revoked token valid.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const oauthServiceMocks = vi.hoisted(() => ({
+  createOAuthLauncher: vi.fn(),
+  getOAuthPageOrigin: vi.fn(),
+}));
+
+vi.mock('../../src/providers/oauth-service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/providers/oauth-service.js')>();
+  return { ...actual, ...oauthServiceMocks };
+});
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => storage.set(k, v),
+  removeItem: (k: string) => storage.delete(k),
+  get length() {
+    return storage.size;
+  },
+  key: (i: number) => [...storage.keys()][i] ?? null,
+  clear: () => storage.clear(),
+});
+
+const IMS_VALIDATE_URL = 'https://ims-na1.adobelogin.com/ims/validate_token/v1';
+
+/** An IMS-shaped access token. Only the `client_id` claim is ever read back. */
+function imsToken(clientId = 'ims-client'): string {
+  const payload = Buffer.from(JSON.stringify({ client_id: clientId })).toString('base64url');
+  return `header.${payload}.signature`;
+}
+
+function seedAdobeAccount(account: { accessToken?: string; userName?: string }): void {
+  storage.set('slicc_accounts', JSON.stringify([{ providerId: 'adobe', apiKey: '', ...account }]));
+}
+
+/** A fetch stub whose recorded calls stay typed, so `init` is inspectable. */
+function stubFetch(
+  answer: () => Response
+): ReturnType<typeof vi.fn<(url: unknown, init?: RequestInit) => Promise<Response>>> {
+  const spy = vi.fn(async (_url: unknown, _init?: RequestInit) => answer());
+  globalThis.fetch = spy as unknown as typeof globalThis.fetch;
+  return spy;
+}
+
+/** The request `onValidateToken` sent, decoded from the form body. */
+function sentForm(init: RequestInit | undefined): URLSearchParams {
+  return new URLSearchParams(String(init?.body));
+}
+
+describe('adobe onValidateToken (does IMS still accept the token?)', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('reports accepted when IMS answers valid, naming the stored identity', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ valid: true }), { status: 200 })
+    ) as typeof globalThis.fetch;
+    seedAdobeAccount({ accessToken: imsToken(), userName: 'Lars Trieloff' });
+
+    const { config } = await import('../../providers/adobe.js');
+    await expect(config.onValidateToken?.()).resolves.toEqual({
+      status: 'accepted',
+      userName: 'Lars Trieloff',
+    });
+  });
+
+  it('asks the endpoint built for the question, with the token’s own client_id', async () => {
+    const fetchSpy = stubFetch(
+      () => new Response(JSON.stringify({ valid: true }), { status: 200 })
+    );
+    const token = imsToken('experience-catalyst-prod');
+    seedAdobeAccount({ accessToken: token });
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onValidateToken?.();
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(IMS_VALIDATE_URL);
+    const form = sentForm(fetchSpy.mock.calls[0]?.[1]);
+    expect(form.get('token')).toBe(token);
+    expect(form.get('type')).toBe('access_token');
+    // Read back from the JWT rather than `proxyConfigCache`, which is empty
+    // until something has fetched /v1/config this session. IMS answers 400
+    // when `client_id` is missing, which would make every cold-page check
+    // report UNKNOWN.
+    expect(form.get('client_id')).toBe('experience-catalyst-prod');
+  });
+
+  it('reads the verdict from the body — IMS answers 200 for a dead token too', async () => {
+    // The whole point of the hook. A revoked token comes back 200 with
+    // `valid: false`; treating the status as the answer would call it good.
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ valid: false, reason: 'bad_signature' }), { status: 200 })
+    ) as typeof globalThis.fetch;
+    seedAdobeAccount({ accessToken: imsToken() });
+
+    const { config } = await import('../../providers/adobe.js');
+    const result = await config.onValidateToken?.();
+    expect(result?.status).toBe('rejected');
+    expect(result?.detail).toContain('bad_signature');
+  });
+
+  it('still rejects when IMS declines to say why', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ valid: false }), { status: 200 })
+    ) as typeof globalThis.fetch;
+    seedAdobeAccount({ accessToken: imsToken() });
+
+    const { config } = await import('../../providers/adobe.js');
+    const result = await config.onValidateToken?.();
+    expect(result?.status).toBe('rejected');
+    expect(result?.detail).toContain('no reason given');
+  });
+
+  it('never calls a malformed request a rejection', async () => {
+    // A 400 is the check failing, not IMS refusing the credential. Reporting
+    // `rejected` here would send a caller with a perfectly good token through
+    // a consent window that cannot fix anything.
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: 'bad_request' }), {
+          status: 400,
+          statusText: 'Bad Request',
+        })
+    ) as typeof globalThis.fetch;
+    seedAdobeAccount({ accessToken: imsToken() });
+
+    const { config } = await import('../../providers/adobe.js');
+    await expect(config.onValidateToken?.()).resolves.toEqual({
+      status: 'unknown',
+      detail: 'HTTP 400 Bad Request',
+    });
+  });
+
+  it('reports unknown when the call itself fails', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('Failed to fetch');
+    }) as unknown as typeof globalThis.fetch;
+    seedAdobeAccount({ accessToken: imsToken() });
+
+    const { config } = await import('../../providers/adobe.js');
+    await expect(config.onValidateToken?.()).resolves.toEqual({
+      status: 'unknown',
+      detail: 'Failed to fetch',
+    });
+  });
+
+  it('reports unknown without calling IMS when nothing is stored', async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    seedAdobeAccount({});
+
+    const { config } = await import('../../providers/adobe.js');
+    await expect(config.onValidateToken?.()).resolves.toEqual({
+      status: 'unknown',
+      detail: 'no stored token',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('bounds the call so --check always answers', async () => {
+    const fetchSpy = stubFetch(
+      () => new Response(JSON.stringify({ valid: true }), { status: 200 })
+    );
+    seedAdobeAccount({ accessToken: imsToken() });
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onValidateToken?.();
+
+    // Without a signal, a stalled IMS would hang the command forever and the
+    // caller would get neither a verdict nor an exit code.
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('adobe IMS profile lookup (where the display name comes from)', () => {
+  const proxyEndpoint = 'https://adobe-proxy.profile.test';
+  let originalFetch: typeof globalThis.fetch;
+  let originalWindow: unknown;
+  let originalDocument: unknown;
+  let requested: string[];
+
+  /** Answers for the two IMS profile endpoints, keyed by path. */
+  type ProfileAnswers = Record<'/ims/profile/v1' | '/ims/userinfo/v2', unknown>;
+
+  function installFetch(answers: ProfileAnswers): void {
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      const value = String(url);
+      requested.push(value);
+      if (value === `${proxyEndpoint}/v1/config`) {
+        return new Response(JSON.stringify({ clientId: 'adobe-client', scopes: 'openid' }), {
+          status: 200,
+        });
+      }
+      for (const [path, body] of Object.entries(answers)) {
+        if (!value.endsWith(path)) continue;
+        return body === undefined
+          ? new Response('', { status: 404 })
+          : new Response(JSON.stringify(body), { status: 200 });
+      }
+      if (value === `${proxyEndpoint}/v1/models`) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response('', { status: 503 });
+    }) as typeof globalThis.fetch;
+  }
+
+  async function loginAndReadAccount(): Promise<
+    { userName?: string; accessToken?: string } | undefined
+  > {
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: 'adobe', apiKey: '', baseUrl: proxyEndpoint }])
+    );
+    const launcher = vi.fn(async (authorizeUrl: string) => {
+      const authorize = new URL(authorizeUrl);
+      const state = JSON.parse(atob(authorize.searchParams.get('state')!)) as { nonce: string };
+      const redirectUri = authorize.searchParams.get('redirect_uri')!;
+      return `${redirectUri}?nonce=${state.nonce}#access_token=${imsToken()}&expires_in=86400`;
+    });
+    const { config } = await import('../../providers/adobe.js');
+    await config.onOAuthLogin?.(launcher, () => {});
+    const { getAccounts } = await import('../../src/ui/provider-settings.js');
+    return getAccounts().find((candidate) => candidate.providerId === 'adobe');
+  }
+
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+    requested = [];
+    originalFetch = globalThis.fetch;
+    originalWindow = (globalThis as { window?: unknown }).window;
+    originalDocument = (globalThis as { document?: unknown }).document;
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: 'http://localhost:5710', href: 'http://localhost:5710/' },
+    };
+    (globalThis as { document?: unknown }).document = {};
+    oauthServiceMocks.getOAuthPageOrigin.mockResolvedValue({
+      origin: 'http://localhost:5710',
+      href: 'http://localhost:5710/',
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+    else (globalThis as { window?: unknown }).window = originalWindow;
+    if (originalDocument === undefined) delete (globalThis as { document?: unknown }).document;
+    else (globalThis as { document?: unknown }).document = originalDocument;
+  });
+
+  it('takes the name from /ims/profile/v1 without asking the OIDC endpoint', async () => {
+    installFetch({
+      '/ims/profile/v1': { displayName: 'Lars Trieloff', email: 'lars@example.com' },
+      '/ims/userinfo/v2': { displayName: 'should not be reached' },
+    });
+
+    const account = await loginAndReadAccount();
+
+    expect(account?.userName).toBe('Lars Trieloff');
+    expect(requested.some((url) => url.endsWith('/ims/userinfo/v2'))).toBe(false);
+  });
+
+  it('names the user even when the OIDC endpoint answers with only a subject', async () => {
+    // The #2929 shape, verified against live IMS: `/ims/userinfo/v2` returns
+    // `{"sub":"..."}` and nothing else unless the token carries the `profile`
+    // / `email` scopes, which the proxy's scope set does not. Asking it alone
+    // left every Adobe account with no display name at all.
+    installFetch({
+      '/ims/profile/v1': { displayName: 'Lars Trieloff' },
+      '/ims/userinfo/v2': { sub: '4C5F22E269164EE60A495EE4@AdobeID' },
+    });
+
+    const account = await loginAndReadAccount();
+
+    expect(account?.userName).toBe('Lars Trieloff');
+  });
+
+  it('falls back to the OIDC endpoint when the profile endpoint names nobody', async () => {
+    // Kept as a fallback rather than replaced outright: a client whose scopes
+    // make the OIDC endpoint the richer of the two must not regress.
+    installFetch({
+      '/ims/profile/v1': { sub: 'opaque-id-only' },
+      '/ims/userinfo/v2': { displayName: 'Adobe User' },
+    });
+
+    const account = await loginAndReadAccount();
+
+    expect(account?.userName).toBe('Adobe User');
+    expect(requested.some((url) => url.endsWith('/ims/profile/v1'))).toBe(true);
+  });
+
+  it('still completes the login when no endpoint names the user', async () => {
+    installFetch({ '/ims/profile/v1': undefined, '/ims/userinfo/v2': undefined });
+
+    const account = await loginAndReadAccount();
+
+    // A missing display name is cosmetic — it must never cost the token.
+    expect(account?.userName).toBeUndefined();
+    expect(account?.accessToken).toBe(imsToken());
+  });
+});

--- a/packages/webapp/tests/providers/oauth-sync.test.ts
+++ b/packages/webapp/tests/providers/oauth-sync.test.ts
@@ -110,6 +110,27 @@ describe('saveOAuthAccount — CLI sync to /api/secrets/oauth-update', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('names the resolved target when a 2xx comes back without a mask', async () => {
+    // #2929: a misrouted push reaches the tray hub, which answers 200 with its
+    // route catalog for any unmatched path. `r.ok` is true and the JSON parses,
+    // so at this call site the reply is indistinguishable from a real replica
+    // that declined — the breadcrumb has to name where the POST actually went
+    // or the operator debugs a node-server that never saw the request.
+    globalThis.fetch = vi.fn(
+      async () => ({ ok: true, json: async () => ({ routes: ['/tray', '/join'] }) }) as any
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { saveOAuthAccount } = await import('../../src/ui/provider-settings.js');
+    await saveOAuthAccount({ providerId: 'github', accessToken: 'ghp_real_token' });
+
+    const logged = warn.mock.calls.find((c) =>
+      c.some((a) => String(a).includes('missing maskedValue'))
+    );
+    expect(logged).toBeDefined();
+    expect(JSON.stringify(logged)).toContain('/api/secrets/oauth-update');
+    warn.mockRestore();
+  });
+
   it('persists granted scopes and surfaces them via getOAuthAccountInfo', async () => {
     globalThis.fetch = vi.fn(async () => ({ ok: false }) as any);
 

--- a/packages/webapp/tests/ui/boot/bridge-launch-params.test.ts
+++ b/packages/webapp/tests/ui/boot/bridge-launch-params.test.ts
@@ -42,13 +42,49 @@ describe('parseBridgeLaunchParams', () => {
 
   it('accepts wss:// bridge URLs (apiBaseUrl uses https://, lickWsUrl uses wss://)', () => {
     const params = parseBridgeLaunchParams(
-      '?bridge=wss%3A%2F%2Fbridge.example%2Fcdp&bridgeToken=xyz'
+      '?bridge=wss%3A%2F%2Flocalhost%3A5710%2Fcdp&bridgeToken=xyz'
     );
-    expect(params?.url).toBe('wss://bridge.example/cdp');
+    expect(params?.url).toBe('wss://localhost:5710/cdp');
     expect(params?.subprotocol).toBe('slicc.bridge.v1.xyz');
     expect(params?.token).toBe('xyz');
-    expect(params?.apiBaseUrl).toBe('https://bridge.example');
-    expect(params?.lickWsUrl).toBe('wss://bridge.example/licks-ws');
+    expect(params?.apiBaseUrl).toBe('https://localhost:5710');
+    expect(params?.lickWsUrl).toBe('wss://localhost:5710/licks-ws');
+  });
+
+  it('rejects a bridge pointing anywhere but loopback', () => {
+    // The query string is attacker-suppliable — the page is served from the
+    // hosted origin, so a crafted link can name any host here. `apiBaseUrl` is
+    // derived straight from it, which would aim the local /api surface (and the
+    // boot-time OAuth replica push, raw access tokens included) at a remote
+    // server that only has to permit the request via CORS (#2939 review).
+    for (const host of [
+      'attacker.example',
+      'bridge.example',
+      '169.254.169.254',
+      '10.0.0.5',
+      'localhost.attacker.example',
+      '127.0.0.1.attacker.example',
+    ]) {
+      expect(
+        parseBridgeLaunchParams(`?bridge=${encodeURIComponent(`wss://${host}/cdp`)}&bridgeToken=x`)
+      ).toBeNull();
+    }
+  });
+
+  it('accepts every loopback spelling a launcher may emit', () => {
+    // Must match `isLoopbackHostname` — a stricter check here would break the
+    // IPv6 and 127.0.0.0/8 launches the servers legitimately produce.
+    for (const host of ['localhost', '127.0.0.1', '127.0.0.2', '[::1]']) {
+      const params = parseBridgeLaunchParams(
+        `?bridge=${encodeURIComponent(`ws://${host}:5710/cdp`)}&bridgeToken=x`
+      );
+      expect(params, host).not.toBeNull();
+      expect(params?.apiBaseUrl).toBe(`http://${host}:5710`);
+    }
+  });
+
+  it('returns null when the bridge URL passes the scheme test but will not parse', () => {
+    expect(parseBridgeLaunchParams('?bridge=ws://%5B/cdp&bridgeToken=x')).toBeNull();
   });
 
   it('extracts role=leader and role=follower when the launcher stamped one', () => {

--- a/packages/webapp/tests/ui/main-oauth-bridge-wiring.test.ts
+++ b/packages/webapp/tests/ui/main-oauth-bridge-wiring.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression guard for #2929: `ui/main.ts` MUST wire the local /api base and
+ * bridge token BEFORE it calls `bootstrapOAuthReplicas()`.
+ *
+ * The bug this pins: the bootstrap re-pushes every stored OAuth token to the
+ * local node-server's secrets replica, but the wiring only happened later, in
+ * `setupStandalonePrelude`. With `localApiBaseUrl` still unset,
+ * `resolveApiUrl('/api/secrets/oauth-update')` yields a bare relative path,
+ * which on a thin-bridge leader resolves against the hosted origin
+ * (`www.sliccy.ai`) rather than the node-server. The tray hub answers 200
+ * with its route catalog for any unmatched path, so `r.ok` was true, no
+ * `maskedValue` came back, and every account lost its mask on every page
+ * load — `oauth-token <id>` then reported no usable token and demanded a
+ * `--force-login` popup. Two bugs for the price of one, since the raw access
+ * token was also handed to an origin that never needed it.
+ *
+ * Static-source guard, matching `main-telemetry.test.ts`: main.ts has a long
+ * async boot sequence that is expensive to mock, and the invariant at stake
+ * here is purely one of ORDER. The behaviour of the mask handling itself is
+ * covered by `providers/oauth-sync.test.ts`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, '..', '..', 'src', 'ui', 'main.ts'), 'utf8');
+
+describe('ui/main.ts OAuth replica bridge wiring', () => {
+  it('imports both setters from the proxied-fetch module', () => {
+    expect(source).toMatch(
+      /import\s+\{\s*setBridgeToken,\s*setLocalApiBaseUrl\s*\}\s+from\s+['"]\.\.\/shell\/proxied-fetch\.js['"]/
+    );
+  });
+
+  it('sets the local API base before the OAuth bootstrap runs', () => {
+    const wiringIdx = source.indexOf('setLocalApiBaseUrl(bridge.apiBaseUrl)');
+    const bootstrapIdx = source.indexOf('bootstrapOAuthReplicas()');
+    expect(wiringIdx).toBeGreaterThan(-1);
+    expect(bootstrapIdx).toBeGreaterThan(-1);
+    expect(wiringIdx).toBeLessThan(bootstrapIdx);
+  });
+
+  it('pairs the API base with the bridge token', () => {
+    // The node-server enforces `X-Bridge-Token` on cross-origin /api/*, so a
+    // base without the token would swap one silent failure for another.
+    const tokenIdx = source.indexOf('setBridgeToken(bridge.token)');
+    const bootstrapIdx = source.indexOf('bootstrapOAuthReplicas()');
+    expect(tokenIdx).toBeGreaterThan(-1);
+    expect(tokenIdx).toBeLessThan(bootstrapIdx);
+  });
+
+  it('skips the wiring on the extension-delegate path, as the prelude does', () => {
+    // `setupStandalonePrelude` does not parse bridge params when the
+    // extension bridge is in play; wiring them here would diverge from it.
+    expect(source).toMatch(
+      /if\s*\(bridge\?\.apiBaseUrl\s*&&\s*!extensionDelegate\)\s*\{[\s\S]{0,200}setLocalApiBaseUrl/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two bugs behind "`oauth-token adobe` opens a popup, the token lasts a few minutes, and the dance repeats." The token was never short-lived — it was valid for another 23 hours every time. What kept breaking was its **mask**, because the boot-time replica push was silently misrouted to the hosted origin, so `oauth-token` reported no usable token and demanded a `--force-login`. This routes that push at the local node-server, and adds an Adobe `onValidateToken` so `--check` can ask Adobe whether the stored token still works instead of only reporting what is stored locally.

> **Rebased onto #2921.** That PR landed a refactor of this same mask code and fixed the *recovery* half of this bug a better way than I had. See "Overlap with #2921" below for what I dropped as a result.

## Why

Diagnosed live over CDP against a running instance. The chain:

1. `bootstrapOAuthReplicas()` re-pushes every stored token to the local secrets replica on each page load.
2. The bridge wiring it needs to reach the node-server — `setLocalApiBaseUrl` / `setBridgeToken` — only happened **later**, in `setupStandalonePrelude`.
3. With the API base unset, `resolveApiUrl('/api/secrets/oauth-update')` returns a bare relative path. On a thin-bridge leader the page is served from the hosted origin, so the POST went to the **tray hub** — which answers `200` with its route catalog for any unmatched path.
4. `r.ok` was true and the JSON parsed, so this looked like a successful sync, while no `maskedValue` came back and the raw access token was handed to an origin that never needed it.
5. `oauth-token adobe` treats a token with no mask as unusable → `--force-login` → popup. Every reload. Paired with an unrelated kernel-worker crash-reload loop, it looked exactly like tokens expiring every few minutes.

Server logs on the affected instance showed days with 44k requests and **zero** `/api/secrets/oauth-update` POSTs reaching the node-server, which matches.

Separately, `--check adobe` could only answer "cannot be checked upstream", so a healthy token and a revoked one were indistinguishable and both ended at the same popup.

**Repro** (thin-bridge leader, any OAuth provider): log in, confirm `oauth-token <id>` prints a masked token, reload, run it again. Before #2921 it reported no usable token; after #2921 it recovers by remasking, but the boot push is still misrouted and still leaks the token to the hosted origin.

## Overlap with #2921

#2921 added `ensureOAuthMaskReplica`, wired into `oauth-token/run.ts`, which remasks lazily when the replica is missing. My original second commit instead had `saveOAuthAccount` carry the previous `maskedValue` forward on a failed push. **I dropped that on rebase**, for two reasons:

- It is redundant. Re-deriving the mask is strictly better than reusing the old one.
- On top of #2921 it would be a regression. #2921 added `attachMaskIfTokenUnchanged` specifically so a replica never attaches to a rotated token. An unconditional carry-forward would let a *new* token inherit the *old* token's mask, and `isUsableOAuthMaskReplica` (which only checks `mask !== accessToken`) would not catch it — so `ensureOAuthMaskReplica` would return a stale mask pointing at a revoked token instead of remasking.

What remains from that commit is the root-cause fix (#1 below) plus a logging breadcrumb. `docs/pitfalls.md` records the reasoning, including why re-deriving beats carrying forward.

## What changed

**1. Boot ordering** (`ui/main.ts`) — wire the API base and bridge token before the OAuth bootstrap, mirroring the prelude's own condition (skipped on the extension-delegate path). Setting it twice is idempotent; setting it late is not. This is what stops the misrouted POST, and it is the only part of the change that closes the token leak — #2921's lazy remask recovers the mask but runs *after* boot, so without this the boot push still goes to the hosted origin every time.

I deliberately did **not** add an origin guard that refuses to POST when the target looks remote: in classic CLI mode a relative path is correct (the page *is* the node-server), and the topology signals available in `providers/` cannot tell that apart from the hosted case without a float probe.

**2. Breadcrumb** (`providers/account-store.ts`) — both failure paths in `persistCliMaskReplica` now log the resolved URL. A 2xx from the wrong origin is otherwise indistinguishable at the call site from a replica that declined, which is exactly what made this cost days.

**3. Adobe `onValidateToken`** (`providers/adobe.ts`) — `POST {imsHost}/ims/validate_token/v1` with `client_id` / `token` / `type=access_token`. Verified against live IMS:

| Case | IMS response | Hook returns |
| --- | --- | --- |
| Valid token | `200 {"valid":true,"token":{…}}` | `accepted` |
| Tampered token | `200 {"valid":false,"reason":"bad_signature"}` | `rejected` |
| No token in request | `400 {"error":"bad_request"}` | `unknown` |

The trap worth knowing: **IMS answers 200 for both verdicts** and puts the answer in the body. Reading the status as the verdict would call every revoked token valid, and a non-2xx there is the check failing — `unknown`, never a rejection that would send a caller with a good token through a consent window. The required `client_id` is read back from the access token's own JWT claims rather than from `proxyConfigCache`, which is empty until something has fetched `/v1/config`; without that, every cold-page check would report `UNKNOWN`. Bounded with `AbortSignal.timeout(10s)` so `--check` always answers.

**4. Display name** (`providers/adobe.ts`) — found while testing (3): `/ims/userinfo/v2`, the endpoint the login flow used, returns nothing but `{"sub":"…"}` unless the token carries the `profile` / `email` scopes, which the proxy's scope set does not. Every Adobe account was therefore stored with no name at all. `/ims/profile/v1` answers with `displayName` for the same token; it is now asked first, with the OIDC endpoint kept as the fallback for clients whose scopes make it the richer of the two.

## Cross-cutting impact

- **Floats exercised**: the boot-ordering fix is page-realm (`ui/main.ts`), so it affects CLI / Electron / Sliccstart / hosted-leader thin-bridge boots. The extension-delegate path is explicitly excluded, matching `setupStandalonePrelude`. Cherry / follower boots return before this code.
- **Persisted state**: unchanged. Dropping the carry-forward means this PR no longer alters how `maskedValue` is written — #2921 owns that field end to end.
- **Security**: the misrouted POST was sending raw access tokens to the hosted origin on every boot; (1) closes that. No secrets are added to logs — the new `url` field is the request target only, never the body.
- **Bundle size**: `+0.2 kB` page, `+0.1 kB` worker.

## Test plan

- [x] `npm run verify` — all 8 checks passed (includes the boy-scout debt gate)
- [x] `npm run typecheck` — all 9 projects
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] Coverage gate — statements 83.2% (floor 82), branches 74.86% (74), functions 83.29% (83), lines 85.17% (84)
- [x] Affected suites, post-rebase: 39 passing across `oauth-sync.test.ts` (23), `adobe-token-validation.test.ts` (12), `main-oauth-bridge-wiring.test.ts` (4). #2921's own `attachMaskIfTokenUnchanged` / `isUsableOAuthMaskReplica` guards still fire in their tests.
- [x] New behaviour covered:
  - `packages/webapp/tests/providers/adobe-token-validation.test.ts` — both verdicts at HTTP 200, 400-is-not-a-rejection, JWT-derived `client_id`, timeout bound, profile-endpoint ordering
  - `packages/webapp/tests/providers/oauth-sync.test.ts` — the 2xx-without-a-mask breadcrumb names the resolved target
  - `packages/webapp/tests/ui/main-oauth-bridge-wiring.test.ts` — source-order guard, matching `main-telemetry.test.ts`
- [x] Verified live over CDP against a real Adobe IMS token: `validate_token/v1` returns `valid:true` for the stored token and `valid:false` / `bad_signature` for a tampered one; `/ims/profile/v1` returns a `displayName` where `/ims/userinfo/v2` returns only `sub`.

**Pre-existing failure on `main`, not from this PR**: `packages/webapp/tests/fs/zenfs-preload-concurrency.test.ts` fails 5/5 (`expected 56 to be 16`). Reproduced identically on a detached checkout of `origin/main`, and it fails in isolation, so it is a deterministic breakage rather than a flake. It aborts the coverage gate before thresholds are computed; the numbers above were taken with that one file set aside. Not fixed here — out of scope, and it needs its own change.

## Documentation

- [x] `docs/` — `shell-reference.md` (per-provider `--check` table + the IMS body-not-status trap), `oauth-intercept.md` (new "Upstream token validation" section), `pitfalls.md` (new "A 200 From the Hosted Origin Is Not a Successful `/api` Call", including why re-deriving a lost mask beats carrying the old one forward)
- [x] `.agents/skills/adding-slicc-features/SKILL.md` — "read the verdict where the provider puts it" rule for `onValidateToken`

## Risk & rollback

Blast radius is the OAuth boot path on every non-extension float. Reverts cleanly — no migration, no flag, and no change to persisted account shape.

Worth verifying by hand before approving (CI cannot): a real thin-bridge leader boot, confirming the `/api/secrets/oauth-update` POST now lands on the node-server rather than the hosted origin, and one `oauth-token adobe --check` round-trip against live IMS.

---

## Review round 1 (all threads resolved)

**P1 — bridge launch param accepted any host** (`94b732eb0`). `parseBridgeLaunchParams` validated only the `ws://`/`wss://` scheme while `apiBaseUrl` is derived straight from that host, so a crafted hosted-origin link could aim the local `/api` surface — the boot-time OAuth push included — at a remote server. Fixed at the parser rather than my call site, because `setupSwRegistration` receives the same unvalidated value a few lines earlier and the prelude wires it again later; one check now covers the SW registration, `/api` base, lick socket and CDP dial. Loopback is the documented contract already stated on the type, and every producer emits `ws://localhost:<cdpPort>/cdp`, so no legitimate launch changes. Uses the canonical `isLoopbackHostname` from `@slicc/shared-ts`.

**P1 — carry-forward could pin a stale mask** — dropped entirely on the rebase onto #2921; see "Overlap with #2921" above. The reviewer independently reached the same conclusion, and traced a consequence worth recording: GitHub's renewal path writes the mask into git config, so a stale mask would have left shell operations on a dead credential after a *successful* renewal.

**P2 — a 200 with no verdict rejected** (`b4dd0c6b8`). Only `valid: false` rejects now; an IMS error envelope or truncated body is `unknown`. This contradicted the rule the rest of the hook follows.

**P2 — IMS environment came from the first cached config** (`b4dd0c6b8`). `--check` now resolves the config for the endpoint *this account* uses, fixing both the stale-after-proxy-switch read and the cold page silently falling back to production IMS. Bounded at 5s and degrading to build-time defaults, since `fetchProxyConfig` has no timeout of its own and `--check` must always answer.

Both Adobe fixes were mutation-tested: reverting either one fails its new test.

**Left for a separate change**: `silentRenewToken` reads `proxyConfigCache` the same first-value way (pre-existing, `adobe.ts` ~L536). Same bug class, outside this PR's scope.

### Re-verified after the review fixes

`npm run verify` (8/8) · `npm run typecheck` (9 projects) · `npm run test` — 20,378 passing · coverage statements 83.16/82, branches 74.9/74, functions 83.31/83, lines 85.12/84 · both builds. The only failures are the 5 pre-existing `zenfs-preload-concurrency` cases documented above, which also fail on a clean `origin/main`.
