### PR TITLE
fix(swift-server): actually suppress the Keychain ACL dialog when headless

### DIFF
--- a/docs/swift-server-details.md
+++ b/docs/swift-server-details.md
@@ -80,7 +80,14 @@ The durable fix is a stable code-signing identity (`packages/dev-tools/tools/set
 - The identity must be TRUSTED, not just imported. A self-signed cert imports as `CSSMERR_TP_NOT_TRUSTED`, so `security find-identity -v -p codesigning` (the valid-only form both `setup-dev-cert.sh` and `dev-swift-fresh.sh` use to detect it) lists nothing, and the harness silently falls back to ad-hoc signing — leaving `/api/secrets/masked` empty.
 - `setup-dev-cert.sh` therefore runs `security add-trusted-cert -p codeSign` in the user trust domain (no `sudo`/`-d`, applied non-interactively) after import, and de-duplicates any pre-existing copies by SHA-1 hash first (a CN is "ambiguous" once stacked) so exactly one valid identity remains.
 
-`SLICC_KEYCHAIN_NONINTERACTIVE=1` (set by the dev fresh-bridge harness) is only an anti-hang guard, not a fix for the prompt: it makes `readBlob` pass `kSecUseAuthenticationUIFail` so a headless launch that would otherwise block on the unanswerable dialog fails fast with `errSecInteractionNotAllowed` instead of hanging. An already-granted item still reads fine; otherwise the read path logs an actionable hint and the server continues without Keychain secrets. It never produces silent success.
+`SLICC_KEYCHAIN_NONINTERACTIVE=1` (set by the dev fresh-bridge harness) is only an anti-hang guard, not a fix for the prompt: a headless launch that would otherwise block on the unanswerable dialog fails fast with `errSecInteractionNotAllowed` instead of hanging. An already-granted item still reads fine; otherwise the read path logs an actionable hint and the server continues without Keychain secrets. It never produces silent success.
+
+Suppressing that dialog takes **two** switches, and only the second one actually works on this item:
+
+- `kSecUseAuthenticationUIFail` (`kSecUseAuthenticationUI`) governs the **data-protection** keychain. `ai.sliccy.slicc / __envfile__` is a **file-based** keychain item, so `SecItemCopyMatching` dispatches to `SecItemCopyMatching_osx` and the flag has no effect on the ACL dialog.
+- `SecKeychainSetUserInteractionAllowed(false)` is the process-wide switch that does gate it. `SecretStore.withInteractionSuppressed` wraps every `SecItem*` call in read **and** write paths with it, restoring the previous state afterwards; interactive runs never touch the switch, so the first-run "Always Allow" grant still works.
+
+Without the second switch the guard silently does nothing: a `nohup`-style launch hangs inside `SecItemCopyMatching` forever — **before** Hummingbird binds, so there is no port, no log line, and no Chrome — which reads as "the binary is broken" rather than "the Keychain is waiting". `KeychainSecretStoreTests` asserts the switch is flipped and restored; an assertion that only round-trips an already-granted item cannot catch this, because the test runner needs no dialog.
 
 ## API route contracts
 

--- a/packages/swift-server/Sources/Keychain/SecretStore.swift
+++ b/packages/swift-server/Sources/Keychain/SecretStore.swift
@@ -82,6 +82,37 @@ enum SecretStore {
         ProcessInfo.processInfo.environment["SLICC_KEYCHAIN_NONINTERACTIVE"] == "1"
     }
 
+    /// Seam over the process-wide legacy-Keychain interaction switch. Tests
+    /// substitute a recorder; production flips the real switch.
+    ///
+    /// `SecKeychainSetUserInteractionAllowed` is deprecated (as is the
+    /// `kSecUseAuthenticationUI` key below) but remains the only switch that
+    /// governs the *file-based* keychain's ACL dialog — the keychain
+    /// `ai.sliccy.slicc / __envfile__` actually lives in. Its replacement,
+    /// `LAContext.interactionNotAllowed`, covers the data-protection keychain
+    /// only, so it cannot suppress this dialog.
+    static var setUserInteractionAllowed: (Bool) -> Void = { allowed in
+        SecKeychainSetUserInteractionAllowed(allowed)
+    }
+
+    /// Run `body` with the legacy Keychain's ACL dialog suppressed whenever
+    /// `SLICC_KEYCHAIN_NONINTERACTIVE=1`.
+    ///
+    /// `kSecUseAuthenticationUIFail` governs the data-protection keychain only.
+    /// The dialog that `SecItemCopyMatching` raises for a *file-based* keychain
+    /// item whose ACL does not yet trust this binary — the `SecItemCopyMatching_osx`
+    /// path, which is what `ai.sliccy.slicc / __envfile__` is — is gated by the
+    /// process-wide `SecKeychainSetUserInteractionAllowed` switch instead. With
+    /// the flag alone, a headless launch blocks inside `SecItemCopyMatching`
+    /// forever, before the HTTP server ever binds, which is precisely the hang
+    /// the env var exists to prevent.
+    private static func withInteractionSuppressed<T>(_ body: () throws -> T) rethrows -> T {
+        guard nonInteractive else { return try body() }
+        setUserInteractionAllowed(false)
+        defer { setUserInteractionAllowed(true) }
+        return try body()
+    }
+
     static func get(name: String) -> Secret? {
         readSecrets().first(where: { $0.name == name })
     }
@@ -153,7 +184,9 @@ enum SecretStore {
             query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
         }
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = withInteractionSuppressed {
+            SecItemCopyMatching(query as CFDictionary, &result)
+        }
         if status == errSecItemNotFound {
             return ""
         }
@@ -169,6 +202,10 @@ enum SecretStore {
     }
 
     /// Replace the env-file blob in Keychain (creates the item on first use).
+    ///
+    /// A write raises the same ACL dialog a read does, so it runs under the
+    /// same suppression — otherwise a headless `POST /api/secrets` would hang
+    /// the request instead of returning an error.
     static func writeBlob(_ content: String) throws {
         let valueData = Data(content.utf8)
         let searchQuery: [String: Any] = [
@@ -177,10 +214,12 @@ enum SecretStore {
             kSecAttrAccount as String: keychainAccount,
         ]
 
-        let updateStatus = SecItemUpdate(
-            searchQuery as CFDictionary,
-            [kSecValueData as String: valueData] as CFDictionary
-        )
+        let updateStatus = withInteractionSuppressed {
+            SecItemUpdate(
+                searchQuery as CFDictionary,
+                [kSecValueData as String: valueData] as CFDictionary
+            )
+        }
 
         if updateStatus == errSecSuccess {
             return
@@ -189,7 +228,7 @@ enum SecretStore {
         if updateStatus == errSecItemNotFound {
             var addQuery = searchQuery
             addQuery[kSecValueData as String] = valueData
-            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            let addStatus = withInteractionSuppressed { SecItemAdd(addQuery as CFDictionary, nil) }
             guard addStatus == errSecSuccess else {
                 throw SecretStoreError.keychainError(status: addStatus)
             }

--- a/packages/swift-server/Tests/KeychainSecretStoreTests.swift
+++ b/packages/swift-server/Tests/KeychainSecretStoreTests.swift
@@ -138,4 +138,62 @@ final class KeychainSecretStoreTests: XCTestCase {
         XCTAssertNoThrow(try SecretStore.readBlob())
         XCTAssertEqual(SecretStore.get(name: name)?.value, "ghp_noninteractive")
     }
+
+    /// The test above cannot catch the hang it describes: the runner already
+    /// holds ACL access, so no dialog is raised either way. What actually keeps
+    /// a headless launch from blocking inside `SecItemCopyMatching` on the
+    /// legacy file-based keychain is `SecKeychainSetUserInteractionAllowed` —
+    /// `kSecUseAuthenticationUIFail` only covers the data-protection keychain.
+    /// Assert the switch is flipped around the read, and restored after it.
+    func testNonInteractiveReadSuppressesLegacyKeychainInteraction() throws {
+        setenv("SLICC_KEYCHAIN_NONINTERACTIVE", "1", 1)
+        var calls: [Bool] = []
+        SecretStore.setUserInteractionAllowed = { calls.append($0) }
+        defer {
+            unsetenv("SLICC_KEYCHAIN_NONINTERACTIVE")
+            SecretStore.setUserInteractionAllowed = { allowed in
+                SecKeychainSetUserInteractionAllowed(allowed)
+            }
+        }
+
+        _ = try? SecretStore.readBlob()
+
+        XCTAssertEqual(calls, [false, true], "read must suppress interaction, then restore it")
+    }
+
+    /// A write raises the same dialog, so `POST /api/secrets` must not be able
+    /// to hang a request the way startup could hang a launch.
+    func testNonInteractiveWriteSuppressesLegacyKeychainInteraction() throws {
+        setenv("SLICC_KEYCHAIN_NONINTERACTIVE", "1", 1)
+        var calls: [Bool] = []
+        SecretStore.setUserInteractionAllowed = { calls.append($0) }
+        defer {
+            unsetenv("SLICC_KEYCHAIN_NONINTERACTIVE")
+            SecretStore.setUserInteractionAllowed = { allowed in
+                SecKeychainSetUserInteractionAllowed(allowed)
+            }
+        }
+
+        try SecretStore.set(name: secretName("NONINTERACTIVE_WRITE"), value: "v", domains: ["a.com"])
+
+        XCTAssertTrue(calls.contains(false), "write must suppress interaction")
+        XCTAssertEqual(calls.last, true, "write must restore interaction")
+    }
+
+    /// Without the env var the switch must never be touched: an interactive
+    /// Sliccstart run depends on the first-run "Always Allow" grant working.
+    func testInteractiveRunLeavesTheInteractionSwitchAlone() throws {
+        unsetenv("SLICC_KEYCHAIN_NONINTERACTIVE")
+        var calls: [Bool] = []
+        SecretStore.setUserInteractionAllowed = { calls.append($0) }
+        defer {
+            SecretStore.setUserInteractionAllowed = { allowed in
+                SecKeychainSetUserInteractionAllowed(allowed)
+            }
+        }
+
+        _ = try? SecretStore.readBlob()
+
+        XCTAssertTrue(calls.isEmpty, "interactive runs must not suppress the ACL dialog")
+    }
 }


### PR DESCRIPTION
## Summary

`SLICC_KEYCHAIN_NONINTERACTIVE=1` is documented as the anti-hang guard for headless swift-server launches, but it did not work. Before: a headless launch blocked forever inside `SecItemCopyMatching` at startup — no listening port, no log line, no Chrome, no output, which reads as a broken binary rather than a waiting Keychain. Now: the read fails fast and the server boots without Keychain secrets, exactly as documented.

## Why

The guard only passed `kSecUseAuthenticationUIFail`. That key governs the **data-protection** keychain. `ai.sliccy.slicc / __envfile__` is a **file-based** keychain item, so `SecItemCopyMatching` dispatches to `SecItemCopyMatching_osx`, where the ACL dialog is gated by the process-wide `SecKeychainSetUserInteractionAllowed` switch instead. Headless, that dialog can never be answered or even drawn, so the process waits indefinitely.

Found while exercising `secret set` end to end against the swift bridge: the server never came up.

**Repro**:

1. `swift build`
2. `PORT=5716 SLICC_KEYCHAIN_NONINTERACTIVE=1 nohup ./.build/debug/slicc-server --cdp-port 9232 --profile e2e &`
3. `lsof -nP -iTCP:5716 -sTCP:LISTEN`

Expected: the server binds `:5716`, logs an actionable Keychain hint, and continues without Keychain secrets.
Actual: nothing bound, log file empty, process alive at ~0% CPU indefinitely.

`sample <pid>` puts the whole process below `SecretInjector.init`, before Hummingbird binds:

```
ServerCommand.run() → SecretInjector.init → loadSecretsKeychainAndEnvSnapshot
  → SecretStore.all() → readSecrets() → readBlob() → SecItemCopyMatching
    → SecItemCopyMatching_osx → AddItemResults      [blocked 2.5 min]
```

## Approach / Implementation notes

- `SecretStore.withInteractionSuppressed` wraps the `SecItem*` calls with `SecKeychainSetUserInteractionAllowed(false)` and restores the previous state after. `kSecUseAuthenticationUIFail` is kept: it is correct for the data-protection keychain, just insufficient here.
- Applied to the **write** path as well, not only the read: a write raises the same dialog, so a headless `POST /api/secrets` could hang a request the way startup hung a launch.
- Interactive runs never touch the switch, so the first-run **"Always Allow"** grant that `setup-dev-cert.sh` depends on still works.
- The API is deprecated and documented as such at the seam: its replacement (`LAContext.interactionNotAllowed`) covers the data-protection keychain only, so it cannot suppress this dialog. The deprecation warning matches the pre-existing one on `kSecUseAuthenticationUIFail` a few lines below.
- Behind a `setUserInteractionAllowed` seam so tests can observe the suppression without a real ACL dialog.

## Cross-cutting impact

- **Floats exercised**: Sliccstart / swift-server only. `packages/node-server` has no Keychain path, so there is no twin to keep in sync.
- **Other callers of the changed contract**: every `SecretStore` caller goes through `readSecrets()` / `mutate()`, which funnel into `readBlob()` / `writeBlob()`. Both are wrapped, so `get` / `list` / `all` / `set` / `delete` and the `SecretStoreAccess.keychain` adapter are all covered by one change. Error shapes are unchanged: `errSecInteractionNotAllowed` already had a fail-fast branch in `readSecrets()` that this makes reachable for the first time.
- **Persisted state**: none. The Keychain blob format is untouched; only whether a dialog may be raised while reading or writing it.
- **Security**: no change to what is stored or who may read it. The ACL still governs access; this only decides whether an unanswerable prompt is raised instead of an error being returned.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 111 passing, 0 failures (`KeychainSecretStoreTests` 10 → 13)
- [x] **New behavior is covered by unit tests** in `packages/swift-server/Tests/KeychainSecretStoreTests.swift`: switch flipped and restored on read, on write, and left alone when the env var is unset
- [x] `npm run lint -w @slicc/swift-server` — 0 serious; `npm run lint:format -w @slicc/swift-server` clean
- [x] `npm run lint:docs` clean; full `npm run lint` clean
- [x] Manual smoke (Sliccstart): after the fix the server boots, binds `:5716`, launches Chrome on CDP `:9232`, and the full `secret` path works through the swift bridge — set → masked `$NAME` → real value injected at the network boundary → 403 for an out-of-scope host → delete
- [ ] UI change? N/A — server startup path only

**Pre-existing failures**: none. The deprecation warnings in `SecretStore.swift`, `FileLogger.swift`, and `CDPProxy.swift` are pre-existing.

## Documentation

- [x] `docs/` — `docs/swift-server-details.md` asserted the broken mechanism as fact; it now explains that suppression takes two switches and only `SecKeychainSetUserInteractionAllowed` governs this item, plus why a round-trip test cannot catch the hang
- [ ] No documentation changes needed

## Risk & rollback

- Blast radius: swift-server startup and the Keychain-backed `POST /api/secrets`. A regression would surface as either the hang returning or an unexpected ACL dialog in an interactive run — the third new test guards the latter.
- No feature flag; reverts cleanly as a single commit with no persisted-state migration.
- **Reviewer should verify by hand** (CI cannot): on a machine whose Keychain ACL does *not* yet trust the freshly built binary, confirm that an interactive `slicc-server` run still raises the prompt and that "Always Allow" persists, and that a `nohup` run with `SLICC_KEYCHAIN_NONINTERACTIVE=1` now boots instead of hanging. Keychain prompt z-order is exactly the class of behavior the test suite cannot reach.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (no wire-contract change; `GET|POST /api/secrets` behavior is unchanged apart from no longer being able to hang)
- [x] Contract used by other floats checked: node-server has no Keychain path, so bridge parity is unaffected
