### PR TITLE
fix(webapp): clear the masked shell env var on secret delete

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -58,6 +58,8 @@ Do **not** treat `git config github.token "$(oauth-token github)"` as a long-liv
 
 ### Shell-env naming convention
 
+`secret set` injects the masked value into the owning shell's env and `secret delete` removes it again, so `$NAME` never outlives the secret it stands for. That symmetry matters: a mask whose secret is gone still expands, so the request is built and sent, but the fetch proxy has no secret left to match — it neither unmasks nor 403s, and upstream silently receives a dead credential.
+
 Only secrets whose names are valid POSIX env identifiers — `[A-Za-z_][A-Za-z0-9_]*` — are exposed as `$NAME` in the agent shell. Names containing dots, hyphens, or starting with a digit (e.g. `s3.r2.access_key_id`, `oauth.adobe.token`, `db.prod.password`) are still loaded into the fetch-proxy for header unmasking, but they do not leak into `printenv` or `$VAR` resolution. Use this to keep subsystem secrets (mount backends, OAuth replicas) out of the agent's environment while still letting the proxy substitute them when an HTTP request happens to carry the masked value.
 
 Set file permissions: `chmod 600 ~/.slicc/secrets.env`.
@@ -96,7 +98,7 @@ Inside the SLICC shell, the `secret` command manages secrets:
 | `secret test <name> <url>`                           | None       | Check whether a secret would be injected for a given URL.                                                                  |
 | `secret set <name> <value> --domain <pat> --persist` | **Prompt** | Persist to `.env` / Keychain / `chrome.storage.local`.                                                                     |
 | `secret scope <name> --domain <pat>`                 | **Prompt** | Edit the allowed host/domain scope of an existing secret.                                                                  |
-| `secret delete <name>`                               | None       | Remove a secret (or show how, in CLI mode).                                                                                |
+| `secret delete <name>`                               | None       | Remove a secret (or show how, in CLI mode). Also drops the masked `$NAME` from the shell env.                              |
 
 ### Session secrets and the sudo model
 

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -367,12 +367,14 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
   private pendingSudoBypasses = new Map<string, number>();
   /**
    * Env writes performed by supplemental commands during a `bash.exec()` call
-   * (currently only `secret set` injecting a masked value). `bash.exec()`
-   * returns its own snapshot of the working env that overwrites `lastEnv` on
-   * return — these pending writes are reapplied after that overwrite so they
-   * survive into the next exec call.
+   * (`secret set` injecting a masked value, `secret delete` dropping one).
+   * `bash.exec()` returns its own snapshot of the working env that overwrites
+   * `lastEnv` on return — these pending writes are reapplied after that
+   * overwrite so they survive into the next exec call. A `null` value is a
+   * pending REMOVAL: the snapshot still carries the old value, so the var has
+   * to be deleted again after the overwrite, not just before it.
    */
-  private pendingEnvWrites = new Map<string, string>();
+  private pendingEnvWrites = new Map<string, string | null>();
 
   /**
    * The `kind:'shell'` pid of the in-flight `executeCommand` call, set by
@@ -557,6 +559,14 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
       setEnv: (name, value) => {
         this.pendingEnvWrites.set(name, value);
         this.lastEnv[name] = value;
+      },
+      // `secret delete` must also drop the var, and the removal has to be
+      // queued the same way: `bash.exec`'s returned env snapshot still carries
+      // the old value, so deleting it from `lastEnv` alone would be undone on
+      // return and the mask would come back.
+      unsetEnv: (name) => {
+        this.pendingEnvWrites.set(name, null);
+        delete this.lastEnv[name];
       },
     });
   }
@@ -1035,10 +1045,15 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     // Reapply env writes performed by supplemental commands during this exec
     // (e.g. `secret set` injecting a masked value). `bash.exec`'s `result.env`
     // does not include them — without this re-merge the next exec would not see
-    // `$NAME`.
+    // `$NAME`. A `null` is a removal: `result.env` DOES still carry the old
+    // value, so it has to be deleted after the overwrite or it comes back.
     if (this.pendingEnvWrites.size > 0) {
       for (const [k, v] of this.pendingEnvWrites) {
-        this.lastEnv[k] = v;
+        if (v === null) {
+          delete this.lastEnv[k];
+        } else {
+          this.lastEnv[k] = v;
+        }
       }
       this.pendingEnvWrites.clear();
     }

--- a/packages/webapp/src/shell/supplemental-commands/index.ts
+++ b/packages/webapp/src/shell/supplemental-commands/index.ts
@@ -63,7 +63,7 @@ import { createPython3LikeCommand } from './python-command.js';
 import { createRsyncCommand } from './rsync-command.js';
 import { createSayCommand } from './say-command.js';
 import { createScreencaptureCommand } from './screencapture-command.js';
-import { createSecretCommand } from './secret-command.js';
+import { createSecretCommand, type SecretCommandDeps } from './secret-command.js';
 import { createSerialCommand } from './serial-command.js';
 import { createServeCommand } from './serve-command.js';
 import { createSessionCommand } from './session-command.js';
@@ -166,6 +166,12 @@ export interface SupplementalCommandsConfig extends ImgcatCommandOptions {
    * shell session (LLM-context parity with container-loaded secrets).
    */
   setEnv?: (name: string, value: string) => void;
+  /**
+   * Removal counterpart to {@link setEnv}, so a successful `secret delete` also
+   * drops the masked `$NAME` that `secret set` injected — otherwise the mask
+   * outlives the secret and expands to a value nothing can unmask.
+   */
+  unsetEnv?: (name: string) => void;
   /** Runtime topology and tray-status readers for the webhook command. */
   webhook?: WebhookCommandOptions;
   /** Runtime topology reader for the crontask command. */
@@ -179,6 +185,18 @@ export interface SupplementalCommandsConfig extends ImgcatCommandOptions {
    * then falls back to the global PM / an ephemeral PM, parented to pid 1).
    */
   buildProcessConfig?: (runEnv?: ReadonlyMap<string, string>) => JshProcessConfig | undefined;
+}
+
+/**
+ * `secret` deps: the paired shell-env hooks plus the SAME sudo broker the rest
+ * of the shell uses (never a locally constructed one — see `secret-command.ts`).
+ */
+function secretCommandDeps(options: SupplementalCommandsConfig): SecretCommandDeps {
+  return {
+    setEnv: options.setEnv,
+    unsetEnv: options.unsetEnv,
+    broker: options.sudoCommand?.broker,
+  };
 }
 
 export function createSupplementalCommands(options: SupplementalCommandsConfig = {}): Command[] {
@@ -281,7 +299,7 @@ export function createSupplementalCommands(options: SupplementalCommandsConfig =
     // Reuses the SAME broker as the explicit `sudo <cmd>` command and SudoFS
     // write gating — one properly-composed broker per float (#2276), not an
     // independent one `secret-command.ts` constructs for itself.
-    createSecretCommand({ setEnv: options.setEnv, broker: options.sudoCommand?.broker }),
+    createSecretCommand(secretCommandDeps(options)),
     createRsyncCommand({ fs: options.fs }),
     createScreencaptureCommand(),
     createPbcopyCommand(),

--- a/packages/webapp/src/shell/supplemental-commands/secret-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-command.ts
@@ -132,6 +132,14 @@ export interface SecretCommandDeps {
    * skipped; a null `getMasked` lookup is also skipped silently.
    */
   setEnv?: (name: string, value: string) => void;
+  /**
+   * Counterpart to {@link setEnv}, called after a successful `secret delete`.
+   * Without it the masked value injected by `secret set` outlives the secret it
+   * stood for, and `$NAME` keeps expanding to a mask that no longer resolves —
+   * so a request built from it ships a dead credential upstream with no error
+   * (the domain gate cannot fire for a secret that is gone).
+   */
+  unsetEnv?: (name: string) => void;
 }
 
 /**
@@ -147,6 +155,7 @@ interface SecretCmdEnv {
   inExtension: boolean;
   gate: (op: GatedOp, name: string) => Promise<GateOutcome>;
   injectMaskedEnv: (name: string) => Promise<void>;
+  clearMaskedEnv: (name: string) => void;
 }
 
 function refused(decision: SudoDecision): ExecResult {
@@ -211,7 +220,16 @@ function buildEnv(deps: SecretCommandDeps): SecretCmdEnv {
     }
   };
 
-  return { backend, inExtension, gate, injectMaskedEnv };
+  // Removal counterpart, called only after the backend confirms the secret is
+  // gone. Mirrors `injectMaskedEnv`'s POSIX-name filter: a name that was never
+  // injected has nothing to clear.
+  const clearMaskedEnv = (name: string): void => {
+    if (!deps.unsetEnv) return;
+    if (!isValidShellEnvName(name)) return;
+    deps.unsetEnv(name);
+  };
+
+  return { backend, inExtension, gate, injectMaskedEnv, clearMaskedEnv };
 }
 
 // Pipeline-friendly: `echo $TOKEN | secret set NAME` keeps the literal
@@ -414,6 +432,7 @@ async function handleDelete(
   if (!result.removed) {
     return { stdout: '', stderr: `secret: no secret named "${name}"\n`, exitCode: 1 };
   }
+  env.clearMaskedEnv(name);
   const scope = result.fromSession === true ? 'session' : 'persisted';
   return { stdout: `Removed ${scope} secret "${name}"\n`, stderr: '', exitCode: 0 };
 }

--- a/packages/webapp/tests/shell/almost-bash-shell-secret.integration.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell-secret.integration.test.ts
@@ -60,6 +60,11 @@ function installSecretApiFetchMock(session: Map<string, SessionEntry>) {
         }))
       );
     }
+    if (url.startsWith('/api/secrets/') && method === 'DELETE') {
+      const name = decodeURIComponent(url.slice('/api/secrets/'.length));
+      if (!session.delete(name)) return json({ error: 'not-found' }, false, 404);
+      return json({ ok: true, name, fromSession: true });
+    }
     return json({ error: 'unhandled' }, false, 404);
   });
   vi.stubGlobal('fetch', fetchMock);
@@ -98,6 +103,25 @@ describe('AlmostBashShellHeadless + secret set — masked-env injection (LLM-con
     expect(echoRes.stdout.trim()).toBe(maskFor('real-value'));
     // The real value MUST NOT have been injected into the shell env.
     expect(echoRes.stdout).not.toContain('real-value');
+  });
+
+  it('drops $NAME again after secret delete, so no dead mask survives the secret', async () => {
+    const shell = new AlmostBashShellHeadless({ fs });
+
+    await shell.executeCommand('secret set K real-value --domain api.x.com');
+    expect((await shell.executeCommand('echo $K')).stdout.trim()).toBe(maskFor('real-value'));
+
+    const delRes = await shell.executeCommand('secret delete K');
+    expect(delRes.exitCode).toBe(0);
+    expect(session.has('K')).toBe(false);
+
+    // `bash.exec`'s returned env snapshot still carries the old value, so this
+    // is what proves the removal is reapplied after that overwrite rather than
+    // being silently undone.
+    const echoRes = await shell.executeCommand('echo "[$K]"');
+    expect(echoRes.exitCode).toBe(0);
+    expect(echoRes.stdout.trim()).toBe('[]');
+    expect(echoRes.stdout).not.toContain(maskFor('real-value'));
   });
 
   it('accepts the value via stdin (echo v | secret set K2)', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/secret-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/secret-command.test.ts
@@ -462,6 +462,68 @@ describe('secret command — masked-env injection on set', () => {
     expect(res.exitCode).toBe(0);
     expect(setEnv).not.toHaveBeenCalled();
   });
+
+  // A mask that outlives its secret is worse than a missing var: `$NAME` still
+  // expands, so the request is built and sent, and the fetch proxy has no
+  // secret left to match — it neither unmasks nor 403s. Upstream just receives
+  // a dead credential. Observed live on both privileged bridges.
+  it('clears the masked shell env var after a successful delete', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: true, fromSession: true })),
+    });
+    const unsetEnv = vi.fn();
+    const res = await run(['delete', 'OPENAI_KEY'], {
+      backend,
+      broker: broker.broker,
+      unsetEnv,
+    });
+    expect(res.exitCode).toBe(0);
+    expect(unsetEnv).toHaveBeenCalledWith('OPENAI_KEY');
+  });
+
+  it('clears the masked shell env var after deleting a persisted secret too', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: true, fromSession: false })),
+    });
+    const unsetEnv = vi.fn();
+    const res = await run(['rm', 'TOKEN'], { backend, broker: broker.broker, unsetEnv });
+    expect(res.exitCode).toBe(0);
+    expect(unsetEnv).toHaveBeenCalledWith('TOKEN');
+  });
+
+  it('leaves the env alone when the secret did not exist', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: false })),
+    });
+    const unsetEnv = vi.fn();
+    const res = await run(['delete', 'NOPE'], { backend, broker: broker.broker, unsetEnv });
+    expect(res.exitCode).toBe(1);
+    expect(unsetEnv).not.toHaveBeenCalled();
+  });
+
+  it('skips the env clear for non-POSIX dot-namespaced names', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: true, fromSession: true })),
+    });
+    const unsetEnv = vi.fn();
+    const res = await run(['delete', 's3.r2.access_key_id'], {
+      backend,
+      broker: broker.broker,
+      unsetEnv,
+    });
+    expect(res.exitCode).toBe(0);
+    // Never injected (same POSIX filter as `secret set`), so nothing to clear.
+    expect(unsetEnv).not.toHaveBeenCalled();
+  });
+
+  it('deletes fine when no unsetEnv hook is supplied (backward compatible)', async () => {
+    const backend = makeBackend({
+      delete: vi.fn(async () => ({ removed: true, fromSession: true })),
+    });
+    const res = await run(['delete', 'OPENAI_KEY'], { backend, broker: broker.broker });
+    expect(res.exitCode).toBe(0);
+    expect(backend.delete).toHaveBeenCalledWith('OPENAI_KEY');
+  });
 });
 
 describe('secret command — delete / rm', () => {


### PR DESCRIPTION
## Summary

`secret set` injects the masked value into the owning shell's env so `$NAME` works for the agent; `secret delete` had no counterpart. Before: after deleting a secret, `$NAME` still expanded to its mask for the rest of the shell session, and a request built from it was sent upstream with a credential nothing could unmask. Now: a successful delete drops the var, so `$NAME` expands to nothing.

## Why

A leftover mask is worse than a missing var. The mask still expands, so the request is built and sent — and the fetch proxy has no secret left to match, so it neither unmasks **nor** 403s (the domain gate cannot fire for a secret that no longer exists). Upstream silently receives a dead credential and the agent gets no signal that its token is gone.

Found while exercising `secret set` end to end through a real browser against both privileged bridges. It reproduces identically on node-server and swift-server, so this is client-side, not a bridge divergence.

**Repro** (loopback echo server logging the `Authorization` header it actually receives):

1. `secret set E2E_TOKEN e2e-real-value-4711-abcdef --domain 127.0.0.1`
2. `curl -s -H "Authorization: Bearer $E2E_TOKEN" http://127.0.0.1:8899/headers`
3. `secret delete E2E_TOKEN` → `Removed session secret "E2E_TOKEN"`; `secret list` no longer lists it
4. `curl -s -H "Authorization: Bearer $E2E_TOKEN" http://127.0.0.1:8899/headers`

Expected: step 4 sends no credential (the var is gone).
Actual: upstream receives the dead mask, with no error anywhere in the chain.

```
step 2: GET /headers authorization=Bearer e2e-real-value-4711-abcdef real=YES   ← boundary did its job
step 4: GET /headers authorization=Bearer 97f0afdb61db2811879b68d36d  real=no   ← dead mask, after delete
```

## Approach / Implementation notes

- `unsetEnv` hook added alongside `setEnv` (`SecretCommandDeps`, `SupplementalCommandsConfig`), called from `handleDelete` **only after** the backend confirms removal — a 404 delete leaves the env untouched.
- Same POSIX-name filter as injection: a dotted name like `s3.r2.access_key_id` is never exposed as `$NAME`, so there is nothing to clear.
- **The non-obvious half:** `pendingEnvWrites` now carries `string | null`, where `null` is a pending *removal*. `bash.exec` returns its own env snapshot that overwrites `lastEnv`, and that snapshot still holds the old value, so deleting from `lastEnv` alone is undone on return and the mask comes back. The removal has to be reapplied after the overwrite, exactly like an injection.
- `createSupplementalCommands` sat one line under the 150-line `noExcessiveLinesPerFunction` gate, so the `secret` deps moved into a named `secretCommandDeps` helper instead of inflating the array literal.

## Cross-cutting impact

- **Floats exercised**: CLI (node-server bridge) and Sliccstart (swift-server bridge), both driven live. Extension is unaffected by construction — `setEnv`/`unsetEnv` are wired by `AlmostBashShellHeadless`, which every float shares, and both hooks stay optional.
- **Other callers of the changed contract**: `pendingEnvWrites` had exactly one producer (`setEnv`) and one consumer (the post-exec re-merge); both are updated together. Widening the map's value type is caught by `tsc`, and no other code reads the map.
- **Persisted state**: none. Session-scoped shell env only; no ledger, no localStorage, no IndexedDB shape change.
- **Security**: the change strictly reduces what survives in the agent's env. No new value is ever written; deletion is the only new effect. Real secret values remain server-side throughout.

## Test plan

- [x] `npx prettier --write <changed-files>`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell` — 5171 passing / 22 skipped, no new failures
- [x] **New behavior is covered by unit tests** in `packages/webapp/tests/shell/supplemental-commands/secret-command.test.ts` (session delete, persisted delete, 404 leaves env alone, non-POSIX name skipped, no-hook back-compat) plus an integration test through a real `AlmostBashShellHeadless` in `packages/webapp/tests/shell/almost-bash-shell-secret.integration.test.ts`
- [x] Integration test verified to FAIL without the wiring (`× drops $NAME again after secret delete`), so it pins the bug and not the new code shape
- [x] Manual smoke (CLI): isolated harness on bridge `:5715`, secret set → masked `$NAME` → real value injected at the boundary → 403 on an out-of-scope host → delete → var gone
- [x] Manual smoke (Sliccstart): same sequence against swift-server on `:5716`
- [x] Full `npm run lint` clean; boy-scout debt gate clean
- [ ] UI change? N/A — shell behavior only, no UI surface

**Pre-existing failures**: none observed in the suites run.

## Documentation

- [x] `docs/` — `docs/secrets.md`: the `secret delete` row now states that it also drops the masked `$NAME`, plus a short paragraph on why the set/delete env symmetry matters
- [ ] No documentation changes needed

## Risk & rollback

- Blast radius: one shell env var per `secret delete`. If it regressed, the failure mode is a var disappearing that should have stayed — which `secret get` / `secret list` immediately expose.
- No feature flag; reverts cleanly as a single commit with no persisted-state migration.
- CI cannot catch the original bug end to end (it needs a real bridge plus an upstream witness that records the header actually received). The integration test covers the mechanism; the live evidence is in the Why section above.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (the values shown are throwaway test strings from a loopback server)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] Contract used by other floats checked: `setEnv`/`unsetEnv` stay optional, so every float that wires neither is unchanged
