### PR TITLE
fix(webapp): name slicc.screenshot() failures and document the API

### DIFF
--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -327,7 +327,7 @@ Available as `slicc` in `<script>` tags and `onclick` attributes:
 - `slicc.stat(path)` — get file metadata (returns `Promise<{type, size}>`).
 - `slicc.mkdir(path)` — create a directory (recursive).
 - `slicc.rm(path)` — remove a file.
-- `slicc.screenshot(selector?)` — capture sprinkle DOM as base64 PNG data URL. Note: the screenshot captures a DOM clone using SVG foreignObject. External stylesheets and some computed styles may not be fully reproduced. For best results, use inline styles on elements you intend to screenshot.
+- `slicc.screenshot(selector?)` — capture sprinkle DOM as base64 PNG data URL. No argument targets `document.body` (fragment mode: the sprinkle container). The target must have non-zero width AND height; zero-sized elements are rejected, not captured. Works in a hidden tab — you do not need to foreground the sprinkle. Note: the screenshot captures a DOM clone using SVG `foreignObject`. External stylesheets, web fonts, and some computed styles may not be fully reproduced; huge serialised SVGs can fail to rasterise. For best results, use inline styles on elements you intend to screenshot.
 - `slicc.captureScreen()` — capture a screen, window, or browser tab via Chrome's native picker. Takes no arguments. Returns `Promise<{base64: string, width: number, height: number, mimeType: string}>`. The picker appears immediately; the Promise resolves once the user selects a target and the frame is grabbed. Rejects if the user cancels or screen capture is unavailable. Use `slicc.attachImage(shot.base64, 'screenshot.png', shot.mimeType)` to send the result to the agent. Key difference from `screenshot()`: this captures external content (any tab/window/screen), not the sprinkle's own DOM.
 
 ### Shell, agent, and jsh globals

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -35,6 +35,7 @@ import * as usbOps from '../kernel/usb-operations.js';
 import type { LickEvent } from '../scoops/lick-manager.js';
 import { getSprinkleRoute } from '../shell/sprinkle-routes.js';
 import { toPreviewUrl } from '../shell/supplemental-commands/shared.js';
+import { captureSprinkleScreenshot } from './sprinkle-screenshot.js';
 
 export interface CaptureScreenResult {
   base64: string;
@@ -971,36 +972,14 @@ export class SprinkleBridge {
 
   /**
    * Capture a sprinkle DOM element or its child as a PNG data URL.
-   * Uses SVG foreignObject trick + canvas rendering to capture styled content.
+   * Keep in lockstep with the iframe `screenshot()` copy in sprinkle-renderer.ts.
    */
   private createScreenshotHandler(
     container: HTMLElement | undefined
   ): (selector?: string) => Promise<string> {
     return async (selector) => {
       if (!container) return '';
-      const target = selector ? container.querySelector<HTMLElement>(selector) : container;
-      if (!target) throw new Error('Element not found: ' + (selector || 'container'));
-      const rect = target.getBoundingClientRect();
-      const w = Math.ceil(rect.width);
-      const h = Math.ceil(rect.height);
-      if (w === 0 || h === 0) throw new Error('Element has zero dimensions');
-      const canvas = document.createElement('canvas');
-      const dpr = window.devicePixelRatio || 1;
-      canvas.width = w * dpr;
-      canvas.height = h * dpr;
-      const ctx = canvas.getContext('2d')!;
-      ctx.scale(dpr, dpr);
-      const clone = (target as HTMLElement).cloneNode(true) as HTMLElement;
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}"><foreignObject width="100%" height="100%">${new XMLSerializer().serializeToString(clone)}</foreignObject></svg>`;
-      return new Promise<string>((resolve, reject) => {
-        const img = new Image();
-        img.onload = () => {
-          ctx.drawImage(img, 0, 0);
-          resolve(canvas.toDataURL('image/png'));
-        };
-        img.onerror = () => reject(new Error('Screenshot rendering failed'));
-        img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
-      });
+      return captureSprinkleScreenshot(selector, container);
     };
   }
 

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -11,6 +11,7 @@
 import { isNestedInAnotherFrame, nudgeIframeRepaint } from '@slicc/shared-ts';
 import type { EntryType } from '../fs/index.js';
 import type { SprinkleAgentOptions, SprinkleBridgeAPI } from './sprinkle-bridge.js';
+import { iframeScreenshotHelpersSource } from './sprinkle-screenshot.js';
 import { isThemeLight, registerSprinkleWindow, unregisterSprinkleWindow } from './theme.js';
 
 declare global {
@@ -451,6 +452,8 @@ export class SprinkleRenderer {
     return btoa(bin);
   }
 
+  ${iframeScreenshotHelpersSource()}
+
   var api = {
     lick: function(event) {
       var action, data;
@@ -481,29 +484,82 @@ export class SprinkleRenderer {
       return _vfsCall('sprinkle-rm', { path: path });
     },
     screenshot: function(selector) {
+      // Keep in lockstep with captureSprinkleScreenshot in sprinkle-screenshot.ts.
       return new Promise(function(resolve, reject) {
         try {
           var target = selector ? document.querySelector(selector) : document.body;
-          if (!target) { reject(new Error('Element not found: ' + selector)); return; }
+          var label = screenshotTargetLabel(selector, target);
+          if (!target) { reject(new Error('Element not found: ' + (selector || label))); return; }
           var rect = target.getBoundingClientRect();
           var w = Math.ceil(rect.width);
           var h = Math.ceil(rect.height);
-          if (w === 0 || h === 0) { reject(new Error('Element has zero dimensions')); return; }
+          if (w === 0 || h === 0) {
+            reject(new Error(screenshotZeroDimensionError(label, rect.width, rect.height)));
+            return;
+          }
           var canvas = document.createElement('canvas');
           var dpr = window.devicePixelRatio || 1;
           canvas.width = w * dpr;
           canvas.height = h * dpr;
           var ctx = canvas.getContext('2d');
+          if (!ctx) {
+            reject(new Error(screenshotRasteriseError('canvas context unavailable', label, w, h)));
+            return;
+          }
           ctx.scale(dpr, dpr);
           var clone = target.cloneNode(true);
-          var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w + '" height="' + h + '">' +
-            '<foreignObject width="100%" height="100%">' +
-            new XMLSerializer().serializeToString(clone) +
-            '</foreignObject></svg>';
+          if (clone.querySelectorAll) {
+            var junk = clone.querySelectorAll('script, link[rel="stylesheet"]');
+            for (var i = 0; i < junk.length; i++) {
+              if (junk[i].parentNode) junk[i].parentNode.removeChild(junk[i]);
+            }
+          }
+          var xhtml;
+          try {
+            xhtml = new XMLSerializer().serializeToString(clone);
+          } catch (serErr) {
+            var serMsg = serErr && serErr.message ? serErr.message : String(serErr);
+            reject(new Error(screenshotRasteriseError('XMLSerializer threw: ' + serMsg, label, w, h)));
+            return;
+          }
+          var svg = buildScreenshotSvg(xhtml, w, h);
+          var svgBytes = svg.length;
+          var dataUrl;
+          try {
+            dataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+          } catch (encErr) {
+            reject(new Error(screenshotRasteriseError('data-URL too large', label, w, h, svgBytes)));
+            return;
+          }
+          var dataUrlBytes = dataUrl.length;
+          var src = dataUrl;
+          var blobUrl = null;
+          if (typeof URL !== 'undefined' && URL.createObjectURL) {
+            try {
+              blobUrl = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml;charset=utf-8' }));
+              src = blobUrl;
+            } catch (blobErr) {
+              if (dataUrlBytes > 2097152) {
+                reject(new Error(screenshotRasteriseError('data-URL too large', label, w, h, svgBytes, dataUrlBytes)));
+                return;
+              }
+            }
+          } else if (dataUrlBytes > 2097152) {
+            reject(new Error(screenshotRasteriseError('data-URL too large', label, w, h, svgBytes, dataUrlBytes)));
+            return;
+          }
           var img = new Image();
-          img.onload = function() { ctx.drawImage(img, 0, 0); resolve(canvas.toDataURL('image/png')); };
-          img.onerror = function() { reject(new Error('Screenshot rendering failed')); };
-          img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+          img.onload = function() {
+            if (blobUrl) { try { URL.revokeObjectURL(blobUrl); } catch (e) {} }
+            ctx.drawImage(img, 0, 0);
+            resolve(canvas.toDataURL('image/png'));
+          };
+          img.onerror = function() {
+            if (blobUrl) { try { URL.revokeObjectURL(blobUrl); } catch (e) {} }
+            var reason = !blobUrl && dataUrlBytes > 2097152 ? 'data-URL too large' : 'image decode failed';
+            reject(new Error(screenshotRasteriseError(reason, label, w, h, svgBytes, dataUrlBytes)));
+          };
+          img.src = src;
         } catch(e) { reject(e); }
       });
     },

--- a/packages/webapp/src/ui/sprinkle-screenshot.ts
+++ b/packages/webapp/src/ui/sprinkle-screenshot.ts
@@ -1,0 +1,201 @@
+/**
+ * Shared `slicc.screenshot()` helpers for the fragment bridge and the
+ * full-document iframe copy. Error strings and the SVG wrapper must stay in
+ * lockstep — the iframe injects the formatter/`buildScreenshotSvg` functions
+ * via `Function#toString()` (assigned to known `var` names so minify is safe).
+ */
+
+/** Chromium data-URL length at which we refuse to fall back from a blob URL. */
+export const SCREENSHOT_DATA_URL_LIMIT = 2 * 1024 * 1024;
+
+export function screenshotTargetLabel(selector?: string, target?: Element | null): string {
+  if (selector) return selector;
+  if (typeof document !== 'undefined' && target === document.body) return 'document.body';
+  return 'container';
+}
+
+export function screenshotZeroDimensionError(label: string, width: number, height: number): string {
+  return 'Element has zero dimensions (' + label + ', ' + width + 'x' + height + ')';
+}
+
+export function screenshotRasteriseError(
+  reason: string,
+  label: string,
+  width: number,
+  height: number,
+  svgBytes?: number,
+  dataUrlBytes?: number
+): string {
+  let msg = 'Screenshot rendering failed (' + reason + '; ' + label + ' ' + width + 'x' + height;
+  if (svgBytes) msg += '; serialised SVG ' + svgBytes + ' bytes';
+  if (dataUrlBytes) msg += '; data URL ' + dataUrlBytes + ' bytes';
+  return msg + ')';
+}
+
+/**
+ * Wrap a serialised HTML clone in an SVG `foreignObject` with an XHTML
+ * namespace. Missing xmlns is a common reason Chrome's SVG-as-image decoder
+ * fires `img.onerror` on an otherwise sized target.
+ */
+export function buildScreenshotSvg(xhtml: string, width: number, height: number): string {
+  let wrapped = xhtml;
+  if (xhtml.indexOf('xmlns="http://www.w3.org/1999/xhtml"') === -1) {
+    wrapped = '<div xmlns="http://www.w3.org/1999/xhtml">' + xhtml + '</div>';
+  }
+  return (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="' +
+    width +
+    '" height="' +
+    height +
+    '">' +
+    '<foreignObject width="100%" height="100%" xmlns="http://www.w3.org/1999/xhtml">' +
+    wrapped +
+    '</foreignObject></svg>'
+  );
+}
+
+/** Formatter + SVG-builder source injected into full-document sprinkle iframes. */
+export function iframeScreenshotHelpersSource(): string {
+  return (
+    'var screenshotTargetLabel = ' +
+    screenshotTargetLabel.toString() +
+    ';\n' +
+    'var screenshotZeroDimensionError = ' +
+    screenshotZeroDimensionError.toString() +
+    ';\n' +
+    'var screenshotRasteriseError = ' +
+    screenshotRasteriseError.toString() +
+    ';\n' +
+    'var buildScreenshotSvg = ' +
+    buildScreenshotSvg.toString() +
+    ';\n'
+  );
+}
+
+/**
+ * Capture a sprinkle DOM node as a PNG data URL.
+ * Keep the iframe `screenshot()` body in `sprinkle-renderer.ts` in lockstep.
+ */
+export async function captureSprinkleScreenshot(
+  selector?: string,
+  defaultRoot?: Element | null
+): Promise<string> {
+  const root = defaultRoot ?? document.body;
+  const target = selector ? root.querySelector(selector) : root;
+  const label = screenshotTargetLabel(selector, target);
+  if (!target) throw new Error('Element not found: ' + (selector || label));
+  const rect = target.getBoundingClientRect();
+  const width = Math.ceil(rect.width);
+  const height = Math.ceil(rect.height);
+  if (width === 0 || height === 0) {
+    throw new Error(screenshotZeroDimensionError(label, rect.width, rect.height));
+  }
+
+  const canvas = document.createElement('canvas');
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error(screenshotRasteriseError('canvas context unavailable', label, width, height));
+  }
+  ctx.scale(dpr, dpr);
+
+  const clone = target.cloneNode(true);
+  stripNonRasterisableClone(clone);
+
+  let xhtml: string;
+  try {
+    xhtml = new XMLSerializer().serializeToString(clone);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      screenshotRasteriseError('XMLSerializer threw: ' + message, label, width, height)
+    );
+  }
+
+  const svg = buildScreenshotSvg(xhtml, width, height);
+  return rasteriseSvgToPng(svg, ctx, canvas, label, width, height);
+}
+
+function stripNonRasterisableClone(clone: Node): void {
+  if (!('querySelectorAll' in clone)) return;
+  const junk = (clone as Element).querySelectorAll('script, link[rel="stylesheet"]');
+  for (let i = 0; i < junk.length; i++) {
+    junk[i].parentNode?.removeChild(junk[i]);
+  }
+}
+
+function rasteriseSvgToPng(
+  svg: string,
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  label: string,
+  width: number,
+  height: number
+): Promise<string> {
+  const svgBytes = svg.length;
+  let dataUrl: string;
+  try {
+    dataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  } catch {
+    return Promise.reject(
+      new Error(screenshotRasteriseError('data-URL too large', label, width, height, svgBytes))
+    );
+  }
+  const dataUrlBytes = dataUrl.length;
+  const source = resolveScreenshotImageSrc(svg, dataUrl, dataUrlBytes, label, width, height);
+  if (source instanceof Error) return Promise.reject(source);
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const cleanup = () => {
+      if (source.blobUrl) {
+        try {
+          URL.revokeObjectURL(source.blobUrl);
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+    img.onload = () => {
+      cleanup();
+      ctx.drawImage(img, 0, 0);
+      resolve(canvas.toDataURL('image/png'));
+    };
+    img.onerror = () => {
+      cleanup();
+      const oversizedDataUrl = !source.blobUrl && dataUrlBytes > SCREENSHOT_DATA_URL_LIMIT;
+      const reason = oversizedDataUrl ? 'data-URL too large' : 'image decode failed';
+      reject(
+        new Error(screenshotRasteriseError(reason, label, width, height, svgBytes, dataUrlBytes))
+      );
+    };
+    img.src = source.src;
+  });
+}
+
+function resolveScreenshotImageSrc(
+  svg: string,
+  dataUrl: string,
+  dataUrlBytes: number,
+  label: string,
+  width: number,
+  height: number
+): { src: string; blobUrl: string | null } | Error {
+  const tooLarge = () =>
+    new Error(
+      screenshotRasteriseError('data-URL too large', label, width, height, svg.length, dataUrlBytes)
+    );
+  if (typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function') {
+    try {
+      const blobUrl = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml;charset=utf-8' }));
+      return { src: blobUrl, blobUrl };
+    } catch {
+      if (dataUrlBytes > SCREENSHOT_DATA_URL_LIMIT) return tooLarge();
+      return { src: dataUrl, blobUrl: null };
+    }
+  }
+  if (dataUrlBytes > SCREENSHOT_DATA_URL_LIMIT) return tooLarge();
+  return { src: dataUrl, blobUrl: null };
+}

--- a/packages/webapp/tests/ui/sprinkle-bridge.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-bridge.test.ts
@@ -173,6 +173,43 @@ describe('SprinkleBridge', () => {
     expect(result).toBe('');
   });
 
+  it('screenshot() names a zero-size container and rect', async () => {
+    const api = bridge.createAPI('test-sprinkle');
+    api._container = {
+      getBoundingClientRect: () =>
+        ({
+          width: 1072.4,
+          height: 0,
+          top: 0,
+          left: 0,
+          right: 1072.4,
+          bottom: 0,
+          x: 0,
+          y: 0,
+          toJSON() {
+            return {};
+          },
+        }) as DOMRect,
+      querySelector: () => null,
+      cloneNode: () => ({}),
+    } as unknown as HTMLElement;
+    await expect(api.screenshot()).rejects.toThrow(
+      'Element has zero dimensions (container, 1072.4x0)'
+    );
+  });
+
+  it('screenshot() keeps Element not found: #no-such-element', async () => {
+    const api = bridge.createAPI('test-sprinkle');
+    api._container = {
+      querySelector: () => null,
+      getBoundingClientRect: () => ({ width: 10, height: 10 }) as DOMRect,
+      cloneNode: () => ({}),
+    } as unknown as HTMLElement;
+    await expect(api.screenshot('#no-such-element')).rejects.toThrow(
+      'Element not found: #no-such-element'
+    );
+  });
+
   it('on/off registers and removes update listeners', () => {
     vi.useFakeTimers();
     const api = bridge.createAPI('test-sprinkle');

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -314,6 +314,12 @@ describe('full document rendering', () => {
     // exec/agent bridge methods are wired into the srcdoc bridge script
     expect(srcdoc).toContain('sprinkle-exec');
     expect(srcdoc).toContain('sprinkle-agent');
+    // Dual copy of slicc.screenshot() — keep in lockstep with sprinkle-screenshot.ts.
+    expect(srcdoc).toContain('Element has zero dimensions');
+    expect(srcdoc).toContain('image decode failed');
+    expect(srcdoc).toContain('XMLSerializer threw');
+    expect(srcdoc).toContain('http://www.w3.org/1999/xhtml');
+    expect(srcdoc).toContain('var screenshotTargetLabel = ');
   });
 
   it('handles bridge calls posted while the iframe is being appended', async () => {

--- a/packages/webapp/tests/ui/sprinkle-screenshot.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-screenshot.test.ts
@@ -1,0 +1,219 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildScreenshotSvg,
+  captureSprinkleScreenshot,
+  iframeScreenshotHelpersSource,
+  screenshotRasteriseError,
+  screenshotTargetLabel,
+  screenshotZeroDimensionError,
+} from '../../src/ui/sprinkle-screenshot.js';
+
+type G = typeof globalThis & {
+  window: Window & typeof globalThis;
+  document: Document;
+  Image: typeof Image;
+  XMLSerializer: typeof XMLSerializer;
+  HTMLElement: typeof HTMLElement;
+  HTMLCanvasElement: typeof HTMLCanvasElement;
+};
+
+function installDom(): JSDOM {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost' });
+  const g = globalThis as G;
+  g.window = dom.window as unknown as Window & typeof globalThis;
+  g.document = dom.window.document;
+  g.Image = dom.window.Image;
+  g.XMLSerializer = dom.window.XMLSerializer;
+  g.HTMLElement = dom.window.HTMLElement;
+  g.HTMLCanvasElement = dom.window.HTMLCanvasElement;
+  return dom;
+}
+
+function stubCanvasContext(dom: JSDOM): void {
+  const proto = dom.window.HTMLCanvasElement.prototype;
+  proto.getContext = function getContext() {
+    return {
+      scale() {},
+      drawImage() {},
+    };
+  } as unknown as typeof proto.getContext;
+  proto.toDataURL = function toDataURL() {
+    return 'data:image/png;base64,AAAA';
+  };
+}
+
+function sizedRect(width: number, height: number): DOMRect {
+  return {
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return {};
+    },
+  } as DOMRect;
+}
+
+function setRect(el: Element, width: number, height: number): void {
+  el.getBoundingClientRect = () => sizedRect(width, height);
+}
+
+class ErrorImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  set src(_value: string) {
+    queueMicrotask(() => this.onerror?.());
+  }
+}
+
+describe('screenshot error formatters', () => {
+  it('names document.body and a fractional WxH', () => {
+    expect(screenshotZeroDimensionError('document.body', 1072.4, 0)).toBe(
+      'Element has zero dimensions (document.body, 1072.4x0)'
+    );
+  });
+
+  it('names a selector and 0x0', () => {
+    expect(screenshotZeroDimensionError('#foo', 0, 0)).toBe(
+      'Element has zero dimensions (#foo, 0x0)'
+    );
+  });
+
+  it('labels a selector, the body, or the fragment container', () => {
+    expect(screenshotTargetLabel('#foo', null)).toBe('#foo');
+    expect(screenshotTargetLabel(undefined, undefined)).toBe('container');
+  });
+
+  it('labels document.body when that is the measured target', () => {
+    const dom = installDom();
+    try {
+      expect(screenshotTargetLabel(undefined, document.body)).toBe('document.body');
+    } finally {
+      dom.window.close();
+    }
+  });
+
+  it('names decode failure with rect and byte lengths', () => {
+    const msg = screenshotRasteriseError(
+      'image decode failed',
+      'document.body',
+      1072,
+      565,
+      12345,
+      23456
+    );
+    expect(msg).toContain('image decode failed');
+    expect(msg).toContain('document.body 1072x565');
+    expect(msg).toContain('serialised SVG 12345 bytes');
+    expect(msg).toContain('data URL 23456 bytes');
+    expect(msg).not.toBe('Screenshot rendering failed');
+  });
+
+  it('names a serializer throw', () => {
+    expect(screenshotRasteriseError('XMLSerializer threw: boom', 'container', 10, 10)).toContain(
+      'XMLSerializer threw: boom'
+    );
+  });
+
+  it('wraps serialised HTML in an XHTML foreignObject', () => {
+    const svg = buildScreenshotSvg('<p>hi</p>', 10, 20);
+    expect(svg).toContain('xmlns="http://www.w3.org/1999/xhtml"');
+    expect(svg).toContain('<foreignObject width="100%" height="100%"');
+    expect(svg).toContain('<p>hi</p>');
+  });
+});
+
+describe('iframeScreenshotHelpersSource', () => {
+  it('embeds the shared formatters under known names', () => {
+    const src = iframeScreenshotHelpersSource();
+    expect(src).toContain('var screenshotTargetLabel = ');
+    expect(src).toContain('var screenshotZeroDimensionError = ');
+    expect(src).toContain('var screenshotRasteriseError = ');
+    expect(src).toContain('var buildScreenshotSvg = ');
+    expect(src).toContain('Element has zero dimensions');
+    expect(src).toContain('Screenshot rendering failed');
+    expect(src).toContain('http://www.w3.org/1999/xhtml');
+  });
+});
+
+describe('captureSprinkleScreenshot', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = installDom();
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  it('rejects zero-size document.body with selector-or-body and WxH', async () => {
+    setRect(document.body, 1072.4, 0);
+    await expect(captureSprinkleScreenshot()).rejects.toThrow(
+      'Element has zero dimensions (document.body, 1072.4x0)'
+    );
+  });
+
+  it('rejects a zero-size selector with #id and 0x0', async () => {
+    const foo = document.createElement('div');
+    foo.id = 'foo';
+    setRect(foo, 0, 0);
+    document.body.appendChild(foo);
+    await expect(captureSprinkleScreenshot('#foo')).rejects.toThrow(
+      'Element has zero dimensions (#foo, 0x0)'
+    );
+  });
+
+  it('keeps Element not found: #no-such-element', async () => {
+    setRect(document.body, 100, 100);
+    await expect(captureSprinkleScreenshot('#no-such-element')).rejects.toThrow(
+      'Element not found: #no-such-element'
+    );
+  });
+
+  it('names image decode failed (not only Screenshot rendering failed) on img.onerror', async () => {
+    stubCanvasContext(dom);
+    const origImage = globalThis.Image;
+    (globalThis as G).Image = ErrorImage as unknown as typeof Image;
+    setRect(document.body, 1072.4, 565);
+    try {
+      let message = '';
+      try {
+        await captureSprinkleScreenshot();
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+      expect(message).toContain('image decode failed');
+      expect(message).toContain('document.body 1073x565');
+      expect(message).toMatch(/serialised SVG \d+ bytes/);
+      expect(message).toMatch(/data URL \d+ bytes/);
+      expect(message).toMatch(/^Screenshot rendering failed \(/);
+      expect(message).not.toBe('Screenshot rendering failed');
+    } finally {
+      (globalThis as G).Image = origImage;
+    }
+  });
+
+  it('names an XMLSerializer throw', async () => {
+    stubCanvasContext(dom);
+    setRect(document.body, 80, 40);
+    const orig = globalThis.XMLSerializer;
+    (globalThis as G).XMLSerializer = class {
+      serializeToString(): string {
+        throw new Error('unescaped ampersand');
+      }
+    } as unknown as typeof XMLSerializer;
+    try {
+      await expect(captureSprinkleScreenshot()).rejects.toThrow(
+        /XMLSerializer threw: unescaped ampersand/
+      );
+    } finally {
+      (globalThis as G).XMLSerializer = orig;
+    }
+  });
+});


### PR DESCRIPTION
Closes #2930
Closes #2943

## Summary

`slicc.screenshot()` still rejects zero-sized targets, but the error now names the selector or `document.body` and the measured rect. Rasterisation failures (`img.onerror`, serializer throws) name a short reason plus canvas size and serialised SVG / data-URL byte lengths, instead of a bare `Screenshot rendering failed`. Large sprinkles get an XHTML `foreignObject` wrapper and a blob URL so they can rasterise.

## Why

#2930: authors hit `Element has zero dimensions` without knowing the default target is `document.body` (fragment: the sprinkle container), that both axes must be non-zero, or that the API works in a hidden tab. The rejection itself is correct.

#2943: a sized body (`interview-me`, 1072.4×565) failed with a generic `img.onerror` while a smaller sprinkle in the same hidden session succeeded. The caller could not tell decode vs size vs serializer.

Not in this PR: #2942 (`sprinkle reload` leaving the iframe 0×0 — zero-dimension rejection is correct there), #2417 / PR #2937.

## Approach / Implementation notes

- Shared formatters + capture live in `packages/webapp/src/ui/sprinkle-screenshot.ts`. The fragment path calls `captureSprinkleScreenshot`. The full-document iframe copy stays in `generateBridgeScript` and injects the formatters/`buildScreenshotSvg` via `Function#toString()` assigned to known `var` names (minify-safe).
- Cheap rasterisation fixes, not CSS hunting: wrap cloned HTML in `xmlns="http://www.w3.org/1999/xhtml"` on `foreignObject`, strip `script` / external `link[rel=stylesheet]` from the clone, prefer `URL.createObjectURL` over a data URL (2 MiB fallback cap).
- Agent skill documents non-zero width **and** height, the no-arg target, hidden-tab behaviour, and known-unsupported constructs (external stylesheets, web fonts, huge serialised SVG) next to the existing `foreignObject` caveat.

## Cross-cutting impact

- **Floats exercised**: fragment (CLI/extension inline) and full-document `srcdoc` iframe. Same error strings on both copies.
- **Other callers**: `slicc.screenshot()` with no container still returns `''` (unchanged). `Element not found: #no-such-element` unchanged.
- **Bundle size**: +0.0 kB first-load vs merge-base.

## Test plan

- [x] `npm run verify` — all 8 checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [x] `npm run test` — 20401 passed, 46 skipped
- [x] `npm run test:coverage:webapp` — floors held
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load +0.0 kB
- [x] Unit tests: zero-size names selector-or-body and `WxH`; non-zero + `img.onerror` names decode/size; serializer throw is named; empty-container `screenshot()` still returns `''`

## Documentation

- [x] `packages/vfs-root/workspace/skills/sprinkles/SKILL.md` (agent-facing)

## Risk & rollback

Blast radius is sprinkle `slicc.screenshot()` only. Revert this PR. Zero-size rejection is unchanged; only the message and rasterisation path differ.