### PR TITLE
feat(webapp): give the exhausted-budget error a card that can fix it

### DIFF
--- a/docs/operational-telemetry.md
+++ b/docs/operational-telemetry.md
@@ -118,7 +118,7 @@ SLICC uses helix-rum-js's supported checkpoint types with SLICC-specific semanti
 | `convert`      | Cone fed a scoop   | scoop folder name                         | `'scoop-feed'`                      | `emitScoopLifecycle('feed', ...)`, called from `scoop-message-router.ts`                                                                                       |
 | `leave`        | Scoop completed    | scoop folder name                         | `'scoop-complete'`                  | `emitScoopLifecycle('complete', ...)`, called from `scoop-completion-service.ts`                                                                               |
 
-A scoop failure reuses the `error` checkpoint row above rather than getting its own row: `trackScoopLifecycle()` sets `source: 'scoop:<name>'` (not the bare scoop name used by `enter`/`convert`/`leave`) and runs the message through the same `sanitizeError` used for `trackError`, dropping known user-fixable error families (no-api-key, invalid-model, auth-expired) before emitting.
+A scoop failure reuses the `error` checkpoint row above rather than getting its own row: `trackScoopLifecycle()` sets `source: 'scoop:<name>'` (not the bare scoop name used by `enter`/`convert`/`leave`) and runs the message through the same `sanitizeError` used for `trackError`, dropping known user-fixable error families (no-api-key, invalid-model, auth-expired, quota-exceeded) before emitting.
 
 ### Auto-instrumented (from enhancer, CLI/Electron only)
 

--- a/packages/ios-app/SliccFollower/Models/ErrorFamilies.swift
+++ b/packages/ios-app/SliccFollower/Models/ErrorFamilies.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// The pieces an exhausted-provider-budget failure is rendered from.
+///
+/// Swift mirror of `parseQuotaExceededError` in
+/// `packages/webapp/src/core/error-families.ts`. The leader's error card shows
+/// the provider's own prose under an "Out of AI budget" header; without this
+/// the follower would keep printing the raw
+/// `429 {"error":{"type":"quota_exceeded",…}}` envelope under a generic
+/// "Something went wrong", which is the same failure told twice as badly.
+///
+/// Only the TEXT is mirrored. The leader's card also offers "Switch provider
+/// and try again" / "Add a provider"; the follower renders no CTA at all
+/// (see `ErrorCard`), because both act on leader-side state the
+/// follower→leader protocol carries no message for.
+struct QuotaExceededDetail: Equatable {
+    /// The provider's explanation, with the trailing "connect your own LLM
+    /// provider" sentence dropped — on the follower there is nothing to click.
+    let message: String
+    /// ISO-8601 instant the budget refills, when the provider sent one.
+    let resetsAt: String?
+
+    /// Header the error card shows instead of "Something went wrong".
+    static let label = "Out of AI budget"
+
+    /// Body for an envelope that carried no usable message of its own.
+    static let fallbackMessage = "The usage budget for this provider has been fully used."
+
+    /// The `error.type` the Adobe proxy stamps on an exhausted-budget refusal.
+    /// Matched instead of the prose, so re-worded proxy copy — or a
+    /// `Scoop "…" failed with unrecoverable error: ` wrapper — never drops the
+    /// failure out of detection.
+    private static let typeToken = "quota_exceeded"
+
+    /// Trailing self-service sentence the leader's CTAs replace.
+    private static let connectCtaPattern = #"\s*You can (also )?connect your own LLM provider\.?\s*$"#
+
+    /// Parse `content` as a quota refusal, or `nil` if it is not one. A
+    /// malformed or truncated envelope still yields a detail: the family is
+    /// established by the type token, and a parse miss must not fall back to
+    /// dumping JSON at the reader.
+    init?(content: String) {
+        guard content.lowercased().contains(Self.typeToken) else { return nil }
+        let error = Self.errorEnvelope(in: content)
+        let raw = error?["message"] as? String ?? ""
+        let stripped = raw.replacingOccurrences(
+            of: Self.connectCtaPattern,
+            with: "",
+            options: [.regularExpression, .caseInsensitive]
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        message = stripped.isEmpty ? Self.fallbackMessage : stripped
+        if let resets = error?["resets_at"] as? String, !resets.isEmpty {
+            resetsAt = resets
+        } else {
+            resetsAt = nil
+        }
+    }
+
+    /// The `error` object inside the JSON the provider status line prefixes
+    /// (`429 {…}`). Widest span from the first `{` to the last `}`, so a
+    /// wrapper prefix never breaks the parse.
+    private static func errorEnvelope(in content: String) -> [String: Any]? {
+        guard let start = content.firstIndex(of: "{"), let end = content.lastIndex(of: "}"),
+            start < end
+        else { return nil }
+        let json = String(content[start...end])
+        guard let data = json.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object["error"] as? [String: Any]
+    }
+
+    /// Card body: the provider's prose, plus the structured reset instant when
+    /// — and only when — that prose does not already name one, so the card
+    /// never states the same reset twice in two formats.
+    var body: String {
+        guard let resetsAt, message.range(of: "reset", options: .caseInsensitive) == nil else {
+            return message
+        }
+        let parser = ISO8601DateFormatter()
+        parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = parser.date(from: resetsAt) ?? ISO8601DateFormatter().date(from: resetsAt)
+        guard let date else { return message }
+        let out = DateFormatter()
+        out.dateStyle = .long
+        out.timeStyle = .none
+        return "\(message) Resets on \(out.string(from: date))."
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/QuotaExceededDetailTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/QuotaExceededDetailTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import XCTest
+
+@testable import SliccFollower
+
+/// The follower's mirror of the leader's `quota_exceeded` parsing
+/// (`packages/webapp/src/core/error-families.ts`). Same envelope, same prose,
+/// so the same failure does not read one way on the leader and another here.
+final class QuotaExceededDetailTests: XCTestCase {
+    /// The verbatim Adobe proxy refusal, as it reaches the error card.
+    private static let adobe429 = """
+        429 {"error":{"type":"quota_exceeded","message":"Weekly budget has been fully used. \
+        Resets on 2026-09-14. You can also connect your own LLM provider.",\
+        "resets_at":"2026-09-14T00:00:00.000Z"}}
+        """
+
+    func testParsesTheAdobeEnvelope() {
+        let detail = QuotaExceededDetail(content: Self.adobe429)
+        XCTAssertEqual(detail?.message, "Weekly budget has been fully used. Resets on 2026-09-14.")
+        XCTAssertEqual(detail?.resetsAt, "2026-09-14T00:00:00.000Z")
+    }
+
+    func testDropsTheConnectYourOwnProviderSentence() {
+        // The leader replaces that sentence with CTAs; the follower has none,
+        // but repeating advice the reader cannot act on here is still noise.
+        let detail = QuotaExceededDetail(content: Self.adobe429)
+        XCTAssertEqual(detail?.message.contains("connect your own"), false)
+    }
+
+    func testParsesThroughAScoopWrapperPrefix() {
+        let wrapped = "Scoop \"digest\" failed with unrecoverable error: \(Self.adobe429)"
+        XCTAssertEqual(QuotaExceededDetail(content: wrapped)?.resetsAt, "2026-09-14T00:00:00.000Z")
+    }
+
+    func testRejectsNeighbouringErrorFamilies() {
+        XCTAssertNil(
+            QuotaExceededDetail(
+                content: "403 {\"error\":{\"type\":\"forbidden\",\"message\":\"Model not allowed\"}}"
+            ))
+        XCTAssertNil(QuotaExceededDetail(content: "Adobe session expired — please log in again"))
+        XCTAssertNil(QuotaExceededDetail(content: "429 Too Many Requests"))
+        XCTAssertNil(QuotaExceededDetail(content: ""))
+    }
+
+    func testFallsBackToGenericCopyRatherThanRawJson() {
+        let detail = QuotaExceededDetail(content: "429 {\"error\":{\"type\":\"quota_exceeded\"}}")
+        XCTAssertEqual(detail?.message, QuotaExceededDetail.fallbackMessage)
+        XCTAssertNil(detail?.resetsAt)
+    }
+
+    func testSurvivesATruncatedEnvelope() {
+        // The family is established by the type token; a parse miss must not
+        // fall back to dumping a broken payload at the reader.
+        let detail = QuotaExceededDetail(
+            content: "429 {\"error\":{\"type\":\"quota_exceeded\",\"message\":\"Wee")
+        XCTAssertEqual(detail?.message, QuotaExceededDetail.fallbackMessage)
+    }
+
+    func testSpellsOutAResetTheProseOmits() {
+        let detail = QuotaExceededDetail(
+            content: """
+                429 {"error":{"type":"quota_exceeded","message":"Your budget is used up.",\
+                "resets_at":"2026-09-14T00:00:00.000Z"}}
+                """)
+        XCTAssertEqual(detail?.body.hasPrefix("Your budget is used up. Resets on "), true)
+    }
+
+    func testNeverStatesTheResetTwice() {
+        let body = QuotaExceededDetail(content: Self.adobe429)?.body
+        XCTAssertEqual(body, "Weekly budget has been fully used. Resets on 2026-09-14.")
+    }
+
+    func testLeavesTheBodyAloneWhenTheResetInstantIsUnparseable() {
+        let detail = QuotaExceededDetail(
+            content: """
+                429 {"error":{"type":"quota_exceeded","message":"Your budget is used up.",\
+                "resets_at":"soon"}}
+                """)
+        XCTAssertEqual(detail?.body, "Your budget is used up.")
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/AttachmentChips.swift
+++ b/packages/ios-app/SliccFollower/Views/AttachmentChips.swift
@@ -86,15 +86,28 @@ struct AttachmentChips: View {
 /// A cone error, rendered as a card instead of an ordinary assistant bubble.
 ///
 /// Mirrors `slicc-error-card.ts`: a red-tinted card with an uppercase
-/// "Something went wrong" header over the raw error text.
+/// "Something went wrong" header over the raw error text. The exhausted-budget
+/// family is the one exception the leader also makes: its envelope is parsed
+/// into prose under an "Out of AI budget" header (`QuotaExceededDetail`),
+/// because a raw `429 {"error":{"type":"quota_exceeded",…}}` line tells the
+/// reader nothing they can use.
 ///
 /// The web card also offers a contextual action (`Try again`, `Open Settings`,
-/// `Change model`, `Log in again`). Those are omitted here for the same reason
+/// `Change model`, `Log in again`, and the quota card's "Switch provider and
+/// try again" / "Add a provider"). Those are omitted here for the same reason
 /// the follower's `tool_ui` card is read-only: every one of them acts on
 /// leader-side state, the follower→leader protocol carries no equivalent
 /// message, and a button that silently does nothing is worse than no button.
 struct ErrorCard: View {
     let message: ChatMessage
+
+    /// Non-nil when this failure is the exhausted-provider-budget family.
+    private var quota: QuotaExceededDetail? { QuotaExceededDetail(content: message.content) }
+
+    /// Header copy: the budget family names itself, everything else stays generic.
+    private var headerLabel: String {
+        quota == nil ? "Something went wrong" : QuotaExceededDetail.label
+    }
 
     private let cardBackground = Color(red: 0x3A / 255, green: 0x14 / 255, blue: 0x18 / 255)
     private let borderColor = Color(red: 0xDC / 255, green: 0x26 / 255, blue: 0x26 / 255)
@@ -104,13 +117,13 @@ struct ErrorCard: View {
             HStack(spacing: 7) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 11))
-                Text("Something went wrong".uppercased())
+                Text(headerLabel.uppercased())
                     .font(.system(size: 10.5, weight: .semibold))
                     .kerning(0.2)
             }
             .foregroundStyle(Color(red: 0xF8 / 255, green: 0x71 / 255, blue: 0x71 / 255))
 
-            Text(message.content)
+            Text(quota?.body ?? message.content)
                 .font(.system(size: 12.5))
                 .foregroundStyle(.white.opacity(0.9))
                 .textSelection(.enabled)

--- a/packages/webapp/src/core/error-families.ts
+++ b/packages/webapp/src/core/error-families.ts
@@ -55,7 +55,101 @@ export function isAuthExpiredError(content: string | null | undefined): boolean 
   return content.toLowerCase().includes('please log in again');
 }
 
-/** Whether an error belongs to one of the three user-fixable families. */
+/**
+ * Structured detail parsed out of a provider quota refusal. The Adobe proxy
+ * answers an exhausted budget with
+ * `429 {"error":{"type":"quota_exceeded","message":"Weekly budget has been
+ * fully used. Resets on 2026-09-14. You can also connect your own LLM
+ * provider.","resets_at":"2026-09-14T00:00:00.000Z"}}` — the whole envelope
+ * reaches the error card verbatim, which is why the card parses it instead of
+ * showing raw JSON under a generic header.
+ */
+export interface QuotaExceededDetail {
+  /**
+   * The provider's own explanation, with the trailing "connect your own LLM
+   * provider" sentence dropped: the card's CTAs now DO that, so leaving the
+   * prose in would tell the user to go find an affordance they are looking at.
+   */
+  message: string;
+  /** ISO-8601 instant the budget refills, when the provider sent one. */
+  resetsAt: string | null;
+}
+
+/** The `error.type` the Adobe proxy stamps on an exhausted-budget refusal. */
+const QUOTA_ERROR_TYPE = 'quota_exceeded';
+
+/**
+ * Fallback body for a `quota_exceeded` envelope whose `message` is missing or
+ * empty — the type alone still tells the user what happened.
+ */
+const QUOTA_FALLBACK_MESSAGE = 'The usage budget for this provider has been fully used.';
+
+/** Trailing self-service sentence the card's CTAs replace. */
+const QUOTA_CONNECT_CTA_RE = /\s*You can (?:also )?connect your own LLM provider\.?\s*$/i;
+
+/**
+ * Detect a cone failure caused by an exhausted provider budget (the Adobe
+ * rate-limit family). Matched on the machine-readable `error.type` rather than
+ * the prose, so re-worded proxy copy or a `Scoop … failed with unrecoverable
+ * error: ` wrapper never drops it out of detection.
+ */
+export function isQuotaExceededError(content: string | null | undefined): boolean {
+  if (!content) return false;
+  return content.toLowerCase().includes(QUOTA_ERROR_TYPE);
+}
+
+/** Envelope shape read out of a `quota_exceeded` body — every field unverified. */
+interface QuotaEnvelope {
+  error?: { message?: unknown; resets_at?: unknown };
+}
+
+/**
+ * The `{ … }` JSON object embedded in an error string (the provider status
+ * line prefixes it, e.g. `429 {…}`). Widest span from the first `{` to the
+ * last `}` so a wrapper prefix never breaks the parse; `null` when the string
+ * carries no parseable object.
+ */
+function embeddedJsonObject(content: string): QuotaEnvelope | null {
+  const start = content.indexOf('{');
+  const end = content.lastIndexOf('}');
+  if (start < 0 || end <= start) return null;
+  try {
+    const parsed: unknown = JSON.parse(content.slice(start, end + 1));
+    if (parsed === null || typeof parsed !== 'object') return null;
+    return parsed as QuotaEnvelope;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a `quota_exceeded` failure into the pieces the error card renders.
+ * Returns `null` for anything that is not that family, so callers can use it
+ * as the detect-and-parse step in one call. A malformed or truncated envelope
+ * still yields a detail — the family is established by
+ * {@link isQuotaExceededError}, and a parse miss must not fall back to
+ * dumping JSON at the user.
+ */
+export function parseQuotaExceededError(
+  content: string | null | undefined
+): QuotaExceededDetail | null {
+  if (!isQuotaExceededError(content)) return null;
+  const envelope = embeddedJsonObject(content as string);
+  const raw = typeof envelope?.error?.message === 'string' ? envelope.error.message : '';
+  const message = raw.replace(QUOTA_CONNECT_CTA_RE, '').trim();
+  const resetsAt =
+    typeof envelope?.error?.resets_at === 'string' && envelope.error.resets_at.length > 0
+      ? envelope.error.resets_at
+      : null;
+  return { message: message || QUOTA_FALLBACK_MESSAGE, resetsAt };
+}
+
+/** Whether an error belongs to one of the four user-fixable families. */
 export function isUserFixableError(content: string | null | undefined): boolean {
-  return isNoApiKeyError(content) || isInvalidModelError(content) || isAuthExpiredError(content);
+  return (
+    isNoApiKeyError(content) ||
+    isInvalidModelError(content) ||
+    isAuthExpiredError(content) ||
+    isQuotaExceededError(content)
+  );
 }

--- a/packages/webapp/src/kernel/telemetry.ts
+++ b/packages/webapp/src/kernel/telemetry.ts
@@ -241,8 +241,8 @@ export function trackImageView(context: string): void {
 export function trackError(errorType: string, details?: string): void {
   let target = details;
   if (typeof target === 'string') {
-    // User-fixable known states (no-api-key, invalid-model, auth-expired)
-    // own dedicated remediation UX and are not regressions — beaconing them
+    // User-fixable known states (no-api-key, invalid-model, auth-expired,
+    // quota-exceeded) own dedicated remediation UX and are not regressions — beaconing them
     // would only add triage noise. Mirrors the sibling filters in
     // `trackScoopLifecycle` and `wc-chat-controller.ts#emitErrorCardBeacon`
     // so the raw `llm` beacon emitted from `scoop-context.ts` doesn't leak

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -647,6 +647,24 @@ export function getAllAvailableModels(): GroupedModels[] {
   return [...seen.values()];
 }
 
+/**
+ * Provider ids OTHER than `excludeProviderId` that have a configured account
+ * offering at least one pickable model — i.e. the providers the user could
+ * switch to right now, without connecting anything new.
+ *
+ * Drives the exhausted-budget error card's CTA (`ui/wc/wc-message-view.ts`):
+ * "Switch provider and try again" is only honest when such a provider exists;
+ * otherwise the card offers "Add a provider" instead. Derived from
+ * {@link getAllAvailableModels} so hidden, build-excluded and policy-denied
+ * providers are filtered out exactly as they are in the model picker — a CTA
+ * that opens a dropdown must not promise an entry the dropdown lacks.
+ */
+export function getAlternativeModelProviders(excludeProviderId?: string | null): string[] {
+  return getAllAvailableModels()
+    .map((group) => group.providerId)
+    .filter((id) => id !== excludeProviderId);
+}
+
 // --- Account storage ---
 
 export function getAccounts(): Account[] {

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -8,6 +8,7 @@
 
 import type { ChatCompactionMarker, ToolProgressEvent } from '@slicc/shared-ts';
 import { escapeHtml } from '@slicc/webcomponents/internal/html';
+import { isUserFixableError } from '../../core/error-families.js';
 import { trackChatSend, trackError, trackLickBackpressure } from '../../kernel/telemetry.js';
 import {
   applyDictationMarkers,
@@ -26,9 +27,6 @@ import {
   type ClusterCallState,
   collateLickMessages,
   daySeparatorEl,
-  isAuthExpiredError,
-  isInvalidModelError,
-  isNoApiKeyError,
   messageEls,
   reflowToolClusters,
   unwrapToolClusters,
@@ -1264,17 +1262,16 @@ export class WcChatController {
   /**
    * Best-effort RUM beacon for user-visible error cards that have NO dedicated
    * handler (the default "Try again" variant). The handled families — no-api-key,
-   * invalid-model, auth-expired — own remediation UX and are user-fixable known
-   * states, so beaconing them would only add triage noise; we skip them. A
+   * invalid-model, auth-expired, quota-exceeded — own remediation UX and are
+   * user-fixable known states, so beaconing them would only add triage noise;
+   * `isUserFixableError` is the single list all three skip sites share. A
    * distinct `'error-card'` source lets the nightly triage distinguish these
    * from the agent-loop `'llm'`/`'tool'` beacons. Mirrors `#emitChatSendBeacon`'s
    * fire-and-forget style — telemetry must never disrupt the error-render path.
    */
   #emitErrorCardBeacon(error: string): void {
     try {
-      if (isNoApiKeyError(error) || isInvalidModelError(error) || isAuthExpiredError(error)) {
-        return;
-      }
+      if (isUserFixableError(error)) return;
       trackError('error-card', error);
     } catch {
       // Telemetry must never block the error render.

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -34,8 +34,14 @@ import {
   isInvalidModelError,
   isNoApiKeyError,
   NO_API_KEY_ERROR_PREFIX,
+  parseQuotaExceededError,
+  type QuotaExceededDetail,
 } from '../../core/error-families.js';
 import { trackImageView } from '../../kernel/telemetry.js';
+import {
+  getAlternativeModelProviders,
+  getSelectedProvider,
+} from '../../providers/account-store.js';
 import { lickChannelFromBody } from '../../scoops/agent-message-to-chat.js';
 import { scoopColor } from './wc-scoop-color.js';
 
@@ -1194,11 +1200,67 @@ function delegationEls(message: ChatMessage): HTMLElement[] {
   return [line, bubble];
 }
 
+/** Header label for the exhausted-provider-budget card. */
+const QUOTA_ERROR_LABEL = 'Out of AI budget';
+
+/**
+ * Providers, other than the one that just failed, the user could switch to
+ * without connecting anything new. Reads the account store at render time —
+ * an account added since the card first rendered should change what the card
+ * offers on the next thread rebuild. Never throws: the store touches
+ * `localStorage` and a provider catalog, and neither may take an error card
+ * down with it.
+ */
+function alternativeProviders(): string[] {
+  try {
+    return getAlternativeModelProviders(getSelectedProvider());
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Card body for a parsed quota refusal. The provider's own prose already names
+ * the reset date in the Adobe envelope, so the structured `resets_at` is only
+ * spelled out when the message does NOT mention a reset — otherwise the card
+ * would say it twice, in two formats.
+ */
+function quotaBody(detail: QuotaExceededDetail): string {
+  if (detail.resetsAt === null || /reset/i.test(detail.message)) return detail.message;
+  const when = new Date(detail.resetsAt);
+  if (Number.isNaN(when.getTime())) return detail.message;
+  return `${detail.message} Resets on ${when.toLocaleDateString(undefined, { dateStyle: 'long' })}.`;
+}
+
+/**
+ * CTAs for the exhausted-budget card. "Try again" cannot work — the budget is
+ * gone until it resets — so the affordances become the two remediations that
+ * DO work:
+ * - Another connected provider exists → primary "Switch provider and try
+ *   again" (`change-model`, which `wireWcNav` routes to the composer model
+ *   picker and which auto-replays this turn once a model is picked), with
+ *   "Add a provider" as the outline secondary.
+ * - No other provider is connected → the single CTA is "Add a provider"
+ *   (`settings`), because a model picker holding only the exhausted account
+ *   would be a dead end.
+ */
+function quotaCtaAttrs(): Record<string, string> {
+  if (alternativeProviders().length === 0) {
+    return { action: 'settings', 'button-label': 'Add a provider' };
+  }
+  return {
+    action: 'change-model',
+    'button-label': 'Switch provider and try again',
+    'secondary-action': 'settings',
+    'secondary-button-label': 'Add a provider',
+  };
+}
+
 /**
  * `slicc-error-card` for a cone-error message. The card is purely
  * presentational; the chat controller listens for the bubbled
  * `slicc-error-retry` event to re-run the last user turn via its existing
- * agent send path. Three error families flip the CTA:
+ * agent send path. Four error families flip the CTA:
  * - "No API key configured" → `action="settings"`, fires
  *   `slicc-error-open-settings`; routed to the settings dialog by
  *   `wireWcNav` since the retry path would just re-hit the same missing key.
@@ -1208,12 +1270,22 @@ function delegationEls(message: ChatMessage): HTMLElement[] {
  * - Auth-expired errors → `action="login"`, fires `slicc-error-login`; routed
  *   to the connected provider's OAuth window by `wireWcNav` since the retry
  *   path would just re-hit the same expired session.
+ * - Exhausted-budget errors → see {@link quotaCtaAttrs}. The only family that
+ *   also rewrites the label and body, and it does that even in a read-only
+ *   transcript: a reader who cannot act is still owed readable text instead of
+ *   a raw JSON envelope.
  */
 function errorCardEl(message: ChatMessage, readOnly: boolean): HTMLElement {
   const attrs: Record<string, string> = {
     message: message.content,
     'message-id': message.id,
   };
+  // Detect-and-parse in one call: a non-null detail IS the quota family.
+  const quota = parseQuotaExceededError(message.content);
+  if (quota) {
+    attrs.label = QUOTA_ERROR_LABEL;
+    attrs.message = quotaBody(quota);
+  }
   // A read-only transcript (a scoop, #2312) shows WHAT failed but offers no
   // CTA: retry, settings, sign-in and "Change model" all act on behalf of a
   // unit the user does not talk to. `no-action` drops the footer entirely —
@@ -1223,6 +1295,7 @@ function errorCardEl(message: ChatMessage, readOnly: boolean): HTMLElement {
     attrs['no-action'] = '';
     return el('slicc-error-card', attrs);
   }
+  if (quota) return el('slicc-error-card', { ...attrs, ...quotaCtaAttrs() });
   if (isNoApiKeyError(message.content)) attrs.action = 'settings';
   else if (isInvalidModelError(message.content)) attrs.action = 'change-model';
   else if (isAuthExpiredError(message.content)) attrs.action = 'login';

--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -508,8 +508,9 @@ function handleTrayActionId(id: string, log: BootStageLogger): boolean {
 
 /**
  * Route every "open the provider Settings dialog" trigger to `openSettings`:
- * the "No API key" error card's `slicc-error-open-settings` (bubbled on the
- * thread — same surface as the composer-meta `add-ai` action), and the extension
+ * the error card's `slicc-error-open-settings` (bubbled on the thread — same
+ * surface as the composer-meta `add-ai` action) from either the "No API key"
+ * primary CTA or the exhausted-budget card's "Add a provider", and the extension
  * side-panel follower's `slicc:open-settings-from-panel` window event (the SW's
  * `extension.open-settings` bridge command, re-broadcast by
  * `setup-standalone-prelude`, so a side-panel sign-in lands on the login UI, not
@@ -524,8 +525,10 @@ function wireOpenSettingsSurfaces(refs: WcShellRefs, openSettings: () => void): 
 /**
  * The invalid-model error card (see `wc-message-view.ts:errorCardEl`) flips
  * its CTA to "Change model" and bubbles `slicc-error-change-model` up through
- * the thread. Route it to the composer model picker so the user can pick a
- * working model without re-running the same failed turn first; stamp the
+ * the thread; the exhausted-budget card reuses the same event behind a
+ * "Switch provider and try again" label, which is exactly what the staged
+ * replay below delivers. Route it to the composer model picker so the user can
+ * pick a working model without re-running the same failed turn first; stamp the
  * failed message id so the NEXT model-change auto-replays the originating
  * turn (the chat controller's `#handleErrorRetry` walks back from that id
  * through any preceding lick — the onboarding welcome lick is the common

--- a/packages/webapp/tests/core/error-families.test.ts
+++ b/packages/webapp/tests/core/error-families.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The `quota_exceeded` family — detection and envelope parsing. The other
+ * three families are covered through the render path in
+ * `tests/ui/wc/wc-message-view.test.ts`; this one carries a parser, so it gets
+ * its own DOM-free suite.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isQuotaExceededError,
+  isUserFixableError,
+  parseQuotaExceededError,
+} from '../../src/core/error-families.js';
+
+/** The verbatim Adobe proxy refusal, as it reaches the error card. */
+const ADOBE_429 =
+  '429 {"error":{"type":"quota_exceeded","message":"Weekly budget has been fully used. Resets on 2026-09-14. You can also connect your own LLM provider.","resets_at":"2026-09-14T00:00:00.000Z"}}';
+
+describe('isQuotaExceededError', () => {
+  it('matches the Adobe proxy 429 envelope', () => {
+    expect(isQuotaExceededError(ADOBE_429)).toBe(true);
+  });
+
+  it('matches through a scoop unrecoverable-error wrapper', () => {
+    expect(
+      isQuotaExceededError(`Scoop "digest" failed with unrecoverable error: ${ADOBE_429}`)
+    ).toBe(true);
+  });
+
+  it('does not match neighbouring error families or empty input', () => {
+    expect(
+      isQuotaExceededError('403 {"error":{"type":"forbidden","message":"Model not allowed"}}')
+    ).toBe(false);
+    expect(isQuotaExceededError('Adobe session expired — please log in again')).toBe(false);
+    expect(isQuotaExceededError('429 Too Many Requests')).toBe(false);
+    expect(isQuotaExceededError('')).toBe(false);
+    expect(isQuotaExceededError(null)).toBe(false);
+    expect(isQuotaExceededError(undefined)).toBe(false);
+  });
+});
+
+describe('parseQuotaExceededError', () => {
+  it('extracts the provider message and reset instant', () => {
+    expect(parseQuotaExceededError(ADOBE_429)).toEqual({
+      message: 'Weekly budget has been fully used. Resets on 2026-09-14.',
+      resetsAt: '2026-09-14T00:00:00.000Z',
+    });
+  });
+
+  it('drops the trailing "connect your own LLM provider" sentence the CTAs replace', () => {
+    expect(parseQuotaExceededError(ADOBE_429)?.message).not.toContain('connect your own');
+  });
+
+  it('parses through a wrapper prefix that precedes the JSON', () => {
+    const wrapped = `Scoop "digest" failed with unrecoverable error: ${ADOBE_429}`;
+    expect(parseQuotaExceededError(wrapped)?.resetsAt).toBe('2026-09-14T00:00:00.000Z');
+  });
+
+  it('falls back to generic copy — never raw JSON — for a message-less envelope', () => {
+    const detail = parseQuotaExceededError('429 {"error":{"type":"quota_exceeded"}}');
+    expect(detail).toEqual({
+      message: 'The usage budget for this provider has been fully used.',
+      resetsAt: null,
+    });
+  });
+
+  it('still yields a detail when the envelope is truncated mid-JSON', () => {
+    // The family is established by the type token; a parse miss must not fall
+    // back to dumping a broken payload at the user.
+    const detail = parseQuotaExceededError('429 {"error":{"type":"quota_exceeded","message":"Wee');
+    expect(detail?.message).toBe('The usage budget for this provider has been fully used.');
+    expect(detail?.resetsAt).toBeNull();
+  });
+
+  it('ignores non-string message / resets_at fields', () => {
+    const detail = parseQuotaExceededError(
+      '429 {"error":{"type":"quota_exceeded","message":42,"resets_at":0}}'
+    );
+    expect(detail?.message).toBe('The usage budget for this provider has been fully used.');
+    expect(detail?.resetsAt).toBeNull();
+  });
+
+  it('returns null for anything outside the family', () => {
+    expect(parseQuotaExceededError('No API key configured')).toBeNull();
+    expect(parseQuotaExceededError(null)).toBeNull();
+  });
+});
+
+describe('isUserFixableError', () => {
+  it('covers the quota family alongside the other three', () => {
+    expect(isUserFixableError(ADOBE_429)).toBe(true);
+    expect(isUserFixableError('No API key configured for provider "adobe".')).toBe(true);
+    expect(isUserFixableError('Model not allowed: claude-opus-4-6')).toBe(true);
+    expect(isUserFixableError('please log in again')).toBe(true);
+    expect(isUserFixableError('The agent turn failed.')).toBe(false);
+  });
+});

--- a/packages/webapp/tests/providers/cross-provider-model-resolution.test.ts
+++ b/packages/webapp/tests/providers/cross-provider-model-resolution.test.ts
@@ -381,3 +381,71 @@ describe('resolveModelSelectionForScoop (/etc/models policy)', () => {
     expect(providers).toContain(OTHER);
   });
 });
+
+/**
+ * The exhausted-budget error card asks this: is "switch provider" a real offer
+ * right now, or must the card say "add a provider" instead?
+ */
+describe('getAlternativeModelProviders', () => {
+  beforeEach(async () => {
+    storage.clear();
+    await registerProviders();
+    storage.set('selected-model', `${SELECTED}:claude-opus-5`);
+  });
+
+  afterEach(async () => {
+    setActiveModelPolicy(emptyModelPolicy());
+    const { unregisterProviderConfig } = await import('../../src/providers/index.js');
+    for (const id of [SELECTED, OTHER, SECOND_OTHER]) unregisterProviderConfig(id);
+  });
+
+  it('lists the other connected providers, never the excluded one', async () => {
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([
+        { providerId: SELECTED, apiKey: '', accessToken: 'x' },
+        { providerId: OTHER, apiKey: 'sk-or-x' },
+      ])
+    );
+    const { getAlternativeModelProviders } = await import('../../src/providers/account-store.js');
+    expect(getAlternativeModelProviders(SELECTED)).toEqual([OTHER]);
+  });
+
+  it('is empty when the exhausted provider is the only account', async () => {
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: SELECTED, apiKey: '', accessToken: 'x' }])
+    );
+    const { getAlternativeModelProviders } = await import('../../src/providers/account-store.js');
+    expect(getAlternativeModelProviders(SELECTED)).toEqual([]);
+  });
+
+  it('omits a provider whose models the picker would not show either', async () => {
+    // A denied catalogue empties the group, so `getAllAvailableModels` drops
+    // the provider — the CTA must not promise a dropdown entry that is gone.
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([
+        { providerId: SELECTED, apiKey: '', accessToken: 'x' },
+        { providerId: SECOND_OTHER, apiKey: 'sk-third-x' },
+      ])
+    );
+    setActiveModelPolicy(
+      parseModelPolicy(`[${SELECTED}]\n-${SECOND_OTHER}:shared/ambiguous-model\n`)
+    );
+    const { getAlternativeModelProviders } = await import('../../src/providers/account-store.js');
+    expect(getAlternativeModelProviders(SELECTED)).toEqual([]);
+  });
+
+  it('keeps every provider when nothing is excluded', async () => {
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([
+        { providerId: SELECTED, apiKey: '', accessToken: 'x' },
+        { providerId: OTHER, apiKey: 'sk-or-x' },
+      ])
+    );
+    const { getAlternativeModelProviders } = await import('../../src/providers/account-store.js');
+    expect(getAlternativeModelProviders(null)).toEqual([SELECTED, OTHER]);
+  });
+});

--- a/packages/webapp/tests/ui/telemetry.test.ts
+++ b/packages/webapp/tests/ui/telemetry.test.ts
@@ -207,6 +207,12 @@ describe('telemetry', () => {
       'Validation error: Bedrock CAMP API error (400): The provided model identifier is invalid.'
     );
     trackError('llm', 'Adobe session expired — please log in again');
+    // The Adobe rate-limit family: the exhausted-budget card owns its own
+    // switch-provider / add-provider remediation, so it is not a regression.
+    trackError(
+      'llm',
+      '429 {"error":{"type":"quota_exceeded","message":"Weekly budget has been fully used. Resets on 2026-09-14.","resets_at":"2026-09-14T00:00:00.000Z"}}'
+    );
 
     const errorCalls = mockSampleRUM.mock.calls.filter(([cp]) => cp === 'error');
     expect(errorCalls).toHaveLength(0);

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -5,7 +5,7 @@
  * legacy panel renders has a web-component mapping asserted here.
  */
 
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
@@ -13,6 +13,18 @@ installWcDomStubs();
 // Deterministic cluster labels: the real quick-llm needs a provider key.
 vi.mock('../../../src/providers/quick-llm.js', () => ({
   quickLabel: vi.fn(async () => 'Push the release to main'),
+}));
+
+// The quota error card asks the account store which OTHER providers the user
+// could switch to. Drive that answer from the test instead of seeding
+// localStorage with a whole provider catalog.
+const accountStore = vi.hoisted(() => ({
+  getAlternativeModelProviders: vi.fn<() => string[]>(() => []),
+  getSelectedProvider: vi.fn<() => string>(() => 'adobe'),
+}));
+vi.mock('../../../src/providers/account-store.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  ...accountStore,
 }));
 
 import { hasIcon } from '@slicc/webcomponents';
@@ -807,6 +819,98 @@ describe('isNoApiKeyError + errorCardEl', () => {
     });
     expect(card.tagName.toLowerCase()).toBe('slicc-error-card');
     expect(card.hasAttribute('action')).toBe(false);
+  });
+});
+
+describe('quota-exceeded errorCardEl', () => {
+  const ADOBE_429 =
+    '429 {"error":{"type":"quota_exceeded","message":"Weekly budget has been fully used. Resets on 2026-09-14. You can also connect your own LLM provider.","resets_at":"2026-09-14T00:00:00.000Z"}}';
+
+  function quotaCard(content = ADOBE_429): HTMLElement {
+    const [card] = messageEls({
+      id: 'err-q',
+      role: 'assistant',
+      content,
+      timestamp: 1,
+      error: true,
+    });
+    return card;
+  }
+
+  beforeEach(() => {
+    accountStore.getAlternativeModelProviders.mockReturnValue([]);
+    accountStore.getSelectedProvider.mockReturnValue('adobe');
+  });
+
+  it('replaces the raw JSON envelope and the generic header', () => {
+    const card = quotaCard();
+    expect(card.tagName.toLowerCase()).toBe('slicc-error-card');
+    expect(card.getAttribute('label')).toBe('Out of AI budget');
+    expect(card.getAttribute('message')).toBe(
+      'Weekly budget has been fully used. Resets on 2026-09-14.'
+    );
+    expect(card.getAttribute('message')).not.toContain('quota_exceeded');
+    expect(card.getAttribute('message-id')).toBe('err-q');
+  });
+
+  it('offers only "Add a provider" when no other provider is connected', () => {
+    const card = quotaCard();
+    // A model picker holding only the exhausted account is a dead end.
+    expect(card.getAttribute('action')).toBe('settings');
+    expect(card.getAttribute('button-label')).toBe('Add a provider');
+    expect(card.hasAttribute('secondary-action')).toBe(false);
+  });
+
+  it('leads with "Switch provider and try again" when another provider is connected', () => {
+    accountStore.getAlternativeModelProviders.mockReturnValue(['openai']);
+    const card = quotaCard();
+    expect(card.getAttribute('action')).toBe('change-model');
+    expect(card.getAttribute('button-label')).toBe('Switch provider and try again');
+    expect(card.getAttribute('secondary-action')).toBe('settings');
+    expect(card.getAttribute('secondary-button-label')).toBe('Add a provider');
+  });
+
+  it('excludes the failing provider when asking for alternatives', () => {
+    accountStore.getSelectedProvider.mockReturnValue('adobe');
+    quotaCard();
+    expect(accountStore.getAlternativeModelProviders).toHaveBeenCalledWith('adobe');
+  });
+
+  it('degrades to the add-a-provider CTA when the account store throws', () => {
+    accountStore.getSelectedProvider.mockImplementation(() => {
+      throw new Error('localStorage unavailable');
+    });
+    const card = quotaCard();
+    expect(card.getAttribute('action')).toBe('settings');
+    expect(card.getAttribute('label')).toBe('Out of AI budget');
+  });
+
+  it('spells out a reset instant the provider prose omits', () => {
+    const card = quotaCard(
+      '429 {"error":{"type":"quota_exceeded","message":"Your budget is used up.","resets_at":"2026-09-14T00:00:00.000Z"}}'
+    );
+    expect(card.getAttribute('message')).toMatch(/^Your budget is used up\. Resets on .+\.$/);
+  });
+
+  it('never states the reset twice when the prose already names it', () => {
+    const card = quotaCard();
+    expect(card.getAttribute('message')?.match(/Resets on/g)).toHaveLength(1);
+  });
+
+  it('drops every CTA in a read-only transcript but keeps the readable body', () => {
+    accountStore.getAlternativeModelProviders.mockReturnValue(['openai']);
+    const [card] = messageEls(
+      { id: 'err-q', role: 'assistant', content: ADOBE_429, timestamp: 1, error: true },
+      { readOnly: true }
+    );
+    expect(card.hasAttribute('no-action')).toBe(true);
+    expect(card.hasAttribute('action')).toBe(false);
+    expect(card.hasAttribute('secondary-action')).toBe(false);
+    // A reader who cannot act is still owed prose, not a JSON envelope.
+    expect(card.getAttribute('label')).toBe('Out of AI budget');
+    expect(card.getAttribute('message')).toBe(
+      'Weekly budget has been fully used. Resets on 2026-09-14.'
+    );
   });
 });
 

--- a/packages/webcomponents/src/chat/slicc-error-card.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.stories.ts
@@ -7,6 +7,8 @@ interface ErrorCardArgs {
   bodyHtml?: string;
   'button-label'?: string;
   action?: 'retry' | 'settings' | 'change-model' | 'login';
+  'secondary-action'?: 'retry' | 'settings' | 'change-model' | 'login';
+  'secondary-button-label'?: string;
   theme?: 'light' | 'dark';
 }
 
@@ -36,6 +38,10 @@ function build(args: ErrorCardArgs): HTMLElement {
   if (args.label != null) el.setAttribute('label', args.label);
   if (args['button-label'] != null) el.setAttribute('button-label', args['button-label']);
   if (args.action) el.setAttribute('action', args.action);
+  if (args['secondary-action']) el.setAttribute('secondary-action', args['secondary-action']);
+  if (args['secondary-button-label'] != null) {
+    el.setAttribute('secondary-button-label', args['secondary-button-label']);
+  }
   if (args.theme) el.setAttribute('theme', args.theme);
   // Rich slotted markup wins over the plain `message` attribute when supplied.
   if (args.bodyHtml != null) appendRichBody(el, args.bodyHtml);
@@ -72,6 +78,17 @@ const meta: Meta<ErrorCardArgs> = {
         '"Open Settings" and fires `slicc-error-open-settings`; `change-model` flips it to ' +
         '"Change model" and fires `slicc-error-change-model`; `login` flips it to "Log in again" ' +
         'and fires `slicc-error-login`.',
+    },
+    'secondary-action': {
+      control: 'inline-radio',
+      options: ['retry', 'settings', 'change-model', 'login'],
+      description:
+        'Optional second CTA rendered as an outline button before the primary one. Fires the ' +
+        'same events as `action`. Absent means no secondary button.',
+    },
+    'secondary-button-label': {
+      control: 'text',
+      description: 'Secondary CTA label (defaults to the secondary action\u2019s own default)',
     },
     theme: { control: 'inline-radio', options: ['light', 'dark'], description: 'Theme override' },
   },
@@ -171,6 +188,31 @@ export const LoginAction: Story = {
     label: 'Session expired',
     action: 'login',
     message: 'Your session has expired. Log in again to continue.',
+  },
+};
+
+/**
+ * The exhausted-provider-budget card: the primary CTA switches to another
+ * connected provider (and replays the turn), the outline secondary one opens
+ * account settings to connect a new provider. Both remediations are real, so
+ * both are offered.
+ */
+export const QuotaExceeded: Story = {
+  args: {
+    label: 'Out of AI budget',
+    action: 'change-model',
+    'button-label': 'Switch provider and try again',
+    'secondary-action': 'settings',
+    'secondary-button-label': 'Add a provider',
+    message: 'Weekly budget has been fully used. Resets on 2026-09-14.',
+  },
+};
+
+/** Quota card in dark mode — the outline secondary must still read as a button. */
+export const QuotaExceededDark: Story = {
+  args: {
+    ...QuotaExceeded.args,
+    theme: 'dark',
   },
 };
 

--- a/packages/webcomponents/src/chat/slicc-error-card.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.ts
@@ -37,24 +37,38 @@ import { iconEl } from '../internal/icons.js';
  *   revoked token) so the host can re-run its login flow instead of
  *   re-running the same failed turn.
  *
+ * `secondary-action` adds a SECOND, quieter CTA to the left of the primary
+ * one, drawn from the same four variants and firing the same events. One
+ * failure can have two honest remediations — an exhausted provider budget is
+ * fixed either by switching to another connected provider (primary) or by
+ * connecting a new one (secondary) — and forcing that into a single button
+ * would hide whichever the user actually needs.
+ *
  * @attr label - the header label (default "Something went wrong")
  * @attr message - error body text (escaped); ignored when slotted content is present
  * @attr button-label - action button label (defaults vary by `action`:
  *   "Try again" / "Open Settings" / "Change model" / "Log in again")
  * @attr message-id - id of the failed chat message this card stands for; echoed
  *   back on the action event so the host can bind it to THIS turn
+ * @attr secondary-button-label - label for the secondary CTA (defaults to the
+ *   secondary action's own default label)
  * @attr no-action - render header + body only, with no action button at all
- *   (read-only transcripts — see `noAction`)
+ *   (read-only transcripts — see `noAction`); suppresses the secondary CTA too
  * @attr action - `retry` (default) | `settings` | `change-model` | `login`;
  *   switches the CTA event, default label, and glyph. Unknown values normalize
  *   back to `"retry"` so legacy hosts stay safe.
+ * @attr secondary-action - same four values; renders an additional outline
+ *   button before the primary one. Absent (or unknown) means no secondary CTA
+ *   at all — unlike `action`, it does NOT normalize to `"retry"`, because a
+ *   host that never asked for a second button must not grow one.
  * @attr theme - `light` | `dark`; per-element override of the inherited theme
  * @csspart card - the outer `.err` card
  * @csspart header - the `.eh` header row
  * @csspart icon - the `.ic` span wrapping the lucide `triangle-alert` `<svg>`
  * @csspart label - the header label span
  * @csspart body - the `.eb` body line
- * @csspart button - the action button
+ * @csspart button - the primary action button
+ * @csspart secondary-button - the secondary (outline) action button
  * @slot - rich body content (overrides the `message` attribute)
  * @fires slicc-error-retry - { messageId: string | null } dispatched on retry
  *   click (bubbles, composed) when `action="retry"` (the default)
@@ -144,7 +158,7 @@ const STYLE = `
 }
 .eb ::slotted(b),.eb b{font-weight:600;}
 
-.foot{display:flex;justify-content:flex-end;margin-top:8px;}
+.foot{display:flex;justify-content:flex-end;align-items:center;gap:8px;margin-top:8px;flex-wrap:wrap;}
 .retry{
   appearance:none;border:none;cursor:pointer;
   font-family:var(--ui);font-size:11.5px;font-weight:600;
@@ -153,7 +167,16 @@ const STYLE = `
   display:inline-flex;align-items:center;gap:5px;
   transition:filter .12s ease;
 }
+/* Secondary CTA: same geometry, outline weight — it must read as the
+   quieter of two real choices, not as a disabled primary. */
+.retry.ghost{
+  background:transparent;color:var(--err-head);
+  border:1px solid var(--err-border);
+  padding:4px 10px;
+}
 .retry:hover{filter:brightness(1.08);}
+.retry.ghost:hover{background:color-mix(in srgb,var(--err-btn-bg) 10%,transparent);filter:none;}
+.retry.ghost:focus-visible{outline-color:var(--err-head);}
 .retry:focus-visible{outline:2px solid color-mix(in srgb,var(--err-btn-bg) 60%,var(--ink));outline-offset:2px;}
 .retry svg{display:block;}
 `;
@@ -164,14 +187,17 @@ export class SliccErrorCard extends HTMLElement {
     'label',
     'message',
     'button-label',
+    'secondary-button-label',
     'message-id',
     'action',
+    'secondary-action',
     'no-action',
     'theme',
   ];
 
   readonly #root: ShadowRoot;
   #onActionClick: ((e: MouseEvent) => void) | null = null;
+  #onSecondaryClick: ((e: MouseEvent) => void) | null = null;
 
   constructor() {
     super();
@@ -221,6 +247,16 @@ export class SliccErrorCard extends HTMLElement {
     else this.setAttribute('button-label', value);
   }
 
+  /** Secondary action button label (defaults to the secondary action's own default). */
+  get secondaryButtonLabel(): string | null {
+    return this.getAttribute('secondary-button-label');
+  }
+
+  set secondaryButtonLabel(value: string | null) {
+    if (value == null) this.removeAttribute('secondary-button-label');
+    else this.setAttribute('secondary-button-label', value);
+  }
+
   /**
    * Id of the failed chat message this card stands for. Echoed back on the
    * action event so the host can bind it to the SPECIFIC turn that produced
@@ -250,6 +286,23 @@ export class SliccErrorCard extends HTMLElement {
   set action(value: ErrorAction | null) {
     if (value == null) this.removeAttribute('action');
     else this.setAttribute('action', value);
+  }
+
+  /**
+   * Optional second CTA rendered before the primary one, using the same four
+   * variants and the same events. `null` when absent or unrecognized — an
+   * unknown value must not conjure a button the host never asked for, which
+   * is why this does NOT normalize to `retry` the way {@link action} does.
+   */
+  get secondaryAction(): ErrorAction | null {
+    const a = this.getAttribute('secondary-action');
+    if (a === 'settings' || a === 'change-model' || a === 'login' || a === 'retry') return a;
+    return null;
+  }
+
+  set secondaryAction(value: ErrorAction | null) {
+    if (value == null) this.removeAttribute('secondary-action');
+    else this.setAttribute('secondary-action', value);
   }
 
   /**
@@ -321,6 +374,14 @@ export class SliccErrorCard extends HTMLElement {
     );
   }
 
+  /** Fire the CustomEvent that `action` stands for. Shared by both buttons. */
+  #emit(action: ErrorAction): void {
+    if (action === 'settings') this.openSettings();
+    else if (action === 'change-model') this.changeModel();
+    else if (action === 'login') this.login();
+    else this.retry();
+  }
+
   #render(): void {
     const action = this.action;
     const label = this.label ?? DEFAULT_LABEL;
@@ -356,8 +417,32 @@ export class SliccErrorCard extends HTMLElement {
       buttonLabel
     );
 
+    const secondary = this.secondaryAction;
+    const secondaryLabel = secondary
+      ? (this.secondaryButtonLabel ?? DEFAULT_BUTTON_LABEL[secondary])
+      : null;
+    const secondaryBtn =
+      secondary && secondaryLabel != null
+        ? h(
+            'button',
+            {
+              type: 'button',
+              class: 'retry ghost',
+              part: 'secondary-button',
+              'aria-label': secondaryLabel,
+            },
+            iconEl(BUTTON_ICON[secondary], { size: BUTTON_ICON_SIZE }),
+            secondaryLabel
+          )
+        : null;
+
     const children = [headerRow, bodyRow];
-    if (!this.noAction) children.push(h('div', { class: 'foot' }, actionBtn));
+    if (!this.noAction) {
+      const foot = h('div', { class: 'foot' });
+      if (secondaryBtn) foot.append(secondaryBtn);
+      foot.append(actionBtn);
+      children.push(foot);
+    }
 
     const cardEl = h('div', { class: 'err', part: 'card' }, ...children);
     this.#root.replaceChildren(cardEl);
@@ -367,24 +452,34 @@ export class SliccErrorCard extends HTMLElement {
 
   #bindAction(): void {
     this.#unbindAction();
-    const btn = this.#root.querySelector('.retry');
-    if (!btn) return;
-    const action = this.action;
-    this.#onActionClick = () => {
-      if (action === 'settings') this.openSettings();
-      else if (action === 'change-model') this.changeModel();
-      else if (action === 'login') this.login();
-      else this.retry();
-    };
-    btn.addEventListener('click', this.#onActionClick as EventListener);
+    // `.retry:not(.ghost)` is the primary: the shared class hook keeps legacy
+    // CSS and shadow-piercing tests matching both buttons, so the primary
+    // lookup has to exclude the outline one explicitly.
+    const btn = this.#root.querySelector('.retry:not(.ghost)');
+    if (btn) {
+      const action = this.action;
+      this.#onActionClick = () => this.#emit(action);
+      btn.addEventListener('click', this.#onActionClick as EventListener);
+    }
+    const ghost = this.#root.querySelector('.retry.ghost');
+    const secondary = this.secondaryAction;
+    if (ghost && secondary) {
+      this.#onSecondaryClick = () => this.#emit(secondary);
+      ghost.addEventListener('click', this.#onSecondaryClick as EventListener);
+    }
   }
 
   #unbindAction(): void {
-    const btn = this.#root.querySelector('.retry');
+    const btn = this.#root.querySelector('.retry:not(.ghost)');
     if (btn && this.#onActionClick) {
       btn.removeEventListener('click', this.#onActionClick as EventListener);
     }
     this.#onActionClick = null;
+    const ghost = this.#root.querySelector('.retry.ghost');
+    if (ghost && this.#onSecondaryClick) {
+      ghost.removeEventListener('click', this.#onSecondaryClick as EventListener);
+    }
+    this.#onSecondaryClick = null;
   }
 }
 

--- a/packages/webcomponents/tests/chat/slicc-error-card.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-error-card.test.ts
@@ -478,4 +478,111 @@ describe('slicc-error-card', () => {
       expect((spy.mock.calls[0][0] as CustomEvent).detail).toEqual({ messageId: 'err-2' });
     });
   });
+  describe('secondary action', () => {
+    it('renders no secondary button by default', () => {
+      const el = mount({ message: 'oops' });
+      expect(el.shadowRoot?.querySelector('[part="secondary-button"]')).toBeNull();
+      expect(el.secondaryAction).toBeNull();
+    });
+
+    it('does NOT normalize an unknown secondary-action into a button', () => {
+      // Unlike `action`, an unrecognized value must not conjure a second CTA
+      // the host never asked for.
+      const el = mount({ message: 'oops', 'secondary-action': 'teleport' });
+      expect(el.secondaryAction).toBeNull();
+      expect(el.shadowRoot?.querySelector('[part="secondary-button"]')).toBeNull();
+    });
+
+    it('renders the secondary CTA before the primary with its own glyph and label', () => {
+      const el = mount({
+        message: 'Weekly budget has been fully used.',
+        action: 'change-model',
+        'button-label': 'Switch provider and try again',
+        'secondary-action': 'settings',
+        'secondary-button-label': 'Add a provider',
+      });
+      const foot = el.shadowRoot?.querySelector('.foot') as HTMLElement;
+      const buttons = [...foot.querySelectorAll('button')];
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0].getAttribute('part')).toBe('secondary-button');
+      expect(buttons[1].getAttribute('part')).toBe('button');
+      expect(buttons[0].textContent?.trim()).toBe('Add a provider');
+      expect(buttons[1].textContent?.trim()).toBe('Switch provider and try again');
+      expect(buttons[0].querySelector('svg')?.innerHTML).toBe(iconShape('settings', 12));
+      expect(buttons[1].querySelector('svg')?.innerHTML).toBe(iconShape('sparkles', 12));
+    });
+
+    it('defaults the secondary label to the secondary action default', () => {
+      const el = mount({ message: 'oops', action: 'retry', 'secondary-action': 'settings' });
+      expect(el.shadowRoot?.querySelector('[part="secondary-button"]')?.textContent?.trim()).toBe(
+        'Open Settings'
+      );
+    });
+
+    it('fires each button its own event, and only its own', () => {
+      const el = mount({
+        message: 'Weekly budget has been fully used.',
+        'message-id': 'err-q',
+        action: 'change-model',
+        'secondary-action': 'settings',
+      });
+      const changeSeen: CustomEvent[] = [];
+      const settingsSeen: CustomEvent[] = [];
+      const retrySeen: CustomEvent[] = [];
+      document.body.addEventListener('slicc-error-change-model', (e) =>
+        changeSeen.push(e as CustomEvent)
+      );
+      document.body.addEventListener('slicc-error-open-settings', (e) =>
+        settingsSeen.push(e as CustomEvent)
+      );
+      document.body.addEventListener('slicc-error-retry', (e) => retrySeen.push(e as CustomEvent));
+
+      (el.shadowRoot?.querySelector('[part="button"]') as HTMLButtonElement).click();
+      expect(changeSeen).toHaveLength(1);
+      expect(changeSeen[0].detail).toEqual({ messageId: 'err-q' });
+      expect(settingsSeen).toHaveLength(0);
+
+      (el.shadowRoot?.querySelector('[part="secondary-button"]') as HTMLButtonElement).click();
+      expect(settingsSeen).toHaveLength(1);
+      expect(settingsSeen[0].bubbles).toBe(true);
+      expect(settingsSeen[0].composed).toBe(true);
+      expect(settingsSeen[0].detail).toEqual({ messageId: 'err-q' });
+      expect(changeSeen).toHaveLength(1);
+      expect(retrySeen).toHaveLength(0);
+    });
+
+    it('reflects the secondary-action property and drops the button when cleared', () => {
+      const el = mount({ message: 'oops', 'secondary-action': 'login' });
+      expect(el.secondaryAction).toBe('login');
+      el.secondaryAction = null;
+      expect(el.hasAttribute('secondary-action')).toBe(false);
+      expect(el.shadowRoot?.querySelector('[part="secondary-button"]')).toBeNull();
+      el.secondaryButtonLabel = 'Sign back in';
+      el.secondaryAction = 'login';
+      expect(el.shadowRoot?.querySelector('[part="secondary-button"]')?.textContent?.trim()).toBe(
+        'Sign back in'
+      );
+    });
+
+    it('suppresses the secondary CTA under no-action (read-only transcripts)', () => {
+      const el = mount({
+        message: 'oops',
+        action: 'change-model',
+        'secondary-action': 'settings',
+        'no-action': '',
+      });
+      expect(el.shadowRoot?.querySelector('.foot')).toBeNull();
+      expect(el.shadowRoot?.querySelector('[part="secondary-button"]')).toBeNull();
+    });
+
+    it('unbinds the secondary click listener on disconnect', () => {
+      const el = mount({ message: 'oops', action: 'retry', 'secondary-action': 'settings' });
+      const btn = el.shadowRoot?.querySelector('[part="secondary-button"]') as HTMLButtonElement;
+      const spy = vi.fn();
+      document.body.addEventListener('slicc-error-open-settings', spy);
+      el.remove();
+      btn.click();
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The Adobe proxy's new rate limit reached the chat as a raw
`429 {"error":{"type":"quota_exceeded","message":"Weekly budget has been fully used. Resets on 2026-09-14. You can also connect your own LLM provider.","resets_at":"…"}}`
line, under a generic **Something went wrong** header, behind a **Try again**
button that cannot work — the budget is gone until it resets.

Now the card parses that envelope and offers the two remediations that do work:
**Switch provider and try again** (only when another provider is actually
connected) and **Add a provider**.

## Why

The generic treatment fails the user three ways at once: the body is JSON, the
header says nothing, and the only affordance re-runs the exact request that just
got refused. The information needed to fix it — that a *different* provider would
work, or that connecting one is a click away — is nowhere on screen.

## Approach / Implementation notes

**Which CTA, and why it is conditional** (`errorCardEl`, `wc-message-view.ts`):

- **Another provider connected** → primary `change-model` labelled *"Switch
  provider and try again"*, with *"Add a provider"* (`settings`) as an outline
  secondary. `wireWcNav` already routes `change-model` to the composer model
  picker **and** stages a pending replay, so "and try again" is literal: picking
  a model re-runs the failed turn without a second click. No new nav wiring.
- **Exhausted account is the only one** → the single CTA is *"Add a provider"*.
  Opening a model picker that holds only the exhausted account is a dead end.

"Another provider connected" is the new `getAlternativeModelProviders`
(`account-store.ts`), derived from `getAllAvailableModels` — so hidden,
build-excluded and policy-denied providers are filtered out exactly as the picker
filters them. A CTA that opens a dropdown must not promise an entry the dropdown
lacks. It is read at render time inside a `try`/`catch`: the store touches
`localStorage` and a provider catalog, and neither may take an error card down.

**Detection** (`core/error-families.ts`) matches the machine-readable
`error.type`, not the prose, so re-worded proxy copy — or a
`Scoop "…" failed with unrecoverable error: ` wrapper — never drops the failure
out of the family. `parseQuotaExceededError` is detect-and-parse in one call; a
truncated or message-less envelope still yields a detail, because a parse miss
must not fall back to dumping JSON at the user. The trailing "You can also
connect your own LLM provider." sentence is stripped: the CTAs *are* that now.

**Component** (`slicc-error-card`): new optional `secondary-action` /
`secondary-button-label`, drawn from the same four variants and firing the same
events. Absent **or unknown** means no button — deliberately *not* normalized to
`retry` the way `action` is, so a host that never asked for a second button
cannot grow one.

**Two judgment calls a reviewer should weigh in on:**

1. The ask read as either "one CTA, conditionally chosen" or "two CTAs". I chose
   to show **both** when a switch target exists. Reverting to strictly
   one-or-the-other is a two-line change in `quotaCtaAttrs`.
2. I extended the *reword* (not the CTAs) to the iOS follower and to read-only
   scoop transcripts. See below.

## Cross-cutting impact

- **Floats exercised**: leader (CLI / hosted). The extension side panel needs no
  change — `wc-follower.ts` already forwards `slicc-error-open-settings` and
  `slicc-error-change-model` to the leader tab, and this PR reuses both events
  rather than inventing new ones.
- **iOS follower**: `QuotaExceededDetail` (`Models/ErrorFamilies.swift`) mirrors
  the *text* only. `ErrorCard` still renders **no** CTA — both act on
  leader-side state the follower→leader protocol carries no message for — but a
  reader who cannot act is still owed prose instead of a JSON envelope.
- **Read-only scoop transcripts** (#2312): same reasoning. The label/body rewrite
  now happens *before* the `no-action` early return, so a scoop transcript keeps
  `no-action` and loses every CTA, while still showing readable text.
- **Telemetry**: no new wiring. Both skip sites (`trackError`,
  `trackScoopLifecycle`) already call `isUserFixableError`, which the quota
  family now joins — so the exhausted-budget cascade stops beaconing as a
  regression. `#emitErrorCardBeacon` was switched from its hand-copied
  three-family list to that same predicate, which is now the single shared list.
- **Bundle size**: `wc-message-view.ts` gained a static import of
  `account-store.ts`, which was **already** an eager page chunk (65 kB). The
  first-load gate measures **page +1.3 kB / worker +0.2 kB** vs the merge base —
  well inside the 5 kB allowance, 20 kB / 46 kB under the ceilings.
- **Other callers of the changed contract**: `isUserFixableError` gained a
  fourth family; its three call sites (two telemetry, one error-card beacon) all
  want exactly that widening. The `slicc-error-card` change is additive —
  `#bindAction`'s primary lookup became `.retry:not(.ghost)` so the shared
  `.retry` class hook keeps matching both buttons for existing CSS and
  shadow-piercing tests.
- **Persisted state**: none. No new storage keys, no migrations.

## Test plan

- [x] `npm run verify` — 8/8 (biome, prettier, custom-lints, boy-scout-debt,
      manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — **20,456 passing**, 54 skipped, no new failures
- [x] `npm run test:coverage:webapp` / `:webcomponents` — both gates pass
- [x] iOS: 737 unit tests pass; `swift-coverage-check.sh` passes
      (`ErrorFamilies.swift` at 100% lines / 95% regions)
- [x] `swift format lint --strict` + `swiftlint` clean
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load gate green (numbers above)
- [x] **New behavior covered by unit tests** in four suites:
  - `packages/webapp/tests/core/error-families.test.ts` (new) — parsing, wrapper
    prefixes, truncated envelopes, non-string fields, neighbouring families
  - `packages/webapp/tests/ui/wc/wc-message-view.test.ts` — both CTA branches,
    the failing-provider exclusion, store-throws degradation, read-only parity
  - `packages/webapp/tests/providers/cross-provider-model-resolution.test.ts` —
    `getAlternativeModelProviders`, including the policy-denied case
  - `packages/webcomponents/tests/chat/slicc-error-card.test.ts` — secondary
    button render order, glyphs, event isolation, unknown-value inertness,
    `no-action` suppression, disconnect unbinding
  - `packages/ios-app/…/QuotaExceededDetailTests.swift` (new) — the Swift mirror
- [ ] Manual smoke against a live exhausted budget — **not done**: reproducing it
      means actually burning a weekly Adobe budget. Covered by the fixture-driven
      tests above and the Storybook stories.

**Pre-existing failures**: none observed.

## Screenshots

New Storybook stories `Chat/ErrorCard/QuotaExceeded` (+ `…Dark`) render the card
in isolation. Both show the state where another provider **is** connected, so
both CTAs appear.

**Light:**

![Out of AI budget card, light mode](https://github.com/user-attachments/assets/8952fe56-e845-4791-9312-d5f61ed99503)

**Dark:**

![Out of AI budget card, dark mode](https://github.com/user-attachments/assets/2557e3d7-24ab-4e5e-8890-a410a0f2ed39)

With no other provider connected the card collapses to a single **Add a
provider** button — asserted in `wc-message-view.test.ts`, not just described.

## Documentation

- [x] `docs/operational-telemetry.md` — the user-fixable family list the `error`
      checkpoint drops now names `quota-exceeded`
- [x] Doc comments on `errorCardEl`, `quotaCtaAttrs`, `wireChangeModelEvent`,
      `wireOpenSettingsSurfaces`, `slicc-error-card`, and the Swift `ErrorCard`
      carry the routing story
- [x] Storybook stories are the component-level docs for the new variant

## Risk & rollback

Blast radius is one error-card branch: a message that does not carry
`quota_exceeded` takes exactly the path it took before. No flags, no persisted
state, no migration — revert cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
