### PR TITLE
fix(webapp): settle slicc.fetch from full-document sprinkles

### DIFF
--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -87,11 +87,12 @@ export interface SprinkleFetchInit {
  * Internal wire/transport shape carried by the bridge for `slicc.fetch`.
  * The body is base64-encoded so binary responses survive the
  * JSON/postMessage transport between the realm worker and the page.
- * This is NOT the public return of `slicc.fetch` — the page-side
- * `jshDispatch` rebuilds a native `Response` from these fields before
- * returning to the sprinkle. Unlike the iframe's CORS-bound native
- * `fetch`, this routes through the worker shell's proxied,
- * secret-injecting fetch.
+ * This is NOT the public return of `slicc.fetch`. Fragment-mode
+ * `createAPI.fetch` rebuilds a native `Response` in-page; full-document
+ * iframes post this wire shape across `postMessage` (a `Response` is not
+ * structured-cloneable) and rebuild inside the iframe. Unlike the
+ * iframe's CORS-bound native `fetch`, this routes through the worker
+ * shell's proxied, secret-injecting fetch.
  */
 export interface SprinkleFetchResult {
   ok: boolean;
@@ -312,14 +313,18 @@ export function buildJshNodeScript(op: string, args: unknown[]): string {
     'var bin="",C=0x8000;for(var i=0;i<u.length;i+=C){bin+=String.fromCharCode.apply(null,u.subarray(i,i+C));}' +
     'out={ok:r.ok,status:r.status,statusText:r.statusText,url:r.url,headers:h,bodyBase64:btoa(bin)};' +
     "}else if(op==='http'){" +
+    'var http=require("sliccy:http");' +
     'var c=http.client(a[0]||{});' +
     'var res=await c[a[1]](a[2],Object.assign({},a[3]||{},{raw:true}));' +
     'out={status:res.status,headers:res.headers,body:res.body};' +
     "}else if(op==='browser'){" +
+    'var browser=require("sliccy:browser");' +
     'var m=a[0];if(typeof browser[m]!=="function")throw new Error("browser."+m+" is not available over the sprinkle bridge");' +
     'out=await browser[m].apply(browser,a.slice(1));' +
-    "}else if(op==='spawn'){out=await exec.spawn(a[0]);" +
-    "}else if(op==='fetchToFile'){out=await fs.fetchToFile(a[0],a[1]);" +
+    "}else if(op==='spawn'){" +
+    'out=await require("sliccy:exec").spawn(a[0]);' +
+    "}else if(op==='fetchToFile'){" +
+    'out=await require("fs").fetchToFile(a[0],a[1]);' +
     '}else{throw new Error("unknown jsh op: "+op);}' +
     'emit({ok:true,value:out});' +
     '}catch(e){emit({ok:false,error:(e&&e.message)?e.message:String(e)});}'
@@ -398,30 +403,37 @@ function toUint8Array(value: unknown): Uint8Array {
   throw new Error('expected Uint8Array, ArrayBuffer, or number[]');
 }
 
-/** Statuses that the `Response` constructor forbids carrying a body. */
-const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
-
 /**
- * Build a native `Response` page-side from the bridge's wire shape.
- * Handles null-body statuses (101/103/204/205/304) by passing `null`
- * for the body, and statuses outside the `Response` constructor's
- * accepted `[200,599]` range by constructing a default-status Response
- * and shadowing `status`/`statusText`/`ok` (and `url`) via own data
- * props. `Response.url` is a read-only prototype getter; an own data
- * prop shadows it for property reads while native `.text()`/`.json()`/
- * `.arrayBuffer()`/`.blob()` still read the internal body.
+ * Build a native `Response` from the bridge's wire shape.
+ *
+ * Self-contained (no free variables) so full-document iframes can inject
+ * the same function via `Function#toString()`. Handles null-body statuses
+ * (101/103/204/205/304) by passing `null` for the body, and statuses
+ * outside the `Response` constructor's accepted `[200,599]` range by
+ * constructing a default-status Response and shadowing `status` /
+ * `statusText` / `ok` (and `url`) via own data props. `Response.url` is a
+ * read-only prototype getter; an own data prop shadows it for property
+ * reads while native `.text()`/`.json()`/`.arrayBuffer()`/`.blob()` still
+ * read the internal body.
  */
-function buildFetchResponse(v: SprinkleFetchResult): Response {
-  const bytes = base64ToU8(v.bodyBase64);
-  const body: BodyInit | null = NULL_BODY_STATUSES.has(v.status) ? null : (bytes as BodyInit);
+export function buildFetchResponse(v: SprinkleFetchResult): Response {
+  const bin = atob(v.bodyBase64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  const nullBody =
+    v.status === 101 ||
+    v.status === 103 ||
+    v.status === 204 ||
+    v.status === 205 ||
+    v.status === 304;
+  const body: BodyInit | null = nullBody ? null : bytes;
   const headers = new Headers(v.headers);
-  let resp: Response;
   try {
-    resp = new Response(body, { status: v.status, statusText: v.statusText, headers });
+    const resp = new Response(body, { status: v.status, statusText: v.statusText, headers });
     Object.defineProperty(resp, 'url', { value: v.url, configurable: true });
     return resp;
   } catch {
-    resp = new Response(body, { headers });
+    const resp = new Response(body, { headers });
     const ok = v.status >= 200 && v.status < 300;
     Object.defineProperty(resp, 'status', { value: v.status, configurable: true });
     Object.defineProperty(resp, 'statusText', { value: v.statusText, configurable: true });
@@ -429,6 +441,11 @@ function buildFetchResponse(v: SprinkleFetchResult): Response {
     Object.defineProperty(resp, 'url', { value: v.url, configurable: true });
     return resp;
   }
+}
+
+/** `buildFetchResponse` source injected into full-document sprinkle iframes. */
+export function iframeFetchResponseSource(): string {
+  return 'var buildFetchResponse = ' + buildFetchResponse.toString() + ';\n';
 }
 
 /**
@@ -928,7 +945,9 @@ export class SprinkleBridge {
    * realm-backed op (`fetch`/`http`/`browser`/`spawn`/`fetchToFile`)
    * runs through a single `node -e` program over the shared exec
    * transport. Return values are structured-clone-safe so the renderer
-   * can post them straight back to an iframe in extension mode.
+   * can post them straight back to an iframe — `fetch` stays on the
+   * {@link SprinkleFetchResult} wire shape here; fragment `createAPI.fetch`
+   * and the iframe bridge rebuild a native `Response` on the caller side.
    */
   private async jshDispatch(op: string, args: unknown[]): Promise<unknown> {
     if (op === 'readFileBinary') {
@@ -941,12 +960,7 @@ export class SprinkleBridge {
       await this.fs.writeFile(args[0] as string, base64ToU8(args[1] as string));
       return true;
     }
-    const value = await runJshOp((cmd) => this.runExec(cmd), op, args);
-    if (op === 'fetch') {
-      const v = value as SprinkleFetchResult;
-      return buildFetchResponse(v);
-    }
-    return value;
+    return runJshOp((cmd) => this.runExec(cmd), op, args);
   }
 
   /**
@@ -1211,8 +1225,10 @@ export class SprinkleBridge {
       exec: Object.assign((cmd: string) => this.runExec(cmd), {
         spawn: (argv: string[]) => this.jshDispatch('spawn', [argv]) as Promise<SprinkleExecResult>,
       }) as SprinkleExecFn,
-      fetch: (url: string, init?: SprinkleFetchInit) =>
-        this.jshDispatch('fetch', [url, init ?? null]) as Promise<Response>,
+      fetch: async (url: string, init?: SprinkleFetchInit) =>
+        buildFetchResponse(
+          (await this.jshDispatch('fetch', [url, init ?? null])) as SprinkleFetchResult
+        ),
       http: {
         client: (config: SprinkleHttpClientConfig) => this.createHttpClient(config),
       },

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -324,7 +324,7 @@ export function buildJshNodeScript(op: string, args: unknown[]): string {
     "}else if(op==='spawn'){" +
     'out=await require("sliccy:exec").spawn(a[0]);' +
     "}else if(op==='fetchToFile'){" +
-    'out=await require("fs").fetchToFile(a[0],a[1]);' +
+    'out=await require("node:fs").fetchToFile(a[0],a[1]);' +
     '}else{throw new Error("unknown jsh op: "+op);}' +
     'emit({ok:true,value:out});' +
     '}catch(e){emit({ok:false,error:(e&&e.message)?e.message:String(e)});}'

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -10,7 +10,11 @@
 
 import { isNestedInAnotherFrame, nudgeIframeRepaint } from '@slicc/shared-ts';
 import type { EntryType } from '../fs/index.js';
-import type { SprinkleAgentOptions, SprinkleBridgeAPI } from './sprinkle-bridge.js';
+import {
+  iframeFetchResponseSource,
+  type SprinkleAgentOptions,
+  type SprinkleBridgeAPI,
+} from './sprinkle-bridge.js';
 import { iframeScreenshotHelpersSource } from './sprinkle-screenshot.js';
 import { isThemeLight, registerSprinkleWindow, unregisterSprinkleWindow } from './theme.js';
 
@@ -68,7 +72,23 @@ function postToIframe(
   id: unknown,
   extra: SprinkleIframeResponseBody = {}
 ): void {
-  iframe.contentWindow?.postMessage({ type, id, ...extra }, '*');
+  const win = iframe.contentWindow;
+  if (!win) return;
+  try {
+    win.postMessage({ type, id, ...extra }, '*');
+  } catch (err) {
+    // A non-cloneable success payload (e.g. a native Response) must still
+    // settle the iframe callback — otherwise slicc.fetch hangs until the
+    // caller's timeout (#2946). Skip the fallback if we were already
+    // posting `{ error }` so a second throw cannot recurse.
+    if (extra.error !== undefined) return;
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      win.postMessage({ type, id, error: message }, '*');
+    } catch {
+      /* iframe gone, or even the error payload was rejected */
+    }
+  }
 }
 
 /**
@@ -453,6 +473,7 @@ export class SprinkleRenderer {
   }
 
   ${iframeScreenshotHelpersSource()}
+  ${iframeFetchResponseSource()}
 
   var api = {
     lick: function(event) {
@@ -580,7 +601,9 @@ export class SprinkleRenderer {
     agent: function(prompt, opts) {
       return _vfsCall('sprinkle-agent', { prompt: prompt, opts: opts }, function(m) { return m.result; });
     },
-    fetch: function(url, init) { return _jshCall('fetch', [url, init || null]); },
+    fetch: function(url, init) {
+      return _jshCall('fetch', [url, init || null]).then(function(v) { return buildFetchResponse(v); });
+    },
     http: {
       client: function(cfg) {
         function mk(method) { return function(path, opts) { return _jshCall('http', [cfg, method, path, opts || null]); }; }

--- a/packages/webapp/tests/e2e/sprinkle-fetch-iframe.test.ts
+++ b/packages/webapp/tests/e2e/sprinkle-fetch-iframe.test.ts
@@ -1,0 +1,176 @@
+// packages/webapp/tests/e2e/sprinkle-fetch-iframe.test.ts
+/**
+ * Full-document sprinkle `slicc.fetch` must settle across the iframe
+ * postMessage boundary (#2946). A native `Response` is not structured-
+ * cloneable, so the parent has to post the SprinkleFetchResult wire shape
+ * and the iframe rebuilds `Response`. This scenario drives a real srcdoc
+ * iframe in the running app — a unit-only green is not enough.
+ *
+ *   Run: npm run test:e2e -- sprinkle-fetch-iframe
+ */
+
+import { expect, test } from './fixtures.js';
+import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
+
+const SPRINKLE_NAME = 'e2e-fetch-probe';
+const SPRINKLE_PATH = `/shared/sprinkles/${SPRINKLE_NAME}/${SPRINKLE_NAME}.shtml`;
+const SPRINKLE_HTML = `<!DOCTYPE html>
+<html>
+<head>
+  <title>e2e-fetch-probe</title>
+  <link rel="icon" href="globe" />
+</head>
+<body>
+  <h1>e2e-fetch-probe</h1>
+</body>
+</html>
+`;
+
+const SETTLE_MS = 12_000;
+
+interface SprinkleManagerHarness {
+  fs: {
+    mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+    writeFile(path: string, content: string): Promise<void>;
+  };
+  refresh(): Promise<void>;
+  open(name: string): Promise<void>;
+  opened(): string[];
+}
+
+interface TimedCall {
+  label: string;
+  ms: number;
+  status: 'OK' | 'HANG' | 'ERR';
+  result?: unknown;
+  error?: string;
+}
+
+declare global {
+  interface Window {
+    __slicc_sprinkleManager?: SprinkleManagerHarness;
+  }
+}
+
+test.describe('sprinkle iframe slicc.fetch (#2946)', () => {
+  test('full-document sprinkle fetch/exec/fetchToFile settle', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await seedSkipSwReload(page);
+    await gotoLeader(page);
+    await waitForSW(page);
+    await page.waitForSelector('slicc-input-card');
+    await expect(page.locator('slicc-chat-thread')).toContainText('Welcome to SLICC', {
+      timeout: 20_000,
+    });
+
+    // Warm the lucide script the full-doc iframe load event waits on, so the
+    // 5s render timeout is not spent on a cold 477KB fetch.
+    await page.evaluate(async () => {
+      await fetch('/lucide-icons.js');
+    });
+
+    await page.evaluate(
+      async ({ path, html, name }) => {
+        const mgr = window.__slicc_sprinkleManager;
+        if (!mgr) throw new Error('__slicc_sprinkleManager missing');
+        await mgr.fs.mkdir('/shared/sprinkles/e2e-fetch-probe', { recursive: true });
+        await mgr.fs.writeFile(path, html);
+        await mgr.refresh();
+        if (!mgr.opened().includes(name)) await mgr.open(name);
+      },
+      { path: SPRINKLE_PATH, html: SPRINKLE_HTML, name: SPRINKLE_NAME }
+    );
+
+    await page.waitForFunction(
+      (name: string) => {
+        const iframe = document.querySelector(
+          `[data-sprinkle="${name}"] iframe`
+        ) as HTMLIFrameElement | null;
+        return Boolean(iframe?.contentWindow && 'slicc' in iframe.contentWindow);
+      },
+      SPRINKLE_NAME,
+      { timeout: 20_000 }
+    );
+
+    const results = await page.evaluate(
+      async ({ name, settleMs }) => {
+        const iframe = document.querySelector(
+          `[data-sprinkle="${name}"] iframe`
+        ) as HTMLIFrameElement;
+        const slicc = (
+          iframe.contentWindow as Window & {
+            slicc: {
+              stat(path: string): Promise<{ type: string; size: number }>;
+              exec(cmd: string): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+              fetch(url: string): Promise<Response>;
+              fetchToFile(url: string, path: string): Promise<number>;
+            };
+          }
+        ).slicc;
+        const url = `${window.location.origin}/status`;
+
+        async function timed(label: string, run: () => Promise<unknown>): Promise<TimedCall> {
+          const t0 = performance.now();
+          const hang = new Promise<{ _hang: true }>((resolve) =>
+            setTimeout(() => resolve({ _hang: true }), settleMs)
+          );
+          try {
+            const result = await Promise.race([run(), hang]);
+            const ms = Math.round(performance.now() - t0);
+            if (result && typeof result === 'object' && '_hang' in result) {
+              return { label, ms, status: 'HANG' };
+            }
+            return { label, ms, status: 'OK', result };
+          } catch (err) {
+            return {
+              label,
+              ms: Math.round(performance.now() - t0),
+              status: 'ERR',
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+
+        const exec = await timed('exec', () =>
+          slicc.exec('echo ok').then((r) => ({
+            stdout: r.stdout,
+            stderr: r.stderr,
+            exitCode: r.exitCode,
+          }))
+        );
+        const fetch = await timed('fetch', async () => {
+          const res = await slicc.fetch(url);
+          return {
+            ok: res.ok,
+            status: res.status,
+            ctor: res.constructor?.name,
+            body: (await res.text()).slice(0, 200),
+          };
+        });
+        const fetchToFile = await timed('fetchToFile', () =>
+          slicc.fetchToFile(url, '/workspace/e2e-fetch-probe-body.txt')
+        );
+        return { exec, fetch, fetchToFile };
+      },
+      { name: SPRINKLE_NAME, settleMs: SETTLE_MS }
+    );
+
+    expect(results.exec.status, `exec: ${JSON.stringify(results.exec)}`).toBe('OK');
+    expect(results.exec.result).toMatchObject({ stdout: 'ok\n', exitCode: 0 });
+
+    expect(results.fetch.status, `fetch: ${JSON.stringify(results.fetch)}`).toBe('OK');
+    expect(results.fetch.result).toMatchObject({
+      ok: true,
+      status: 200,
+      ctor: 'Response',
+    });
+    expect(String((results.fetch.result as { body: string }).body)).not.toBe('');
+
+    expect(results.fetchToFile.status, `fetchToFile: ${JSON.stringify(results.fetchToFile)}`).toBe(
+      'OK'
+    );
+    expect(results.fetchToFile.result).toEqual(expect.any(Number));
+    expect(results.fetchToFile.result as number).toBeGreaterThan(0);
+  });
+});

--- a/packages/webapp/tests/ui/sprinkle-bridge.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-bridge.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import type { VirtualFS } from '../../src/fs/index.js';
 import type { LickEvent } from '../../src/scoops/lick-manager.js';
 import {
+  buildFetchResponse,
   buildJshNodeCommand,
   type CaptureScreenResult,
   JSH_RESULT_PREFIX,
@@ -9,6 +10,7 @@ import {
   runJshOp,
   SprinkleBridge,
   type SprinkleExecResult,
+  type SprinkleFetchResult,
 } from '../../src/ui/sprinkle-bridge.js';
 
 /** Build a worker-shell stdout payload carrying a successful jsh result. */
@@ -499,6 +501,30 @@ describe('SprinkleBridge', () => {
       expect(await res.text()).toBe('{"hi":1}');
     });
 
+    it('_jsh(fetch) returns a structured-cloneable wire shape, not a Response', async () => {
+      const wire: SprinkleFetchResult = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        url: 'https://api.example.com/x',
+        headers: { 'content-type': 'text/plain' },
+        bodyBase64: btoa('hello'),
+      };
+      const execHandler = vi.fn().mockResolvedValue(jshOk(wire));
+      const api = bridgeWith(execHandler).createAPI('s');
+      const raw = await api._jsh('fetch', ['https://api.example.com/x', null]);
+      expect(raw).toEqual(wire);
+      expect(raw).not.toBeInstanceOf(Response);
+      expect(() => structuredClone(raw)).not.toThrow();
+      expect(() => structuredClone(new Response('hello'))).toThrow(
+        /could not be cloned|DataCloneError|unsupported type/
+      );
+      const rebuilt = buildFetchResponse(raw as SprinkleFetchResult);
+      expect(rebuilt).toBeInstanceOf(Response);
+      expect(rebuilt.status).toBe(200);
+      expect(await rebuilt.text()).toBe('hello');
+    });
+
     it('fetch() parses JSON via the native Response.json()', async () => {
       const execHandler = vi.fn().mockResolvedValue(
         jshOk({
@@ -598,6 +624,9 @@ describe('SprinkleBridge', () => {
       const bytes = await api.fetchToFile('https://h/file.bin', '/workspace/file.bin');
       expect(bytes).toBe(1234);
       expect(execHandler.mock.calls[0][0]).toContain('fetchToFile');
+      // Realm has no bare `fs` global — VFS is `require("fs")`.
+      expect(execHandler.mock.calls[0][0]).toContain('require("fs").fetchToFile');
+      expect(execHandler.mock.calls[0][0]).not.toContain('await fs.fetchToFile');
     });
 
     it('readFileBinary() reads raw bytes from the VFS (no realm round-trip)', async () => {
@@ -636,7 +665,7 @@ describe('jsh node-command helpers', () => {
     const cmd = buildJshNodeCommand('spawn', [['echo', "it's"]]);
     expect(cmd.startsWith("node -e '")).toBe(true);
     expect(cmd.endsWith("'")).toBe(true);
-    expect(cmd).toContain('exec.spawn');
+    expect(cmd).toContain('require("sliccy:exec").spawn');
     // The realm awaits only the top-level AsyncFunction body, so the program
     // must use top-level await rather than a detached `(async()=>{…})()`
     // IIFE (the IIFE promise was never awaited → no sentinel on stdout).
@@ -644,7 +673,8 @@ describe('jsh node-command helpers', () => {
     expect(cmd).not.toContain('(async ()=>');
     expect(cmd).not.toContain('})()');
     expect(cmd).toContain('var REQ=');
-    expect(cmd).toContain('await exec.spawn');
+    expect(cmd).toContain('await require("sliccy:exec").spawn');
+    expect(cmd).not.toContain('await exec.spawn');
   });
 
   it('parseJshResult returns the value behind the sentinel', () => {

--- a/packages/webapp/tests/ui/sprinkle-bridge.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-bridge.test.ts
@@ -624,8 +624,11 @@ describe('SprinkleBridge', () => {
       const bytes = await api.fetchToFile('https://h/file.bin', '/workspace/file.bin');
       expect(bytes).toBe(1234);
       expect(execHandler.mock.calls[0][0]).toContain('fetchToFile');
-      // Realm has no bare `fs` global — VFS is `require("fs")`.
-      expect(execHandler.mock.calls[0][0]).toContain('require("fs").fetchToFile');
+      // Realm has no bare `fs` global — VFS is `require("node:fs")`.
+      // Use the `node:` specifier so the page bundle does not contain the
+      // CI-forbidden `require("fs")` literal.
+      expect(execHandler.mock.calls[0][0]).toContain('require("node:fs").fetchToFile');
+      expect(execHandler.mock.calls[0][0]).not.toContain('require("fs").fetchToFile');
       expect(execHandler.mock.calls[0][0]).not.toContain('await fs.fetchToFile');
     });
 

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -320,6 +320,9 @@ describe('full document rendering', () => {
     expect(srcdoc).toContain('XMLSerializer threw');
     expect(srcdoc).toContain('http://www.w3.org/1999/xhtml');
     expect(srcdoc).toContain('var screenshotTargetLabel = ');
+    // iframe rebuilds Response from the cloneable SprinkleFetchResult wire.
+    expect(srcdoc).toContain('var buildFetchResponse = ');
+    expect(srcdoc).toContain('.then(function(v) { return buildFetchResponse(v); })');
   });
 
   it('handles bridge calls posted while the iframe is being appended', async () => {
@@ -719,5 +722,86 @@ describe('full document rendering', () => {
       },
       '*'
     );
+  });
+
+  it('posts a structured-cloneable sprinkle-jsh fetch payload', async () => {
+    const bridge = makeBridge('full-doc');
+    const wire = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      url: 'https://example.com/',
+      headers: { 'content-type': 'text/plain' },
+      bodyBase64: btoa('hello'),
+    };
+    (bridge._jsh as ReturnType<typeof vi.fn>).mockResolvedValue(wire);
+    const renderer = new SprinkleRenderer(container, bridge);
+    await renderer.render('<!DOCTYPE html><html><head></head><body>Hi</body></html>', 'full-doc');
+
+    const iframe = container.querySelector('iframe')!;
+    const postMessageSpy = vi.fn((data: unknown) => {
+      structuredClone(data);
+    });
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: { postMessage: postMessageSpy },
+      writable: true,
+    });
+
+    const event = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'sprinkle-jsh',
+        id: 'fetch-1',
+        op: 'fetch',
+        args: ['https://example.com/', null],
+      },
+      source: iframe.contentWindow as any,
+    });
+    dom.window.dispatchEvent(event);
+    await vi.waitFor(() => expect(postMessageSpy).toHaveBeenCalled());
+
+    expect(bridge._jsh).toHaveBeenCalledWith('fetch', ['https://example.com/', null]);
+    const payload = postMessageSpy.mock.calls[0][0] as {
+      type: string;
+      id: string;
+      result: unknown;
+    };
+    expect(payload).toEqual({
+      type: 'sprinkle-jsh-response',
+      id: 'fetch-1',
+      result: wire,
+    });
+    expect(() => structuredClone(payload)).not.toThrow();
+  });
+
+  it('posts { error } instead of hanging when the jsh result is not cloneable', async () => {
+    const bridge = makeBridge('full-doc');
+    (bridge._jsh as ReturnType<typeof vi.fn>).mockResolvedValue(new Response('nope'));
+    const renderer = new SprinkleRenderer(container, bridge);
+    await renderer.render('<!DOCTYPE html><html><head></head><body>Hi</body></html>', 'full-doc');
+
+    const iframe = container.querySelector('iframe')!;
+    const postMessageSpy = vi.fn((data: unknown) => {
+      structuredClone(data);
+    });
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: { postMessage: postMessageSpy },
+      writable: true,
+    });
+
+    const event = new dom.window.MessageEvent('message', {
+      data: { type: 'sprinkle-jsh', id: 'fetch-bad', op: 'fetch', args: ['https://example.com/'] },
+      source: iframe.contentWindow as any,
+    });
+    dom.window.dispatchEvent(event);
+    await vi.waitFor(() => expect(postMessageSpy).toHaveBeenCalled());
+
+    const payload = postMessageSpy.mock.calls[postMessageSpy.mock.calls.length - 1][0] as {
+      type: string;
+      id: string;
+      error?: string;
+    };
+    expect(payload.type).toBe('sprinkle-jsh-response');
+    expect(payload.id).toBe('fetch-bad');
+    expect(payload.error).toMatch(/could not be cloned|DataCloneError|unsupported type/);
   });
 });


### PR DESCRIPTION
Closes #2946

## Summary

`slicc.fetch()` from a full-document sprinkle iframe used to hang until the caller's timeout. It now settles to a native `Response` (or rejects with a message). Same path: `slicc.fetchToFile` settles too.

## Why

**Repro (before), isolated CDP harness `PORT=5715` / wrangler `8795` (production `:5710=39194` / `:9222=48163` untouched):**

```
slicc.stat('/shared')                         1 ms   OK
slicc.exec('echo ok')                        20 ms   OK
slicc.exec('curl … https://example.com')    220 ms   OK, HTTP 200
slicc.fetch('https://example.com')         8001 ms   HANG
slicc.fetch('https://example.com') run2    8002 ms   HANG
```

Parent console, twice:

```
DataCloneError: Failed to execute 'postMessage' on 'Window': Response object could not be cloned.
```

`jshDispatch('fetch')` rebuilt a native `Response` and `respondToIframe` posted `{ result }` across the iframe boundary. `Response` is not structured-cloneable, so `postMessage` threw on the parent and the iframe `_callbacks[id]` never fired. `slicc.exec` returns a plain `{stdout,stderr,exitCode}` object, which is why exec+curl worked.

## Approach / Implementation notes

- `jshDispatch` keeps the cloneable `SprinkleFetchResult` wire shape (ok/status/headers/bodyBase64).
- Fragment `createAPI.fetch` rebuilds `Response` in-page (no postMessage).
- Full-document iframe injects the same `buildFetchResponse` via `Function#toString()` and rebuilds after `_jshCall('fetch')`.
- `postToIframe` catches a success-path clone throw and posts `{ error }` so the promise rejects instead of hanging.
- The realm `node -e` program now `require()`s `fs` / `sliccy:http` / `sliccy:browser` / `sliccy:exec` — there is no bare `fs` global, so `fetchToFile` was rejecting with `fs is not defined` even after the clone hang was gone.

## Cross-cutting impact

- **Floats**: CLI iframe and hosted-leader / cherry follower use the same `sprinkle-renderer` srcdoc path. Fragment mode still returns `Response` in-page.
- **Dips**: already posted a cloneable `{...wire, body}` object; left alone.
- **Public API**: unchanged — `slicc.fetch` still resolves to `Response`.
- **Bundle**: page first-load +0.1 kB vs merge-base (allowance 5 kB).

## Test plan

- [x] `npm run verify` — 8/8 (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 20444 passing, 46 skipped
- [x] `npm run test:coverage:webapp` — floors held (statements 83.41%, lines 85.38%)
- [x] `npm run build -w @slicc/webapp`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK
- [x] Unit: `packages/webapp/tests/ui/sprinkle-bridge.test.ts` — `_jsh('fetch')` is structured-cloneable; iframe rebuilds `Response`
- [x] Unit: `packages/webapp/tests/ui/sprinkle-renderer.test.ts` — cloneable `sprinkle-jsh` payload; `DataCloneError` posts `{ error }` instead of hanging
- [x] E2E: `packages/webapp/tests/e2e/sprinkle-fetch-iframe.test.ts` — real srcdoc iframe `slicc.fetch` / `exec` / `fetchToFile` settle (passed 3.2s on isolated ports 5716/8797/9224)

### Harness after (same sprinkle iframe, after reload of the new build)

```
iframe slicc.stat          0 ms   OK
iframe slicc.exec         25 ms   OK
iframe slicc.fetch       256 ms   OK  Response 200  "Example Domain…"
iframe slicc.fetchToFile  71 ms   OK  559 bytes
fragment api.fetch        74 ms   OK  Response 200
parentErrors []
```

Production listeners unchanged throughout: `:5710=39194` `:9222=48163`.

## Documentation

- [x] No documentation changes needed — public `slicc.fetch` → `Response` contract is unchanged

## Risk & rollback

- Blast radius: sprinkle/dip fetch from full-document iframes. Fragment mode already rebuilt in-page.
- Rollback: revert this PR.
- CI cannot catch a real iframe `postMessage` clone throw; that is what the CDP harness and the Playwright spec cover.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Does not steal #2942, #2930/#2943, or #2417