### PR TITLE
fix(webapp): surface Claude 5 on Bedrock and allow gpt-5.6

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1867,7 +1867,7 @@ bump that learns the model makes the shims no-ops.
 Both shims share a version-threshold parser (`src/providers/claude-model-version.ts`)
 so future releases are picked up automatically.
 
-### 1. `temperature` is deprecated (Opus ≥ 4.7)
+### 1. `temperature` is deprecated (Opus ≥ 4.7, Sonnet ≥ 5.0, all Fable)
 
 Bedrock returns `400 "temperature is deprecated for this model."`. This
 bites the **thinking-disabled** helper calls: `providers/quick-llm.ts` sends
@@ -1878,9 +1878,13 @@ background helpers 502.
 
 Fix: `src/providers/temperature-support.ts` exposes
 `modelSupportsTemperature` / `withSupportedTemperature`, both delegating to
-`claudeRejectsTemperature` (Opus ≥ 4.7) in `claude-model-version.ts`.
+`claudeRejectsTemperature` in `claude-model-version.ts`. The deprecation
+tracks **generations, not families** — Opus picked it up at 4.7, Sonnet at
+5.0, and Fable shipped with it. Haiku 4.5 still accepts `temperature`.
+Assume the next new family also rejects it and verify against the real
+endpoint before adding it.
 
-### 2. Adaptive thinking required (Opus/Sonnet ≥ 4.6)
+### 2. Adaptive thinking required (everything except Haiku, ≥ 4.6)
 
 With thinking **enabled**, Bedrock returns `400 "thinking.type.enabled is
 not supported for this model. Use thinking.type.adaptive and
@@ -1888,13 +1892,109 @@ output_config.effort..."`. pi-ai's `supportsAdaptiveThinking()` may not
 recognize new models and falls back to the legacy shape.
 
 Fix: `src/providers/adaptive-thinking.ts` — an `onPayload` hook rewrites
-`enabled → adaptive` + `output_config.effort` for any Claude Opus/Sonnet
-≥ 4.6. The rewrite only fires when the enabled shape is present, so it's
-a no-op when thinking is off or pi-ai already emits the adaptive shape.
+`enabled → adaptive` + `output_config.effort` for any Claude Opus, Sonnet,
+or Fable ≥ 4.6. The rewrite only fires when the enabled shape is present, so
+it's a no-op when thinking is off or pi-ai already emits the adaptive shape.
+Haiku is the lone holdout — `claude-haiku-4-5` answers `400 "adaptive
+thinking is not supported on this model"` and stays on the legacy shape.
+
+### 3. Version substrings are not capability tests
+
+`bedrock-camp.ts` gated prompt caching on `id.includes('-4-')` and the model
+picker on `/\.anthropic\.claude-(opus|sonnet|haiku)-4/`. Both silently
+mis-answered for Claude 5, whose ids (`us.anthropic.claude-opus-5`,
+`…-sonnet-5`, `…-fable-5`) contain no `-4-`: Opus 5 never appeared in the
+picker at all, and the models that did get through lost every `cachePoint`.
+Neither failure raises an error — the filter just returns `false`.
+
+Route new gates through the `claude-model-version.ts` predicates
+(`claudeSupportsPromptCaching`, `claudeSupportsAdaptiveThinking`,
+`claudeSupportsNativeXhighEffort`, `claudeRejectsTemperature`), which parse
+family + major + minor. Adding a _family_ (as `fable` was) still needs an
+edit in three places: `ClaudeFamily`, `CLAUDE_VERSION_RE`, and the picker's
+`BEDROCK_CAMP_CLAUDE_RE` — which is duplicated in `bedrock-camp.ts` and
+`bedrock-camp-compat.ts` (a parity test pins them together). New _versions_
+within a known family need no edit.
+
+### 4. Bedrock inference-profile prefixes are three tiers, not one
+
+`GET /inference-profiles` per region (the bearer token works cross-region on
+the control plane even when `InvokeModel` doesn't) returns:
+
+| region                         | Anthropic profile prefixes |
+| ------------------------------ | -------------------------- |
+| `us-east-1`, `us-west-2`       | `us.`, `global.`           |
+| `eu-central-1`, `eu-west-1`    | `eu.`, `global.`           |
+| `ap-northeast-1` (Tokyo)       | `apac.`, `jp.`, `global.`  |
+| `ap-southeast-2` (Sydney)      | `apac.`, `au.`, `global.`  |
+| `ap-southeast-1`, `ap-south-1` | `apac.`, `global.`         |
+
+The country tier (`jp.`, `au.`) is **narrower than a region-family prefix
+match** — `jp.` must not be resolved with `startsWith('ap-northeast-')`
+because that would wrongly claim Seoul (`ap-northeast-2`). `profileMatchesRegion`
+enumerates them (`JP_REGIONS`, `AU_REGIONS`); adding a country tier means
+adding its regions explicitly.
+
+Wrong-region ids fail closed but confusingly: `jp.anthropic.claude-sonnet-4-6`
+returns `400 "The provided model identifier is invalid."` on the `us-west-2`
+runtime, while on `ap-northeast-1` the same id returns `403` (an authorization
+error) — so a `403` means the id resolved and a `400` means it didn't.
+
+Separately, pi-ai's `amazon-bedrock` catalogue carries `us.`/`eu.`/`global.`/
+`au.`/`jp.` ids but **no `apac.` ids at all**, so an `ap-southeast-1` or
+`ap-south-1` endpoint sees only the `global.` tier regardless of this filter.
+That is a catalogue gap, not a filter bug.
+
+### 5. Non-Claude Bedrock models: caching is implicit, and `cachePoint` 403s
+
+The picker is default-deny for non-Claude (rule 2 in
+`bedrock-camp-compat.ts`). The allowlist holds exactly one family —
+`openai.gpt-5.6-{sol,terra,luna}` — admitted only after live verification,
+because these models differ from Claude in three ways that each fail silently
+or mid-loop:
+
+|                | Claude                                            | gpt-5.6                                                    |
+| -------------- | ------------------------------------------------- | ---------------------------------------------------------- |
+| prompt caching | explicit `cachePoint` block                       | **implicit**; a `cachePoint` block returns `403`           |
+| `temperature`  | rejected from Opus 4.7 / Sonnet 5.0               | rejected                                                   |
+| thinking shape | `thinking.type.adaptive` + `output_config.effort` | **none accepted**; 400s `unknown_parameter` on every shape |
+
+So enabling gpt-5.6 required removing nothing and adding nothing to the
+request — `supportsPromptCaching` and `buildAdditionalModelRequestFields`
+already gate on `isAnthropicClaudeModel`, and both stay correct. The one real
+change was the `temperature` reject-list, which was Claude-only.
+
+**Prompt caching is the bar for this allowlist**, so measure it before adding
+a model (`bedrock-runtime.us-west-2`):
+
+- **gpt-5.6** — reliable. `cacheWriteInputTokens` on the first call, then
+  `cacheReadInputTokens` on every repeat, including with a system prompt and
+  `toolConfig` attached.
+- **grok-4.6** — NOT allowlisted. Fully functional (200s, tool calls, system
+  prompts) but cached on only 2 of 15 attempts at ~18-20k tokens, so it would
+  bill full input on nearly every turn.
+- **glm-5 / minimax-m2.5** — no caching at 8k, 20k or 40k; the usage response
+  omits the cache fields entirely, matching their `cacheRead: 0`,
+  `cacheWrite: 0` in pi-ai's catalogue.
+
+Three traps worth naming. **A short prefix is not proof of no caching** —
+grok's first cache hits only appeared once the prompt passed ~18k. **A few
+hits are not proof of caching either** — grok looked like it cached (2 of 4)
+until a larger sample put it at 2 of 15; measure across at least ten runs in
+the shape the agent actually sends. And pi-ai's catalogue prices `cacheRead`
+whether caching is explicit, implicit, or effectively absent, so **cost
+metadata is not evidence** — only `usage` on a live repeat is.
+
+One structural gotcha if grok is ever revisited: Bedrock serves it only
+through an inference profile (bare `xai.grok-4.6` 400s with "on-demand
+throughput isn't supported"), while pi-ai's catalogue ships only the bare id.
+`global.xai.grok-4.6` and `us.xai.grok-4.6` both work when invoked directly,
+so admitting it needs an upstream catalogue fix or a synthesized entry — an
+allowlist alone cannot surface it.
 
 **Related tests:** `claude-model-version.test.ts`,
 `temperature-support.test.ts`, `adaptive-thinking.test.ts`,
-`bedrock-camp.test.ts`.
+`bedrock-camp.test.ts`, `bedrock-camp-compat.test.ts`.
 
 ## Detached popout (historical, removed)
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1964,6 +1964,20 @@ request — `supportsPromptCaching` and `buildAdditionalModelRequestFields`
 already gate on `isAnthropicClaudeModel`, and both stay correct. The one real
 change was the `temperature` reject-list, which was Claude-only.
 
+Two consequences of that gating, easy to miss:
+
+- **Effort control is Claude-only.** Because `buildAdditionalModelRequestFields`
+  emits nothing off the Claude path, low/medium/high/xhigh all produce a
+  byte-identical request for gpt-5.6. The composer gates its thinking-level
+  selector on `model.reasoning`, so `account-store.ts` clears that flag for
+  non-Claude picker entries via `isBedrockCampClaudeModel`. This does not
+  suppress `reasoningContent` — gpt-5.6 still reasons, it just cannot be told
+  how hard.
+- **The allowlist is anchored per variant** (`sol|terra|luna`), not a
+  `gpt-5.6-` prefix. A prefix would auto-admit any future variant the
+  catalogue gains without anyone measuring its caching, which is the
+  default-deny hole the list exists to prevent.
+
 **Prompt caching is the bar for this allowlist**, so measure it before adding
 a model (`bedrock-runtime.us-west-2`):
 

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -386,10 +386,11 @@ function applyModelMetadata(
 export function getProviderModels(providerId: string): Model<Api>[] {
   try {
     // Bedrock CAMP uses Amazon Bedrock models with a custom API. Filter to
-    // inference-profile-prefixed Claude 4.x whose region matches the
-    // configured endpoint (eu.* against us-* 400s "invalid model
-    // identifier"). pi-ai's amazon-bedrock registry now ships every Opus 4.7
-    // profile variant; no manual extras list is needed.
+    // inference-profile-prefixed Claude 4.x and newer (plus the narrow
+    // non-Claude allowlist) whose region matches the configured endpoint
+    // (eu.* against us-* 400s "invalid model identifier"). pi-ai's
+    // amazon-bedrock registry ships every profile variant we surface; no
+    // manual extras list is needed.
     if (providerId === 'bedrock-camp') {
       const region = bedrockCampRegionFromBaseUrl(getBaseUrlForProvider('bedrock-camp'));
       return getModelsDynamic('amazon-bedrock')

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -26,6 +26,7 @@ import { apiHeaders, resolveApiUrl } from '../shell/proxied-fetch.js';
 // this eagerly-loaded module's graph in both realms (#first-load ratchet).
 import {
   bedrockCampRegionFromBaseUrl,
+  isBedrockCampClaudeModel,
   isBedrockCampCompatible,
 } from './built-in/bedrock-camp-compat.js';
 import { findFamilyCost } from './family-cost.js';
@@ -399,6 +400,10 @@ export function getProviderModels(providerId: string): Model<Api>[] {
           ...m,
           api: 'bedrock-camp-converse' as Api,
           provider: 'bedrock-camp',
+          // Effort control only reaches the wire for Claude, so don't let a
+          // non-Claude model advertise a thinking-level selector that would
+          // produce an identical request at every level.
+          reasoning: m.reasoning === true && isBedrockCampClaudeModel(m),
         }));
     }
     // Providers that use Anthropic's model registry with custom API

--- a/packages/webapp/src/providers/built-in/bedrock-camp-compat.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp-compat.ts
@@ -61,7 +61,12 @@ const BEDROCK_CAMP_CLAUDE_RE = /\.anthropic\.claude-(opus|sonnet|haiku|fable)-(?
 // `buildAdditionalModelRequestFields` already handle both. It does not accept
 // an explicit `cachePoint` block either — caching is automatic and sending one
 // 403s.
-const BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE = /\.openai\.gpt-5[.-]6-/;
+//
+// Anchored and spelled out per variant on purpose. A looser `gpt-5[.-]6-`
+// would auto-admit any future `*.openai.gpt-5.6-*` the catalogue gains — the
+// exact default-deny hole this list exists to avoid — and would accept the
+// `gpt-5-6-` spelling, which no Bedrock id uses and which was never verified.
+const BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE = /\.openai\.gpt-5\.6-(?:sol|terra|luna)$/;
 // Matches standard (us-east-1), FIPS (us-east-1-fips) and China
 // (cn-north-1.amazonaws.com.cn) Bedrock runtime hosts.
 const BEDROCK_RUNTIME_HOST_RE =
@@ -89,6 +94,22 @@ function profileMatchesRegion(prefix: string, region: string): boolean {
   if (prefix === 'jp') return JP_REGIONS.has(region);
   if (prefix === 'au') return AU_REGIONS.has(region);
   return false;
+}
+
+/**
+ * True when a picker-visible id is an Anthropic Claude model.
+ *
+ * `buildAdditionalModelRequestFields` emits a thinking shape ONLY for Claude,
+ * so effort control (low/medium/high/xhigh) never reaches the wire for the
+ * allowlisted non-Claude models — every level would produce a byte-identical
+ * request. The UI gates its thinking-level selector on `model.reasoning`
+ * (`no-thinking` in `wc-nav.ts` / `wc-live-thinking-hydration.ts`), so
+ * `account-store.ts` uses this to clear that flag and hide a control that
+ * does nothing. It does NOT suppress rendering of `reasoningContent` — gpt-5.6
+ * still reasons, it just cannot be told how hard.
+ */
+export function isBedrockCampClaudeModel(model: { id: string }): boolean {
+  return BEDROCK_CAMP_CLAUDE_RE.test(model.id);
 }
 
 export function isBedrockCampCompatible(model: { id: string }, region?: string | null): boolean {

--- a/packages/webapp/src/providers/built-in/bedrock-camp-compat.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp-compat.ts
@@ -18,20 +18,50 @@
  * implementations agree — change both together.
  */
 
-// Picker filter: keep only Claude 4.x on an inference-profile prefix that
-// is reachable from the configured endpoint region.
+// Picker filter: keep only Claude 4.x and newer on an inference-profile prefix
+// that is reachable from the configured endpoint region.
 //
-// 1. Inference profile (us./eu./global./apac.) — bare anthropic.* 400s with
+// 1. Inference profile (us./eu./global./apac./au./jp.) — bare anthropic.* 400s with
 //    "on-demand throughput isn't supported".
-// 2. Claude 4.x only — older Claude 3.x are weaker at resisting prompt
-//    injection; non-Claude Bedrock models (Nova, Llama, Writer, …) are
-//    similarly risky, and DeepSeek R1 specifically 400s on toolConfig
-//    ("This model doesn't support tool use") which breaks the agent loop.
+// 2. Claude 4.x and newer, plus a narrow allowlist — older Claude 3.x are
+//    weaker at resisting prompt injection; most non-Claude Bedrock models
+//    (Nova, Llama, Writer, …) are similarly risky, and DeepSeek R1
+//    specifically 400s on toolConfig ("This model doesn't support tool use")
+//    which breaks the agent loop. The version group is open-ended so a new
+//    Claude generation (5, 6, …) lands in the picker with no edit here; new
+//    *families* still have to be added to the alternation (as `fable` was).
+//    Non-Claude stays DEFAULT-DENY: an id earns its place in
+//    BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE only after being verified live.
 // 3. Region must match the endpoint — e.g. `eu.*` IDs 400 with "invalid
-//    model identifier" when sent to a `us-*` runtime, and vice versa.
+//    model identifier" when sent to a `us-*` runtime, and vice versa
+//    (confirmed: `jp.anthropic.claude-sonnet-4-6` 400s on the `us-west-2`
+//    runtime but only 403s on `ap-northeast-1`, i.e. the id resolves there).
 //    `global.*` works anywhere.
-const BEDROCK_CAMP_INFERENCE_PROFILE_RE = /^(us|eu|global|apac)\./;
-const BEDROCK_CAMP_CLAUDE_4_RE = /\.anthropic\.claude-(opus|sonnet|haiku)-4/;
+//
+//    The country prefixes are narrower than the continent ones and do NOT
+//    map to a `startsWith` — `jp` is Japan only, so it must not swallow
+//    `ap-northeast-2` (Seoul), and `au` is Australia only. Enumerated from
+//    `GET /inference-profiles` per region: ap-northeast-1 serves
+//    `apac|jp|global`, ap-southeast-2 serves `apac|au|global`, and
+//    ap-southeast-1 / ap-south-1 serve `apac|global` with no country tier.
+const BEDROCK_CAMP_INFERENCE_PROFILE_RE = /^(us|eu|global|apac|au|jp)\./;
+const BEDROCK_CAMP_CLAUDE_RE = /\.anthropic\.claude-(opus|sonnet|haiku|fable)-(?:[4-9]|\d\d)/;
+// Verified live on `bedrock-runtime.us-west-2` (see `docs/pitfalls.md` §5):
+// openai.gpt-5.6-{sol,terra,luna} do implicit prompt caching — cacheWrite on
+// the first call, cacheRead on every repeat, including with a system prompt
+// and toolConfig attached — and emit tool calls reliably.
+//
+// The bar for this list is prompt caching, which is why xai.grok-4.6 is NOT
+// here: it is functional (200s, tool calls) but cached on only 2 of 15
+// attempts at ~18-20k tokens, so it would bill full input on nearly every
+// turn. Re-measure before adding it.
+//
+// gpt-5.6 rejects `temperature` and every `additionalModelRequestFields`
+// thinking shape; `temperature-support.ts` and
+// `buildAdditionalModelRequestFields` already handle both. It does not accept
+// an explicit `cachePoint` block either — caching is automatic and sending one
+// 403s.
+const BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE = /\.openai\.gpt-5[.-]6-/;
 // Matches standard (us-east-1), FIPS (us-east-1-fips) and China
 // (cn-north-1.amazonaws.com.cn) Bedrock runtime hosts.
 const BEDROCK_RUNTIME_HOST_RE =
@@ -47,17 +77,28 @@ export function bedrockCampRegionFromBaseUrl(baseUrl: string | null | undefined)
   }
 }
 
+/** Japan-only and Australia-only inference profiles, listed exhaustively. */
+const JP_REGIONS = new Set(['ap-northeast-1', 'ap-northeast-3']);
+const AU_REGIONS = new Set(['ap-southeast-2', 'ap-southeast-4']);
+
 function profileMatchesRegion(prefix: string, region: string): boolean {
   if (prefix === 'global') return true;
   if (prefix === 'us') return region.startsWith('us-');
   if (prefix === 'eu') return region.startsWith('eu-');
   if (prefix === 'apac') return region.startsWith('ap-');
+  if (prefix === 'jp') return JP_REGIONS.has(region);
+  if (prefix === 'au') return AU_REGIONS.has(region);
   return false;
 }
 
 export function isBedrockCampCompatible(model: { id: string }, region?: string | null): boolean {
   if (!BEDROCK_CAMP_INFERENCE_PROFILE_RE.test(model.id)) return false;
-  if (!BEDROCK_CAMP_CLAUDE_4_RE.test(model.id)) return false;
+  if (
+    !BEDROCK_CAMP_CLAUDE_RE.test(model.id) &&
+    !BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE.test(model.id)
+  ) {
+    return false;
+  }
   if (!region) return true; // no endpoint configured yet — stay permissive
   const prefix = model.id.split('.', 1)[0];
   return profileMatchesRegion(prefix, region);

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -44,6 +44,7 @@ import {
   claudeSupportsAdaptiveThinking,
   claudeSupportsMaxEffort,
   claudeSupportsNativeXhighEffort,
+  claudeSupportsPromptCaching,
 } from '../claude-model-version.js';
 import { modelSupportsTemperature } from '../temperature-support.js';
 import type { ProviderConfig } from '../types.js';
@@ -58,23 +59,53 @@ export const config: ProviderConfig = {
   requiresBaseUrl: true,
   baseUrlPlaceholder: 'https://bedrock-runtime.us-west-2.amazonaws.com',
   baseUrlDescription: 'Bedrock runtime endpoint from CAMP portal',
-  defaultModelId: 'claude-sonnet-4-6',
+  defaultModelId: 'claude-opus-5',
 };
 
-// Picker filter: keep only Claude 4.x on an inference-profile prefix that
-// is reachable from the configured endpoint region.
+// Picker filter: keep only Claude 4.x and newer on an inference-profile prefix
+// that is reachable from the configured endpoint region.
 //
-// 1. Inference profile (us./eu./global./apac.) — bare anthropic.* 400s with
+// 1. Inference profile (us./eu./global./apac./au./jp.) — bare anthropic.* 400s with
 //    "on-demand throughput isn't supported".
-// 2. Claude 4.x only — older Claude 3.x are weaker at resisting prompt
-//    injection; non-Claude Bedrock models (Nova, Llama, Writer, …) are
-//    similarly risky, and DeepSeek R1 specifically 400s on toolConfig
-//    ("This model doesn't support tool use") which breaks the agent loop.
+// 2. Claude 4.x and newer, plus a narrow allowlist — older Claude 3.x are
+//    weaker at resisting prompt injection; most non-Claude Bedrock models
+//    (Nova, Llama, Writer, …) are similarly risky, and DeepSeek R1
+//    specifically 400s on toolConfig ("This model doesn't support tool use")
+//    which breaks the agent loop. The version group is open-ended so a new
+//    Claude generation (5, 6, …) lands in the picker with no edit here; new
+//    *families* still have to be added to the alternation (as `fable` was).
+//    Non-Claude stays DEFAULT-DENY: an id earns its place in
+//    BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE only after being verified live.
 // 3. Region must match the endpoint — e.g. `eu.*` IDs 400 with "invalid
-//    model identifier" when sent to a `us-*` runtime, and vice versa.
+//    model identifier" when sent to a `us-*` runtime, and vice versa
+//    (confirmed: `jp.anthropic.claude-sonnet-4-6` 400s on the `us-west-2`
+//    runtime but only 403s on `ap-northeast-1`, i.e. the id resolves there).
 //    `global.*` works anywhere.
-const BEDROCK_CAMP_INFERENCE_PROFILE_RE = /^(us|eu|global|apac)\./;
-const BEDROCK_CAMP_CLAUDE_4_RE = /\.anthropic\.claude-(opus|sonnet|haiku)-4/;
+//
+//    The country prefixes are narrower than the continent ones and do NOT
+//    map to a `startsWith` — `jp` is Japan only, so it must not swallow
+//    `ap-northeast-2` (Seoul), and `au` is Australia only. Enumerated from
+//    `GET /inference-profiles` per region: ap-northeast-1 serves
+//    `apac|jp|global`, ap-southeast-2 serves `apac|au|global`, and
+//    ap-southeast-1 / ap-south-1 serve `apac|global` with no country tier.
+const BEDROCK_CAMP_INFERENCE_PROFILE_RE = /^(us|eu|global|apac|au|jp)\./;
+const BEDROCK_CAMP_CLAUDE_RE = /\.anthropic\.claude-(opus|sonnet|haiku|fable)-(?:[4-9]|\d\d)/;
+// Verified live on `bedrock-runtime.us-west-2` (see `docs/pitfalls.md` §5):
+// openai.gpt-5.6-{sol,terra,luna} do implicit prompt caching — cacheWrite on
+// the first call, cacheRead on every repeat, including with a system prompt
+// and toolConfig attached — and emit tool calls reliably.
+//
+// The bar for this list is prompt caching, which is why xai.grok-4.6 is NOT
+// here: it is functional (200s, tool calls) but cached on only 2 of 15
+// attempts at ~18-20k tokens, so it would bill full input on nearly every
+// turn. Re-measure before adding it.
+//
+// gpt-5.6 rejects `temperature` and every `additionalModelRequestFields`
+// thinking shape; `temperature-support.ts` and
+// `buildAdditionalModelRequestFields` already handle both. It does not accept
+// an explicit `cachePoint` block either — caching is automatic and sending one
+// 403s.
+const BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE = /\.openai\.gpt-5[.-]6-/;
 // Matches standard (us-east-1), FIPS (us-east-1-fips) and China
 // (cn-north-1.amazonaws.com.cn) Bedrock runtime hosts.
 const BEDROCK_RUNTIME_HOST_RE =
@@ -90,17 +121,28 @@ export function bedrockCampRegionFromBaseUrl(baseUrl: string | null | undefined)
   }
 }
 
+/** Japan-only and Australia-only inference profiles, listed exhaustively. */
+const JP_REGIONS = new Set(['ap-northeast-1', 'ap-northeast-3']);
+const AU_REGIONS = new Set(['ap-southeast-2', 'ap-southeast-4']);
+
 function profileMatchesRegion(prefix: string, region: string): boolean {
   if (prefix === 'global') return true;
   if (prefix === 'us') return region.startsWith('us-');
   if (prefix === 'eu') return region.startsWith('eu-');
   if (prefix === 'apac') return region.startsWith('ap-');
+  if (prefix === 'jp') return JP_REGIONS.has(region);
+  if (prefix === 'au') return AU_REGIONS.has(region);
   return false;
 }
 
 export function isBedrockCampCompatible(model: { id: string }, region?: string | null): boolean {
   if (!BEDROCK_CAMP_INFERENCE_PROFILE_RE.test(model.id)) return false;
-  if (!BEDROCK_CAMP_CLAUDE_4_RE.test(model.id)) return false;
+  if (
+    !BEDROCK_CAMP_CLAUDE_RE.test(model.id) &&
+    !BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE.test(model.id)
+  ) {
+    return false;
+  }
   if (!region) return true; // no endpoint configured yet — stay permissive
   const prefix = model.id.split('.', 1)[0];
   return profileMatchesRegion(prefix, region);
@@ -683,10 +725,7 @@ function isAnthropicClaudeModel(model: Model<Api>): boolean {
 function supportsPromptCaching(model: Model<Api>): boolean {
   const candidates = getModelMatchCandidates(model.id, model.name);
   if (!candidates.some((s) => s.includes('claude'))) return false;
-  if (candidates.some((s) => s.includes('-4-'))) return true;
-  if (candidates.some((s) => s.includes('claude-3-7-sonnet'))) return true;
-  if (candidates.some((s) => s.includes('claude-3-5-haiku'))) return true;
-  return false;
+  return claudeSupportsPromptCaching(model.id, model.name);
 }
 
 function buildCachePoint(cacheRetention: CacheRetention): BedrockCampCachePoint {

--- a/packages/webapp/src/providers/built-in/bedrock-camp.ts
+++ b/packages/webapp/src/providers/built-in/bedrock-camp.ts
@@ -105,7 +105,12 @@ const BEDROCK_CAMP_CLAUDE_RE = /\.anthropic\.claude-(opus|sonnet|haiku|fable)-(?
 // `buildAdditionalModelRequestFields` already handle both. It does not accept
 // an explicit `cachePoint` block either — caching is automatic and sending one
 // 403s.
-const BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE = /\.openai\.gpt-5[.-]6-/;
+//
+// Anchored and spelled out per variant on purpose. A looser `gpt-5[.-]6-`
+// would auto-admit any future `*.openai.gpt-5.6-*` the catalogue gains — the
+// exact default-deny hole this list exists to avoid — and would accept the
+// `gpt-5-6-` spelling, which no Bedrock id uses and which was never verified.
+const BEDROCK_CAMP_ALLOWED_NON_CLAUDE_RE = /\.openai\.gpt-5\.6-(?:sol|terra|luna)$/;
 // Matches standard (us-east-1), FIPS (us-east-1-fips) and China
 // (cn-north-1.amazonaws.com.cn) Bedrock runtime hosts.
 const BEDROCK_RUNTIME_HOST_RE =

--- a/packages/webapp/src/providers/claude-model-version.ts
+++ b/packages/webapp/src/providers/claude-model-version.ts
@@ -15,7 +15,7 @@
  * the adaptive shape itself.
  */
 
-export type ClaudeFamily = 'opus' | 'sonnet' | 'haiku';
+export type ClaudeFamily = 'opus' | 'sonnet' | 'haiku' | 'fable';
 
 export interface ClaudeVersion {
   family: ClaudeFamily;
@@ -44,7 +44,7 @@ function matchCandidates(modelId: string, modelName?: string): string[] {
  * constraint + negative lookahead prevents false positives on legacy IDs like
  * `claude-3-5-sonnet-20241022` where the date suffix would otherwise match.
  */
-const CLAUDE_VERSION_RE = /(opus|sonnet|haiku)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/;
+const CLAUDE_VERSION_RE = /(opus|sonnet|haiku|fable)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/;
 
 /**
  * Parse a Claude family/major/minor out of an id or display name. Returns
@@ -77,26 +77,33 @@ function compareVersion(
 }
 
 /**
- * Adaptive thinking — Claude Opus and Sonnet at version ≥ 4.6 ship with the
- * `thinking: { type: 'adaptive' }` + `output_config.effort` shape (vs. the
- * legacy `thinking: { type: 'enabled', budget_tokens }`).
+ * Adaptive thinking — Claude Opus, Sonnet, and Fable at version ≥ 4.6 ship
+ * with the `thinking: { type: 'adaptive' }` + `output_config.effort` shape
+ * (vs. the legacy `thinking: { type: 'enabled', budget_tokens }`).
+ *
+ * Haiku is the lone holdout: `us.anthropic.claude-haiku-4-5` 400s with
+ * "adaptive thinking is not supported on this model", so it stays on the
+ * legacy shape. Excluding by family (rather than listing the adaptive ones)
+ * keeps a future Fable/Opus generation correct without an edit.
  */
 export function claudeSupportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
   const v = parseClaudeVersion(modelId, modelName);
   if (!v) return false;
-  if (v.family !== 'opus' && v.family !== 'sonnet') return false;
+  if (v.family === 'haiku') return false;
   return compareVersion(v, { major: 4, minor: 6 }) >= 0;
 }
 
 /**
- * Native `effort: "xhigh"` tier — Opus introduced this at 4.7, Sonnet at 5.0.
- * Opus 4.6 and Sonnet 4.6 clamp xhigh to `"max"` / `"high"` respectively.
+ * Native `effort: "xhigh"` tier — Opus introduced this at 4.7, Sonnet at 5.0,
+ * and Fable has it from its first release (5.0). Opus 4.6 and Sonnet 4.6 clamp
+ * xhigh to `"max"` / `"high"` respectively.
  */
 export function claudeSupportsNativeXhighEffort(modelId: string, modelName?: string): boolean {
   const v = parseClaudeVersion(modelId, modelName);
   if (!v) return false;
   if (v.family === 'opus') return compareVersion(v, { major: 4, minor: 7 }) >= 0;
   if (v.family === 'sonnet') return compareVersion(v, { major: 5, minor: 0 }) >= 0;
+  if (v.family === 'fable') return compareVersion(v, { major: 5, minor: 0 }) >= 0;
   return false;
 }
 
@@ -113,12 +120,39 @@ export function claudeSupportsMaxEffort(modelId: string, modelName?: string): bo
 }
 
 /**
- * Bedrock rejects `temperature` for Opus ≥ 4.7 with
- * `400 "temperature is deprecated for this model."`. Sonnet and Haiku still
- * accept it on every released version.
+ * Prompt caching (`cachePoint` blocks) — every Claude ≥ 4.x supports it, plus
+ * the two legacy 3.x models that were backported (3.7 Sonnet, 3.5 Haiku).
+ *
+ * This replaced a `candidates.includes('-4-')` substring test in
+ * `bedrock-camp.ts`, which silently returned false for `claude-opus-5` /
+ * `claude-sonnet-5` / `claude-fable-5` — those have no `-4-` in their id — and
+ * so dropped cache points on every Claude 5 request. Verified live on
+ * `bedrock-runtime.us-west-2`: all three report a non-zero
+ * `cacheWriteInputTokens`.
+ */
+export function claudeSupportsPromptCaching(modelId: string, modelName?: string): boolean {
+  const v = parseClaudeVersion(modelId, modelName);
+  if (v) return v.major >= 4;
+  return matchCandidates(modelId, modelName).some(
+    (s) => s.includes('claude-3-7-sonnet') || s.includes('claude-3-5-haiku')
+  );
+}
+
+/**
+ * Bedrock rejects `temperature` with
+ * `400 "\`temperature\` is deprecated for this model."` for Opus ≥ 4.7,
+ * Sonnet ≥ 5.0, and every Fable. Haiku still accepts it on every released
+ * version (verified against `bedrock-runtime.us-west-2` for opus-5,
+ * sonnet-5, fable-5, and haiku-4-5).
+ *
+ * The deprecation tracks generations, not families: assume a future family
+ * ships without `temperature` and add it here when it lands.
  */
 export function claudeRejectsTemperature(modelId: string, modelName?: string): boolean {
   const v = parseClaudeVersion(modelId, modelName);
-  if (v?.family !== 'opus') return false;
-  return compareVersion(v, { major: 4, minor: 7 }) >= 0;
+  if (!v) return false;
+  if (v.family === 'opus') return compareVersion(v, { major: 4, minor: 7 }) >= 0;
+  if (v.family === 'sonnet') return compareVersion(v, { major: 5, minor: 0 }) >= 0;
+  if (v.family === 'fable') return true;
+  return false;
 }

--- a/packages/webapp/src/providers/claude-model-version.ts
+++ b/packages/webapp/src/providers/claude-model-version.ts
@@ -15,7 +15,20 @@
  * the adaptive shape itself.
  */
 
-export type ClaudeFamily = 'opus' | 'sonnet' | 'haiku' | 'fable';
+/**
+ * Every Claude family this codebase knows about, in one place.
+ *
+ * `CLAUDE_VERSION_RE` is built from this list, and
+ * `tests/providers/bedrock-camp-compat.test.ts` asserts the bedrock picker's
+ * own family alternation accepts all of them. Without that pin, adding a
+ * family here (so the capability shims resolve) while forgetting the picker
+ * regex would make the model parse correctly for temperature/caching yet
+ * never appear in the dropdown — the exact silent-invisibility bug that hid
+ * Claude 5.
+ */
+export const CLAUDE_FAMILIES = ['opus', 'sonnet', 'haiku', 'fable'] as const;
+
+export type ClaudeFamily = (typeof CLAUDE_FAMILIES)[number];
 
 export interface ClaudeVersion {
   family: ClaudeFamily;
@@ -44,7 +57,9 @@ function matchCandidates(modelId: string, modelName?: string): string[] {
  * constraint + negative lookahead prevents false positives on legacy IDs like
  * `claude-3-5-sonnet-20241022` where the date suffix would otherwise match.
  */
-const CLAUDE_VERSION_RE = /(opus|sonnet|haiku|fable)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/;
+const CLAUDE_VERSION_RE = new RegExp(
+  `(${CLAUDE_FAMILIES.join('|')})-(\\d{1,2})(?:-(\\d{1,2}))?(?!\\d)`
+);
 
 /**
  * Parse a Claude family/major/minor out of an id or display name. Returns

--- a/packages/webapp/src/providers/temperature-support.ts
+++ b/packages/webapp/src/providers/temperature-support.ts
@@ -1,7 +1,8 @@
 /**
  * Model capability: does this model accept the `temperature` sampling param?
  *
- * Bedrock-backed Claude Opus ≥ 4.7 rejects `temperature` — Bedrock returns
+ * Bedrock-backed Claude Opus ≥ 4.7, Sonnet ≥ 5.0, and Fable reject
+ * `temperature` — Bedrock returns
  * `400 "temperature is deprecated for this model."`. Through the Adobe proxy
  * that surfaces as a `502 upstream_error`, which the node-server fetch-proxy
  * relays to the agent. Both the Adobe provider (`providers/adobe.ts`) and the
@@ -13,15 +14,50 @@
  * thinking-disabled helper calls (`providers/quick-llm.ts`, e.g. the scope-
  * label and session-title helpers) send `temperature: 0.3` and would otherwise 502.
  *
- * Predicate lives in `claude-model-version.ts` so future Opus releases
- * (4.9 / 5.x) are handled automatically by the version threshold.
+ * Predicate lives in `claude-model-version.ts` so future releases within a
+ * known family are handled automatically by the version threshold.
  */
 
 import { claudeRejectsTemperature } from './claude-model-version.js';
 
+/**
+ * Non-Claude Bedrock models that reject `temperature` the same way.
+ *
+ * The newest third-party models on Bedrock have followed Anthropic in
+ * dropping the param: `openai.gpt-5.6-*` answers `400 "This model doesn't
+ * support the temperature field. Remove temperature and try again."`
+ * (verified on `bedrock-runtime.us-west-2`). Only models the bedrock-camp
+ * picker can actually reach need to be listed here — the allowlist in
+ * `built-in/bedrock-camp-compat.ts` is the other half of this pair, so extend
+ * both together.
+ *
+ * `xai.grok-4.6` also rejects `temperature`, but it is not allowlisted (it
+ * does not cache), so it is deliberately absent — add it here in the same
+ * change that admits it to the picker.
+ *
+ * Matched WITHOUT the vendor prefix so the display name of an opaque
+ * application-inference-profile ARN ("GPT-5.6 Sol (Global)") hits the same
+ * rule as the id ("global.openai.gpt-5.6-sol"). Both `.` and `-` separators
+ * are accepted because the name normalizer collapses spaces to dashes.
+ * The version is pinned: `gpt-5.5` still accepts `temperature`.
+ */
+const NON_CLAUDE_REJECTS_TEMPERATURE_RE = /gpt-5[.-]6/;
+
+function nonClaudeRejectsTemperature(modelId: string, modelName?: string): boolean {
+  const values = modelName ? [modelId, modelName] : [modelId];
+  return values.some((value) => {
+    const lower = value.toLowerCase();
+    return (
+      NON_CLAUDE_REJECTS_TEMPERATURE_RE.test(lower) ||
+      NON_CLAUDE_REJECTS_TEMPERATURE_RE.test(lower.replace(/[\s_]+/g, '-'))
+    );
+  });
+}
+
 /** True unless the model is known to reject the `temperature` param. */
 export function modelSupportsTemperature(modelId: string, modelName?: string): boolean {
-  return !claudeRejectsTemperature(modelId, modelName);
+  if (claudeRejectsTemperature(modelId, modelName)) return false;
+  return !nonClaudeRejectsTemperature(modelId, modelName);
 }
 
 /**

--- a/packages/webapp/tests/providers/bedrock-camp-compat.test.ts
+++ b/packages/webapp/tests/providers/bedrock-camp-compat.test.ts
@@ -43,7 +43,7 @@ describe('bedrockCampRegionFromBaseUrl', () => {
 });
 
 describe('isBedrockCampCompatible', () => {
-  it('accepts Claude 4.x on a region-matching inference profile', () => {
+  it('accepts Claude 4.x and newer on a region-matching inference profile', () => {
     expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-opus-4-8' }, 'us-west-2')).toBe(true);
     expect(isBedrockCampCompatible({ id: 'eu.anthropic.claude-sonnet-4-6' }, 'eu-central-1')).toBe(
       true
@@ -56,7 +56,23 @@ describe('isBedrockCampCompatible', () => {
     );
   });
 
-  it('rejects region mismatches, bare model ids, and non-Claude-4 models', () => {
+  // Regression: the filter used to hardcode `-4`, so every Claude 5 model was
+  // silently dropped from the picker even though Bedrock serves it.
+  it('accepts Claude 5 and the fable family', () => {
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-opus-5' }, 'us-west-2')).toBe(true);
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-sonnet-5' }, 'us-west-2')).toBe(true);
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-fable-5-1' }, 'us-west-2')).toBe(
+      true
+    );
+    expect(isBedrockCampCompatible({ id: 'global.anthropic.claude-fable-5' }, 'eu-central-1')).toBe(
+      true
+    );
+    // Open-ended version group: a future generation needs no edit here.
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-opus-9' }, 'us-west-2')).toBe(true);
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-opus-10' }, 'us-west-2')).toBe(true);
+  });
+
+  it('rejects region mismatches, bare model ids, and pre-4 or non-Claude models', () => {
     expect(isBedrockCampCompatible({ id: 'eu.anthropic.claude-opus-4-8' }, 'us-west-2')).toBe(
       false
     );
@@ -64,7 +80,88 @@ describe('isBedrockCampCompatible', () => {
     expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-3-5-sonnet' }, 'us-west-2')).toBe(
       false
     );
+    expect(isBedrockCampCompatible({ id: 'us.anthropic.claude-3-haiku' }, 'us-west-2')).toBe(false);
     expect(isBedrockCampCompatible({ id: 'us.amazon.nova-pro-v1' }, 'us-west-2')).toBe(false);
+  });
+
+  // Country-tier profiles. `au.anthropic.claude-opus-5` and
+  // `jp.anthropic.claude-sonnet-4-6` were read from
+  // `GET /inference-profiles` on ap-southeast-2 / ap-northeast-1.
+  it('accepts the Japan and Australia country profiles in their own regions', () => {
+    expect(
+      isBedrockCampCompatible({ id: 'jp.anthropic.claude-sonnet-4-6' }, 'ap-northeast-1')
+    ).toBe(true);
+    expect(isBedrockCampCompatible({ id: 'jp.anthropic.claude-opus-4-8' }, 'ap-northeast-3')).toBe(
+      true
+    );
+    expect(isBedrockCampCompatible({ id: 'au.anthropic.claude-opus-5' }, 'ap-southeast-2')).toBe(
+      true
+    );
+    expect(isBedrockCampCompatible({ id: 'au.anthropic.claude-sonnet-5' }, 'ap-southeast-4')).toBe(
+      true
+    );
+    // The continent tier stays available alongside them.
+    expect(
+      isBedrockCampCompatible({ id: 'apac.anthropic.claude-sonnet-4-6' }, 'ap-northeast-1')
+    ).toBe(true);
+  });
+
+  // The country prefixes are NOT a `startsWith` on the region family: Seoul
+  // (ap-northeast-2) and Singapore (ap-southeast-1) serve `apac.` only.
+  it('does not leak jp./au. profiles into neighbouring ap- regions', () => {
+    expect(
+      isBedrockCampCompatible({ id: 'jp.anthropic.claude-sonnet-4-6' }, 'ap-northeast-2')
+    ).toBe(false);
+    expect(isBedrockCampCompatible({ id: 'au.anthropic.claude-opus-5' }, 'ap-southeast-1')).toBe(
+      false
+    );
+    expect(isBedrockCampCompatible({ id: 'jp.anthropic.claude-opus-4-8' }, 'us-west-2')).toBe(
+      false
+    );
+    expect(isBedrockCampCompatible({ id: 'au.anthropic.claude-opus-5' }, 'ap-northeast-1')).toBe(
+      false
+    );
+  });
+
+  // Non-Claude default-deny with a narrow, live-verified allowlist.
+  it('accepts the allowlisted non-Claude models', () => {
+    for (const id of [
+      'global.openai.gpt-5.6-sol',
+      'global.openai.gpt-5.6-terra',
+      'global.openai.gpt-5.6-luna',
+    ]) {
+      expect(isBedrockCampCompatible({ id }, 'us-west-2'), id).toBe(true);
+      // `global.` is reachable from every region.
+      expect(isBedrockCampCompatible({ id }, 'ap-northeast-1'), id).toBe(true);
+    }
+  });
+
+  // Everything else non-Claude stays denied — these are all callable on
+  // Bedrock, so only the allowlist keeps them out.
+  it('keeps every other non-Claude model out of the picker', () => {
+    for (const id of [
+      'us.amazon.nova-pro-v1:0',
+      'us.meta.llama3-3-70b-instruct-v1:0',
+      'us.deepseek.r1-v1:0',
+      'us.writer.palmyra-x5-v1:0',
+      'global.zai.glm-5',
+      'global.minimax.minimax-m2.5',
+      'us.qwen.qwen3-coder-480b-a35b-v1:0',
+      // Functional on Bedrock but does not cache reliably (2/15), so it is
+      // deliberately NOT allowlisted.
+      'global.xai.grok-4.6',
+      // Older/other versions of the allowlisted families are NOT covered.
+      'global.xai.grok-4.3',
+      'global.openai.gpt-5.5',
+      'us.openai.gpt-oss-120b-1:0',
+    ]) {
+      expect(isBedrockCampCompatible({ id }, 'us-west-2'), id).toBe(false);
+    }
+  });
+
+  it('still requires an inference-profile prefix for allowlisted models', () => {
+    // Bare ids 400 with "on-demand throughput isn't supported".
+    expect(isBedrockCampCompatible({ id: 'openai.gpt-5.6-sol' }, 'us-west-2')).toBe(false);
   });
 
   it('stays permissive when no region is configured yet', () => {
@@ -93,6 +190,17 @@ describe('parity with the private copies in bedrock-camp.ts', () => {
     { id: 'us.amazon.nova-pro-v1', region: 'us-west-2' },
     { id: 'eu.anthropic.claude-opus-4-8', region: null },
     { id: 'us.anthropic.claude-opus-5-0', region: 'us-east-1' },
+    { id: 'us.anthropic.claude-opus-5', region: 'us-west-2' },
+    { id: 'us.anthropic.claude-sonnet-5', region: 'us-west-2' },
+    { id: 'us.anthropic.claude-fable-5-1', region: 'us-west-2' },
+    { id: 'eu.anthropic.claude-opus-5', region: 'us-west-2' },
+    { id: 'us.anthropic.claude-3-haiku', region: 'us-west-2' },
+    { id: 'us.openai.gpt-5.6-sol', region: 'us-west-2' },
+    { id: 'jp.anthropic.claude-sonnet-4-6', region: 'ap-northeast-1' },
+    { id: 'jp.anthropic.claude-sonnet-4-6', region: 'ap-northeast-2' },
+    { id: 'au.anthropic.claude-opus-5', region: 'ap-southeast-2' },
+    { id: 'au.anthropic.claude-opus-5', region: 'ap-southeast-1' },
+    { id: 'apac.anthropic.claude-sonnet-4-6', region: 'ap-northeast-1' },
   ];
 
   it('bedrockCampRegionFromBaseUrl matches on every case', () => {

--- a/packages/webapp/tests/providers/bedrock-camp-compat.test.ts
+++ b/packages/webapp/tests/providers/bedrock-camp-compat.test.ts
@@ -18,8 +18,10 @@ import {
 } from '../../src/providers/built-in/bedrock-camp.js';
 import {
   bedrockCampRegionFromBaseUrl,
+  isBedrockCampClaudeModel,
   isBedrockCampCompatible,
 } from '../../src/providers/built-in/bedrock-camp-compat.js';
+import { CLAUDE_FAMILIES, parseClaudeVersion } from '../../src/providers/claude-model-version.js';
 
 describe('bedrockCampRegionFromBaseUrl', () => {
   it('extracts the region from standard, FIPS, and China runtime hosts', () => {
@@ -159,6 +161,20 @@ describe('isBedrockCampCompatible', () => {
     }
   });
 
+  // The allowlist is spelled out per variant, so a future catalogue addition
+  // cannot slip into the picker without someone verifying its caching.
+  it('does not auto-admit unverified gpt-5.6 variants or spellings', () => {
+    for (const id of [
+      'global.openai.gpt-5.6-nova',
+      'global.openai.gpt-5.6-sol-preview',
+      // Dash spelling: no Bedrock id uses it and it was never verified.
+      'global.openai.gpt-5-6-sol',
+      'global.openai.gpt-5.7-sol',
+    ]) {
+      expect(isBedrockCampCompatible({ id }, 'us-west-2'), id).toBe(false);
+    }
+  });
+
   it('still requires an inference-profile prefix for allowlisted models', () => {
     // Bare ids 400 with "on-demand throughput isn't supported".
     expect(isBedrockCampCompatible({ id: 'openai.gpt-5.6-sol' }, 'us-west-2')).toBe(false);
@@ -168,6 +184,45 @@ describe('isBedrockCampCompatible', () => {
     expect(isBedrockCampCompatible({ id: 'eu.anthropic.claude-opus-4-8' }, null)).toBe(true);
     expect(isBedrockCampCompatible({ id: 'eu.anthropic.claude-opus-4-8' })).toBe(true);
   });
+});
+
+// The Claude family set lives in two independent places: `CLAUDE_FAMILIES`
+// (which builds the version parser used by the capability shims) and the
+// picker's own `BEDROCK_CAMP_CLAUDE_RE`. Nothing at runtime couples them, so
+// pin them here — a family added to the parser but not the picker would
+// resolve correctly for temperature/caching and still never be selectable.
+// `account-store.ts` clears `model.reasoning` for anything this returns false
+// for, because effort control never reaches the wire off the Claude path.
+describe('isBedrockCampClaudeModel', () => {
+  it.each([
+    ['us.anthropic.claude-opus-5'],
+    ['global.anthropic.claude-sonnet-5'],
+    ['us.anthropic.claude-fable-5'],
+    ['us.anthropic.claude-haiku-4-5-20251001-v1:0'],
+  ])('is true for %s', (id) => {
+    expect(isBedrockCampClaudeModel({ id })).toBe(true);
+  });
+
+  it.each([
+    ['global.openai.gpt-5.6-sol'],
+    ['global.openai.gpt-5.6-terra'],
+    ['global.openai.gpt-5.6-luna'],
+  ])('is false for the allowlisted non-Claude model %s', (id) => {
+    // Still selectable — it just must not advertise a thinking-level control.
+    expect(isBedrockCampCompatible({ id }, 'us-west-2'), id).toBe(true);
+    expect(isBedrockCampClaudeModel({ id })).toBe(false);
+  });
+});
+
+describe('picker family alternation covers every parsed Claude family', () => {
+  it.each(CLAUDE_FAMILIES.map((f) => [f]))(
+    'the picker accepts the %s family the version parser knows',
+    (family) => {
+      const id = `us.anthropic.claude-${family}-5`;
+      expect(parseClaudeVersion(id), `${id} must parse`).not.toBeNull();
+      expect(isBedrockCampCompatible({ id }, 'us-west-2'), `${id} must be selectable`).toBe(true);
+    }
+  );
 });
 
 describe('parity with the private copies in bedrock-camp.ts', () => {

--- a/packages/webapp/tests/providers/bedrock-camp-picker.test.ts
+++ b/packages/webapp/tests/providers/bedrock-camp-picker.test.ts
@@ -1,0 +1,81 @@
+/**
+ * End-to-end picker behaviour for bedrock-camp: what `getProviderModels()`
+ * actually hands the UI, against the REAL pi-ai catalogue (no mocked model
+ * lists), so a catalogue change that hides a model fails here.
+ *
+ * Covers the two things unit-testing the predicates in isolation misses: that
+ * Claude 5 is genuinely reachable end to end, and that an allowlisted
+ * non-Claude model arrives with `reasoning` cleared so the composer does not
+ * offer a thinking-level control that cannot reach the wire.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const storage = new Map<string, string>();
+const storageStub = {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    storage.set(k, v);
+  },
+  removeItem: (k: string) => {
+    storage.delete(k);
+  },
+  get length() {
+    return storage.size;
+  },
+  key: (i: number) => [...storage.keys()][i] ?? null,
+  clear: () => {
+    storage.clear();
+  },
+};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: storageStub,
+  configurable: true,
+  writable: true,
+});
+
+const BEDROCK_BASE_URL = 'https://bedrock-runtime.us-west-2.amazonaws.com';
+
+async function pickerModels(): Promise<Array<{ id: string; reasoning?: boolean }>> {
+  const { getProviderModels } = await import('../../src/providers/account-store.js');
+  return getProviderModels('bedrock-camp');
+}
+
+describe('bedrock-camp picker contents', () => {
+  beforeEach(() => {
+    storage.clear();
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: 'bedrock-camp', apiKey: 'ABSK-x', baseUrl: BEDROCK_BASE_URL }])
+    );
+  });
+
+  it('surfaces Claude 5 — the regression this whole change exists for', async () => {
+    const ids = (await pickerModels()).map((m) => m.id);
+    expect(ids).toContain('us.anthropic.claude-opus-5');
+    expect(ids.some((id) => /anthropic\.claude-sonnet-5/.test(id))).toBe(true);
+  });
+
+  it('keeps effort control on Claude, where it reaches the wire', async () => {
+    const opus = (await pickerModels()).find((m) => m.id === 'us.anthropic.claude-opus-5');
+    expect(opus?.reasoning).toBe(true);
+  });
+
+  it('clears reasoning on allowlisted non-Claude models', async () => {
+    // gpt-5.6 still reasons; it just cannot be told how hard, so advertising a
+    // low/medium/high/xhigh selector would be a lie — every level produces a
+    // byte-identical request.
+    const gpt = (await pickerModels()).filter((m) => m.id.includes('openai.gpt-5.6'));
+    expect(gpt.length).toBeGreaterThan(0);
+    for (const m of gpt) expect(m.reasoning, m.id).toBe(false);
+  });
+
+  it('keeps unverified non-Claude models out entirely', async () => {
+    const ids = (await pickerModels()).map((m) => m.id);
+    for (const needle of ['grok', 'glm', 'minimax', 'nova', 'llama', 'deepseek', 'palmyra']) {
+      expect(
+        ids.filter((id) => id.includes(needle)),
+        needle
+      ).toEqual([]);
+    }
+  });
+});

--- a/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
+++ b/packages/webapp/tests/providers/built-in/bedrock-camp.test.ts
@@ -471,3 +471,75 @@ describe('bedrock-camp built-in provider', () => {
     expect(result.errorMessage).toContain('Unsupported image MIME type');
   });
 });
+
+/**
+ * The provider default has to survive the picker filter, not just exist in
+ * pi-ai's catalogue. `getProviderModels()` resolves `defaultModelId` with a
+ * case-insensitive substring match over the ALREADY-FILTERED list
+ * (`account-store.ts`), so a default naming a model the filter hides silently
+ * falls through to "first visible model". Runs against the real catalogue.
+ */
+describe('config.defaultModelId resolves against the real catalogue', () => {
+  const REGION = 'us-west-2';
+
+  async function visibleModels(): Promise<Array<{ id: string }>> {
+    const { getModels } = await import('../../../src/core/index.js');
+    const all = (getModels as (p: string) => Array<{ id: string }>)('amazon-bedrock');
+    return all.filter((m) => isBedrockCampCompatible(m, REGION));
+  }
+
+  it('is a Claude 5 default', () => {
+    expect(config.defaultModelId).toBe('claude-opus-5');
+  });
+
+  it('matches at least one model the picker actually shows', async () => {
+    const id = config.defaultModelId!;
+    const matches = (await visibleModels()).filter((m) =>
+      m.id.toLowerCase().includes(id.toLowerCase())
+    );
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) expect(m.id).toMatch(/anthropic\.claude-opus-5/);
+  });
+});
+
+/**
+ * The allowlisted non-Claude model (gpt-5.6) caches IMPLICITLY on Bedrock — an
+ * explicit `cachePoint` block 403s, and every `additionalModelRequestFields`
+ * thinking shape 400s with `unknown_parameter`. Verified live on
+ * `bedrock-runtime.us-west-2`.
+ *
+ * `supportsPromptCaching` and `buildAdditionalModelRequestFields` both gate on
+ * `isAnthropicClaudeModel`, so this already holds — these tests pin it so
+ * widening the picker allowlist can never start emitting either field.
+ */
+describe('allowlisted non-Claude models get no Claude-shaped fields', () => {
+  const NON_CLAUDE = [['global.openai.gpt-5.6-sol', 'GPT-5.6 Sol (Global)']] as const;
+
+  it.each(NON_CLAUDE)('sends no cachePoint for %s', async (id, name) => {
+    const payload = await capturePayload(baseModel({ id, name }), {});
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain('cachePoint');
+  });
+
+  it.each(NON_CLAUDE)(
+    'sends no thinking fields for %s even at reasoning=high',
+    async (id, name) => {
+      const payload = await capturePayload(baseModel({ id, name, reasoning: true }), {
+        reasoning: 'high',
+      });
+      expect(payload.additionalModelRequestFields).toBeUndefined();
+    }
+  );
+
+  it('still sends both for a Claude model (control)', async () => {
+    const payload = await capturePayload(
+      baseModel({ id: 'us.anthropic.claude-opus-5', name: 'Claude Opus 5', reasoning: true }),
+      { reasoning: 'high' }
+    );
+    expect(JSON.stringify(payload)).toContain('cachePoint');
+    expect(payload.additionalModelRequestFields.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    });
+  });
+});

--- a/packages/webapp/tests/providers/claude-model-version.test.ts
+++ b/packages/webapp/tests/providers/claude-model-version.test.ts
@@ -5,6 +5,7 @@ import {
   claudeSupportsAdaptiveThinking,
   claudeSupportsMaxEffort,
   claudeSupportsNativeXhighEffort,
+  claudeSupportsPromptCaching,
   parseClaudeVersion,
 } from '../../src/providers/claude-model-version.js';
 
@@ -21,6 +22,10 @@ describe('parseClaudeVersion', () => {
     ['claude-sonnet-5-0', { family: 'sonnet', major: 5, minor: 0 }],
     ['us.anthropic.claude-sonnet-5-0', { family: 'sonnet', major: 5, minor: 0 }],
     ['claude-haiku-4-5', { family: 'haiku', major: 4, minor: 5 }],
+    ['claude-opus-5', { family: 'opus', major: 5, minor: 0 }],
+    ['claude-fable-5', { family: 'fable', major: 5, minor: 0 }],
+    ['claude-fable-5-1', { family: 'fable', major: 5, minor: 1 }],
+    ['us.anthropic.claude-fable-5-1', { family: 'fable', major: 5, minor: 1 }],
     ['us.anthropic.claude-opus-4-8', { family: 'opus', major: 4, minor: 8 }],
     ['global.anthropic.claude-opus-4-9', { family: 'opus', major: 4, minor: 9 }],
   ])('parses %s', (id, expected) => {
@@ -72,6 +77,11 @@ describe('claudeSupportsAdaptiveThinking', () => {
     ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
     ['us.anthropic.claude-sonnet-5-0'],
+    ['claude-opus-5'],
+    // Verified live against bedrock-runtime.us-west-2: fable-5 400s on
+    // `thinking.type.enabled` and demands `thinking.type.adaptive`.
+    ['claude-fable-5'],
+    ['claude-fable-5-1'],
   ])('returns true for adaptive-capable %s', (id) => {
     expect(claudeSupportsAdaptiveThinking(id)).toBe(true);
   });
@@ -94,7 +104,10 @@ describe('claudeSupportsNativeXhighEffort', () => {
     ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
     ['us.anthropic.claude-sonnet-5-0'],
-  ])('returns true for Opus ≥ 4.7 or Sonnet ≥ 5.0 (%s)', (id) => {
+    ['claude-opus-5'],
+    ['claude-fable-5'],
+    ['claude-fable-5-1'],
+  ])('returns true for Opus ≥ 4.7, Sonnet ≥ 5.0, or Fable (%s)', (id) => {
     expect(claudeSupportsNativeXhighEffort(id)).toBe(true);
   });
 
@@ -120,26 +133,72 @@ describe('claudeSupportsMaxEffort', () => {
     ['claude-opus-4-8'],
     ['claude-sonnet-5'],
     ['claude-sonnet-5-0'],
+    ['claude-fable-5'],
     ['gpt-4o'],
   ])('returns false for %s', (id) => {
     expect(claudeSupportsMaxEffort(id)).toBe(false);
   });
 });
 
+describe('claudeSupportsPromptCaching', () => {
+  it.each([
+    ['claude-opus-4-5'],
+    ['claude-opus-4-8'],
+    ['us.anthropic.claude-sonnet-4-5-20250929-v1:0'],
+    ['claude-haiku-4-5'],
+    // Regression: these have no `-4-` in the id, which the old substring
+    // check keyed on, so cache points were dropped on every request.
+    ['us.anthropic.claude-opus-5'],
+    ['us.anthropic.claude-sonnet-5'],
+    ['us.anthropic.claude-fable-5'],
+    // Legacy 3.x backports.
+    ['anthropic.claude-3-7-sonnet-20250219-v1:0'],
+    ['anthropic.claude-3-5-haiku-20241022-v1:0'],
+  ])('returns true for %s', (id) => {
+    expect(claudeSupportsPromptCaching(id)).toBe(true);
+  });
+
+  it.each([
+    ['anthropic.claude-3-haiku-20240307-v1:0'],
+    ['anthropic.claude-3-5-sonnet-20241022-v1:0'],
+    ['us.amazon.nova-pro-v1'],
+    ['gpt-4o'],
+  ])('returns false for %s', (id) => {
+    expect(claudeSupportsPromptCaching(id)).toBe(false);
+  });
+
+  it('matches on the display name for opaque application-inference-profile ARNs', () => {
+    expect(
+      claudeSupportsPromptCaching(
+        'arn:aws:bedrock:us-west-2:1:application-inference-profile/x',
+        'Claude Opus 5'
+      )
+    ).toBe(true);
+  });
+});
+
 describe('claudeRejectsTemperature', () => {
-  it.each([['claude-opus-4-7'], ['claude-opus-4-8'], ['claude-opus-4-9']])(
-    'returns true for Opus ≥ 4.7 (%s)',
-    (id) => {
-      expect(claudeRejectsTemperature(id)).toBe(true);
-    }
-  );
+  // The reject list tracks generations, not families. Every id below was
+  // confirmed against bedrock-runtime.us-west-2, which answers
+  // `400 \`temperature\` is deprecated for this model.`
+  it.each([
+    ['claude-opus-4-7'],
+    ['claude-opus-4-8'],
+    ['claude-opus-4-9'],
+    ['claude-opus-5'],
+    ['claude-sonnet-5'],
+    ['claude-sonnet-5-0'],
+    ['claude-fable-5'],
+    ['claude-fable-5-1'],
+  ])('returns true for Opus ≥ 4.7, Sonnet ≥ 5.0, or Fable (%s)', (id) => {
+    expect(claudeRejectsTemperature(id)).toBe(true);
+  });
 
   it.each([
     ['claude-opus-4-6'],
     ['claude-sonnet-4-6'],
-    ['claude-sonnet-5'],
-    ['claude-sonnet-5-0'],
     ['claude-sonnet-4-9'],
+    // Haiku 4.5 still accepts `temperature` (live-verified).
     ['claude-haiku-4-9'],
     ['gpt-4o'],
   ])('returns false for %s', (id) => {

--- a/packages/webapp/tests/providers/temperature-support.test.ts
+++ b/packages/webapp/tests/providers/temperature-support.test.ts
@@ -73,3 +73,48 @@ describe('withSupportedTemperature', () => {
     expect(options.temperature).toBe(0.3);
   });
 });
+
+/**
+ * Non-Claude allowlisted models. Both answer
+ * `400 "This model doesn't support the temperature field."` on
+ * `bedrock-runtime.us-west-2`, so `quick-llm.ts`'s `temperature: 0.3` helper
+ * calls would fail without this. Paired with the picker allowlist in
+ * `built-in/bedrock-camp-compat.ts` — extend both together.
+ */
+describe('non-Claude Bedrock models that reject temperature', () => {
+  it.each([
+    ['global.openai.gpt-5.6-sol'],
+    ['global.openai.gpt-5.6-terra'],
+    ['global.openai.gpt-5.6-luna'],
+  ])('%s does not support temperature', (id) => {
+    expect(modelSupportsTemperature(id)).toBe(false);
+  });
+
+  it('matches on the display name for opaque application-inference-profile ARNs', () => {
+    const arn = 'arn:aws:bedrock:us-west-2:1:application-inference-profile/x';
+    expect(modelSupportsTemperature(arn, 'GPT-5.6 Sol (Global)')).toBe(false);
+  });
+
+  it('strips temperature from options for those models', () => {
+    expect(
+      withSupportedTemperature('global.openai.gpt-5.6-sol', undefined, {
+        temperature: 0.3,
+        maxTokens: 8,
+      })
+    ).toEqual({ maxTokens: 8 });
+  });
+
+  it('leaves other non-Claude Bedrock models alone', () => {
+    for (const id of [
+      'us.amazon.nova-pro-v1:0',
+      'us.openai.gpt-oss-120b-1:0',
+      'global.zai.glm-5',
+      'us.qwen.qwen3-32b-v1:0',
+      // Not allowlisted, so never reached — and must not be misdetected.
+      'global.xai.grok-4.6',
+      'global.xai.grok-4.3',
+    ]) {
+      expect(modelSupportsTemperature(id), id).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The Bedrock model picker filtered on the substring `-4`, so **every Claude 5 model was silently invisible** — `us.anthropic.claude-opus-5` contains no `-4`. Before: Opus 5 never appeared in the dropdown even though Bedrock serves it and pi-ai's catalogue lists it. Now: Opus 5, Sonnet 5 and Fable 5 appear, Opus 5 is the default, and the `au.`/`jp.` region tiers plus a narrow `openai.gpt-5.6-*` allowlist are surfaced too.

Substring-matching a version turned out to be the shared root cause of **three** defects, not one. The other two would have made Claude 5 broken rather than merely invisible.

## Why

Started from "why doesn't Opus 5 show up?" against a live CAMP endpoint. Every finding below was verified against `bedrock-runtime.us-west-2` (plus seven other regions for the profile tiers), not inferred from the catalogue.

**Repro (before this PR):**
1. Configure the AWS Bedrock provider against `https://bedrock-runtime.us-west-2.amazonaws.com`.
2. Open the model picker.

Expected: Claude Opus 5 is selectable.
Actual: only Claude 4.x is listed. `POST /model/us.anthropic.claude-opus-5/converse` returns 200 from the same endpoint with the same key, so it is not an access problem.

## Approach / Implementation notes

The three defects and their fixes:

| # | Defect | Failure mode |
| --- | --- | --- |
| 1 | Picker regex required `-4` | Claude 5 absent from the dropdown |
| 2 | `claudeRejectsTemperature` was Opus-only | Sonnet 5 / Fable 400 on `temperature` |
| 3 | `supportsPromptCaching` gated on substring `-4-` | every Claude 5 request shipped **without cache points** |

All three now route through the family+version parser in `claude-model-version.ts`, so a future Claude generation needs no edit. Adding a *family* still does — `fable` had to be added to `ClaudeFamily`, the version regex, and the picker regex (which is deliberately duplicated in `bedrock-camp.ts` and `bedrock-camp-compat.ts`; a parity test pins them together).

**One pre-existing test asserted the opposite of reality.** It required `claudeRejectsTemperature('claude-sonnet-5') === false`; the live endpoint answers `400 "temperature is deprecated for this model."` The case was moved to the true list rather than worked around.

**Region tiers.** `GET /inference-profiles` per region returns three tiers, not one. The country tier is narrower than a region-family prefix — `jp.` is Japan only and must not claim `ap-northeast-2` (Seoul) — so `JP_REGIONS`/`AU_REGIONS` are enumerated sets, not `startsWith`. Tokyo and Sydney go from 10 to 17 models.

**Non-Claude allowlist.** Rule 2 stays default-deny; the admission bar is prompt caching. `openai.gpt-5.6-{sol,terra,luna}` cache *implicitly* — so enabling them required **adding nothing** to the request. `supportsPromptCaching` and `buildAdditionalModelRequestFields` already gate on `isAnthropicClaudeModel` and stay correct; sending an explicit `cachePoint` returns 403 and every thinking shape 400s `unknown_parameter`. The only real change was the temperature reject-list.

Measured and **excluded**: `grok-4.6` cached on 2 of 15 attempts at ~18-20k tokens (and Bedrock serves it only via an inference profile that pi-ai's catalogue lacks entirely); `glm-5` and `minimax-m2.5` never cached at 8k, 20k or 40k. I first reported grok as caching off a 2-of-4 sample — a larger sample in the shape the agent actually sends contradicted it. `docs/pitfalls.md` §5 now records that a few hits are not proof of caching, and that pi-ai prices `cacheRead` whether caching is explicit, implicit, or absent.

Rejected alternative: pi-ai's own `supportsPromptCaching` has the identical `-4-` bug and patches it by hardcoding `opus-5|sonnet-5|fable-5`. Copying that would need another edit per generation.

## Cross-cutting impact

- **Floats exercised**: none directly — this is provider-layer model metadata shared by every float that talks to bedrock-camp. No float-specific code paths changed.
- **Other callers of the changed contract**: `modelSupportsTemperature` / `withSupportedTemperature` are also consumed by the Adobe provider (which routes the same models to Bedrock) — broadening the reject-list is correct for it too. `parseClaudeVersion` is consumed by `family-cost.ts`; adding `fable` means Fable now inherits family pricing instead of falling back to $0.
- **Persisted state**: none. `defaultModelId` is only consulted when no model has been selected; the per-cone model on the work-unit record is untouched.
- **Security**: the Claude-only rule exists for prompt-injection resistance. It is **not** removed — it is widened by one explicit, live-verified family. Every other non-Claude model (Nova, Llama, Writer, DeepSeek R1, glm-5, minimax, grok) is asserted denied by test.
- **Bundle size**: +0.4 kB page / +0.4 kB worker, within the 5 kB per-change allowance.

## Test plan

- [x] `npx prettier --check` on all changed files — clean
- [x] `npm run typecheck` — exit 0
- [x] `npm run test` — 20510 passing, 54 skipped, **0 failures**
- [x] `npm run build` — exit 0
- [x] `npm run build -w @slicc/chrome-extension` — exit 0
- [x] `npm run test:coverage:webapp` — exit 0, no threshold failures
- [x] First-load ratchet — +0.4 kB both graphs, 21 kB / 46 kB under ceiling
- [x] **New behavior covered by unit tests** — `npx vitest run packages/webapp/tests/providers` (674 passing) across `bedrock-camp-compat.test.ts`, `claude-model-version.test.ts`, `temperature-support.test.ts`, `built-in/bedrock-camp.test.ts`
- [x] **Live endpoint verification** — every capability claim checked against `bedrock-runtime.us-west-2`; profile tiers against 8 regions
- [x] **Mutation-tested the new default-model guard** — it fails both when the default names a nonexistent model and when the old `-4` filter is restored, so it would have caught the original bug
- [ ] Manual smoke in a running SLICC — **not done**, see Risk below

**Pre-existing failures**: none observed; the full suite is green on this branch.

Note on the boy-scout gate: `check-touched-exemptions.mjs` reports `no debt lists found — nothing to gate` locally, and does so with an empty diff too, so it appears inert in this environment rather than passing my diff specifically. CI is authoritative for it.

## Documentation

- [x] `docs/` — `docs/pitfalls.md` gains §3 (version substrings are not capability tests), §4 (the three-tier region prefix table), §5 (non-Claude caching is implicit and `cachePoint` 403s), and corrections to the two stale Bedrock sections
- [ ] `README.md` — no user-facing behavior change beyond the picker contents
- [ ] `CLAUDE.md` — existing rule already points capability shims at `claude-model-version.ts`

## Risk & rollback

- **Blast radius**: bedrock-camp provider only. Reverts cleanly — no migrations, no persisted state.
- **What CI cannot catch, and what I did not verify by hand**: I verified everything against the live Bedrock API, but **did not** run a full agent loop in a browser against a real CAMP account. The highest-value manual check is selecting Opus 5 in the picker and confirming a multi-turn conversation reports cache reads. Prompt caching in particular is invisible to the test suite — it can only be observed in `usage` against the live endpoint.
- **Model-picker contents change**, which is user-visible. No screencast is attached since there is no visual/layout change, only list contents; happy to record one if you'd like it before merge.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public API changes are intentional and reflected in docs
- [x] Contract shared with other floats (`temperature-support`, `claude-model-version`) checked for the Adobe provider and `family-cost.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
