### PR TITLE
fix(webapp): hold a cone's queued pile across switches instead of cancelling it

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -486,12 +486,33 @@ own.
     cone B renders in B rather than in the oldest cone. The reply travels back
     by `requestId` alone (`ToolUIActionMsg` carries no jid), so the scoop's
     pending promise still settles where it was raised.
-  - **The cone's queued pile survives the detour.** A selection change
-    normally cancels the pile on the backend — the user navigated away to
-    talk somewhere else. Reading a scoop is not that: there is nowhere else
-    to talk. `stashQueued` / `restoreQueued` hold it across the round trip
-    (re-installed after the returning unit's replay, which clears the pile of
-    its own accord); landing on a _different_ cone cancels it as before.
+  - **The cone's queued pile survives every selection change.** A prompt
+    typed into a working cone stacks as a queue card, and the backend has
+    already accepted it (`Bridge.handleUserMessage` buffers on send). Walking
+    off to read a scoop — or to another cone entirely — is not a retraction,
+    so a switch never cancels: `reconcileQueueForSwitch` (`ui/wc/wc-live.ts`)
+    `stashQueued`s the pile into a per-cone `heldQueues` map before the
+    selection moves and `restoreQueued`s it the moment the user lands back on
+    the owning cone (re-installed after that unit's replay, which clears the
+    live pile of its own accord). The hold is keyed by the **owning cone**, so
+    a hop between two of a cone's scoops cannot re-key it onto a jid no
+    destination could match; a unit missing from the roster has no knowable
+    owner and is held under its own jid. The stash has to happen ahead of the
+    switch because `loadMessages` cancels whatever pile is still live — right
+    for a session reload, wrong for a switch. Entries leave the map only when
+    their cone is selected again, drops off the roster, or the user dismisses
+    the cards with `×`. Cancelling on a switch was the original #2312
+    behaviour and read as SLICC silently discarding work the user had already
+    committed to.
+  - **The Freezer takes the same hold.** Thawing an archive replaces the
+    thread WITHOUT a selection change — `openFrozen` calls `loadMessages`
+    itself and only then `clearSelection` — so the pile used to be cancelled
+    by the very path a switch no longer takes. `wireFreezerRail` gets
+    `holdQueuedPile()` (the shell's `boot.holdQueuedPile`, keyed by the
+    selected unit's owning cone) and calls it **before** the thaw lands; the
+    detour ends with an ordinary `selectScoop`, which finds the hold and
+    restores it. Restoring keys off the DESTINATION alone, so it does not
+    matter that the thaw left `previousJid` null.
   - **The held pile is reconciled against the backend on the way home**
     ([#2354](https://github.com/ai-ecoverse/slicc/issues/2354)). The snapshot
     the panel is holding is a guess about a queue it stopped watching. The

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -303,7 +303,13 @@ export class WcChatController {
    */
   #readOnly = false;
 
-  /** Queue handed back by the host after a read-only detour; see {@link restoreQueued}. */
+  /**
+   * Queue handed back by the host after a detour, waiting for the returning
+   * unit's replay; see {@link restoreQueued}. Carries no unit id — the slot is
+   * only ever armed for the unit the host has just selected — so leaving that
+   * unit again must disarm it ({@link stashQueued}), or the NEXT unit's replay
+   * would consume it and render one cone's cards under another's thread.
+   */
   #pendingQueueRestore: ChatMessage[] | null = null;
 
   constructor(options: WcChatControllerOptions) {
@@ -437,11 +443,19 @@ export class WcChatController {
    * already gone by the time the scoop's replay lands.
    */
   stashQueued(): ChatMessage[] {
+    // An armed-but-unapplied restore belongs to the unit being left, not to
+    // the one being opened: the replay it was waiting for never arrived, so it
+    // rides back out with the live pile rather than staying armed for whatever
+    // replay lands next. The held items come FIRST — they were queued before
+    // anything typed since the selection — though the backend's order wins
+    // over both on the way home (`#applyPendingQueueRestore`).
+    const pending = this.#pendingQueueRestore ?? [];
+    this.#pendingQueueRestore = null;
     const items = this.#queued;
-    if (items.length === 0) return [];
+    if (items.length === 0) return pending;
     this.#queued = [];
     this.#fireQueuedChange();
-    return items;
+    return [...pending, ...items];
   }
 
   /**
@@ -450,6 +464,10 @@ export class WcChatController {
    * asynchronously and clears the pile, so restoring eagerly would lose it
    * again. A second `loadMessages` (a real session reload) finds no pending
    * restore and behaves exactly as before.
+   *
+   * The wait is what makes this racy on its own: if the user leaves before
+   * that replay lands, the host takes the pile back through
+   * {@link stashQueued} and re-holds it for the unit it belongs to.
    */
   restoreQueued(items: readonly ChatMessage[]): void {
     this.#pendingQueueRestore = items.length > 0 ? [...items] : null;

--- a/packages/webapp/src/ui/wc/wc-live-freezer.ts
+++ b/packages/webapp/src/ui/wc/wc-live-freezer.ts
@@ -43,6 +43,13 @@ export interface FreezerRailDeps {
   /** The client protocol's roster — selection is expressed in summaries (#2382 D2a). */
   getUnits(): readonly WorkUnitSummary[];
   clearSelection(): void;
+  /**
+   * Park the selected cone's queued pile before the thaw replaces the thread.
+   * A frozen chat is a detour like a read-only scoop is: the prompts were
+   * committed to the cone's backend queue and the cone is still working
+   * through them, so `loadMessages` must not cancel them on the way past.
+   */
+  holdQueuedPile(): void;
   log: BootStageLogger;
 }
 
@@ -207,6 +214,21 @@ async function clearConeSession(deps: ClearConeSessionDeps): Promise<void> {
     .catch(() => undefined);
 }
 
+/**
+ * Dress the shell for a thawed archive: the provenance caption, the Freezer
+ * tint and mood, and the composer locked out. Attribution lives in the chat
+ * log, not on the rail card (#2272) — one Freezer for all cones, and the
+ * thawed view says whose chat it is.
+ */
+function paintFrozenChrome(refs: WcShellRefs, entry: FrozenSessionIndexEntry | undefined): void {
+  const column = (refs.thread as { inner?: HTMLElement }).inner ?? refs.thread;
+  column.prepend(frozenProvenanceEl(refs.thread.ownerDocument, entry));
+  refs.thread.setAttribute('accent', FREEZER_TINT);
+  applyShellContext(refs, { kind: 'freezer' });
+  refs.inputCard.setAttribute('disabled', '');
+  refs.switcher.removeAttribute('active');
+}
+
 /** Caption at the top of a thawed chat naming the cone it was frozen from. */
 export function frozenProvenanceEl(
   doc: Document,
@@ -361,15 +383,11 @@ export function wireFreezerRail(deps: FreezerRailDeps): FreezerRailHandles {
       );
       refs.thread.setAttribute('context', `freezer:${entry?.filename ?? slug}`);
       currentFrozenSessionId = entry?.sessionId ?? entry?.filename ?? null;
+      // BEFORE the thaw takes the thread: `loadMessages` cancels any pile
+      // still live, and reading an archive is not a retraction.
+      deps.holdQueuedPile();
       getController()?.loadMessages(messages);
-      // Attribution lives in the chat log, not on the rail card (#2272):
-      // one Freezer for all cones, and the thawed view says whose chat it is.
-      const column = (refs.thread as { inner?: HTMLElement }).inner ?? refs.thread;
-      column.prepend(frozenProvenanceEl(refs.thread.ownerDocument, entry));
-      refs.thread.setAttribute('accent', FREEZER_TINT);
-      applyShellContext(refs, { kind: 'freezer' });
-      refs.inputCard.setAttribute('disabled', '');
-      refs.switcher.removeAttribute('active');
+      paintFrozenChrome(refs, entry);
       clearSelection();
     } catch (err) {
       log.error('WC thaw failed', err);

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -111,6 +111,12 @@ export interface WcShellBoot {
   getSelected(): WorkUnitSummary | null;
   clearSelection(): void;
   /**
+   * Hold the selected cone's queued pile before a non-selection surface
+   * replaces the thread (the Freezer's thaw), so re-selecting that cone
+   * restores it instead of the replay cancelling it. See `holdQueuedPile`.
+   */
+  holdQueuedPile(): void;
+  /**
    * Render `id`'s transcript WITHOUT claiming the roster describes it.
    *
    * `selectScoop` is the normal path and takes a summary. A biscotto seat has
@@ -139,78 +145,80 @@ export interface WcShellBoot {
 }
 
 /**
+ * Park the live queued pile under the cone that owns `jid`, so a later
+ * selection of that cone can hand it straight back. A unit missing from the
+ * roster has no knowable owner (`rootForSelection` would fall back to the
+ * DEFAULT root, which would silently read as "some other cone's pile"), so it
+ * is held under its own jid — a hold only its own unit can claim.
+ *
+ * Must run BEFORE whatever replaces the thread: `loadMessages` cancels any
+ * pile still live at that moment.
+ */
+function holdQueuedPile(args: {
+  controller: WcChatController | null;
+  held: Map<string, ChatMessage[]>;
+  jid: string;
+  roster: readonly WorkUnitSummary[];
+}): void {
+  const { controller, held, jid, roster } = args;
+  const items = controller?.stashQueued() ?? [];
+  if (items.length === 0) return;
+  const unit = roster.find((u) => u.id === jid);
+  const key = unit ? (rootForSelection(roster, unit)?.id ?? unit.id) : jid;
+  held.set(key, [...(held.get(key) ?? []), ...items]);
+}
+
+/**
  * Decide what happens to the queued pile when the selection moves (#2354).
  *
- * A read-only detour that stays inside the queue owner's own cone HOLDS the
- * pile; anything else cancels it on the backend, because the orchestrator must
- * never silently deliver a prompt the user dropped by navigating away. The
- * hold is keyed by the OWNING CONE, not by the unit being left: the queue
- * belongs to the cone, so a hop between two of its scoops must not re-key the
- * hold onto a scoop jid that no destination owner could ever match.
+ * The pile belongs to the CONE the user typed into, not to the tab that
+ * happens to be on screen: every queued prompt was already handed to the
+ * backend synchronously on send, and looking at a second cone is not a
+ * retraction. So a switch never cancels — it HOLDS the pile, keyed by the
+ * owning cone, and re-installs it the moment the user lands back on that
+ * cone. Reconciling it against what the cone actually consumed while the user
+ * was away is {@link WcChatController.restoreQueued}'s job.
  *
- * Returns the stash to carry forward, or `null` when there is none left.
+ * The hold is keyed by the OWNING CONE (see {@link holdQueuedPile}), not by
+ * the unit being left: the queue belongs to the cone, so a hop between two of
+ * its scoops must not re-key the hold onto a scoop jid that no destination
+ * owner could ever match.
+ *
+ * Mutates `held` in place; the only way an entry leaves it is the user
+ * returning to its cone, that cone dropping off the roster, or the user
+ * dismissing the cards one by one.
  */
 function reconcileQueueForSwitch(args: {
   controller: WcChatController | null;
-  deleteQueued: (jid: string, id: string) => void;
   destination: string;
+  held: Map<string, ChatMessage[]>;
   previousJid: string | null;
-  readOnly: boolean;
   roster: readonly WorkUnitSummary[];
-  stashed: { jid: string; items: ChatMessage[] } | null;
-}): { jid: string; items: ChatMessage[] } | null {
-  const { controller, deleteQueued, destination, previousJid, readOnly, roster } = args;
-  let stashed = args.stashed;
-  const cancel = (jid: string, ids: readonly string[]): void => {
-    for (const id of ids) deleteQueued(jid, id);
-  };
-  /**
-   * The cone that owns a unit — itself for a cone, its root for a scoop.
-   * `undefined` when the unit is not in the live roster: `rootForSelection`
-   * would fall back to the DEFAULT root there, which would silently read as
-   * "same cone" and preserve a queue the user actually walked away from.
-   * Unknown owner therefore means "cancel", the conservative direction and the
-   * behaviour that predates the hold.
-   */
-  const ownerOf = (jid: string | undefined): string | undefined => {
-    const unit = jid === undefined ? undefined : roster.find((u) => u.id === jid);
-    return unit ? (rootForSelection(roster, unit)?.id ?? unit.id) : undefined;
-  };
-  const destinationOwner = ownerOf(destination);
-  // Snapshot the OLD unit's queued ids and cancel them BEFORE the selection
-  // moves. The controller's own pile is dropped locally later by the replay;
-  // its `onQueuedCancel` hook then fires against the NEW jid as
-  // defense-in-depth (a redundant per-id delete is a no-op).
+}): void {
+  const { controller, destination, held, previousJid, roster } = args;
+  // Take the pile BEFORE the selection moves: the replay for the new unit
+  // drops whatever is still live (and cancels it on the backend through
+  // `onQueuedCancel`), which is right for a session reload and wrong for a
+  // switch — the prompts were queued against the unit we are leaving.
   if (previousJid && previousJid !== destination) {
-    const previousOwner = ownerOf(previousJid);
-    if (readOnly && destinationOwner !== undefined && destinationOwner === previousOwner) {
-      const items = controller?.stashQueued() ?? [];
-      if (items.length > 0) stashed = { items, jid: previousOwner };
-    } else {
-      const queued = controller?.getQueuedMessages() ?? [];
-      cancel(
-        previousJid,
-        queued.map((m) => m.id)
-      );
+    holdQueuedPile({ controller, held, jid: previousJid, roster });
+  }
+  // A cone whose pile is held is not on screen, so nothing can clear these but
+  // the cone going away. Pruned only against a roster that demonstrably knows
+  // the current selection — a transiently empty one must not eat live piles.
+  if (roster.some((u) => u.id === destination)) {
+    for (const key of [...held.keys()]) {
+      if (!roster.some((u) => u.id === key)) held.delete(key);
     }
   }
-  if (!stashed) return null;
-  // Back on the cone that owns the pile: hand it to the controller, which
-  // re-installs it after the replay. Still somewhere inside that cone's subtree
-  // (a sibling scoop): keep holding. Anywhere else — including a DIFFERENT
-  // cone's scoop — the detour is over and the prompts really were abandoned.
-  if (stashed.jid === destination) {
-    controller?.restoreQueued(stashed.items);
-    return null;
+  // Back on the cone that owns a pile: hand it to the controller, which
+  // re-installs it after the replay lands. Anywhere else — a scoop of this
+  // cone, another cone entirely — the hold simply stays put.
+  const returning = held.get(destination);
+  if (returning) {
+    held.delete(destination);
+    controller?.restoreQueued(returning);
   }
-  if (destinationOwner !== stashed.jid) {
-    cancel(
-      stashed.jid,
-      stashed.items.map((m) => m.id)
-    );
-    return null;
-  }
-  return stashed;
 }
 
 /**
@@ -304,21 +312,19 @@ function createSelection(deps: {
   selectScoop(unit: WorkUnitSummary): void;
   getSelected(): WorkUnitSummary | null;
   clear(): void;
+  holdQueue(): void;
 } {
   const { refs } = deps;
   let selected: WorkUnitSummary | null = null;
   /**
-   * A cone's queued pile held while the user reads one of its scoops (#2312).
-   * Selecting a read-only unit is not "dropping a prompt by navigating away"
-   * — there is nowhere else to talk — so the pile survives that round trip.
-   *
-   * The hold is scoped to the OWNING CONE, not merely to "the destination is
-   * read-only": leaving cone A for a scoop of cone B is the user going
-   * somewhere else to work, and A's prompt is abandoned exactly as it would
-   * be by clicking B itself. Only a detour INSIDE A's own subtree preserves
-   * it (Codex P1).
+   * Queued piles held while their cone is off screen, keyed by the OWNING
+   * CONE. Started as a hold for the read-only-scoop detour (#2312) and now
+   * covers every switch: a prompt typed into a working cone is already
+   * committed to that cone's backend queue, so walking over to another cone
+   * must not throw it away. Each entry is handed back the moment its cone is
+   * selected again.
    */
-  let stashedQueue: { jid: string; items: ChatMessage[] } | null = null;
+  const heldQueues = new Map<string, ChatMessage[]>();
 
   const selectScoop = (unit: WorkUnitSummary): void => {
     // The unit we are LEAVING, read before the assignment. It used to be the
@@ -328,14 +334,12 @@ function createSelection(deps: {
     selected = unit;
     const readOnly = isReadOnlyRole(unitRoleFor(unit));
     const host = deps.host();
-    stashedQueue = reconcileQueueForSwitch({
+    reconcileQueueForSwitch({
       controller: deps.controller(),
-      deleteQueued: (jid, id) => void host.deleteQueuedMessage(jid, id).catch(() => undefined),
       destination: unit.id,
+      held: heldQueues,
       previousJid,
-      readOnly,
       roster: deps.client().currentUnits(),
-      stashed: stashedQueue,
     });
     const cachedBackpressure = deps.lickBackpressure.get(unit.id);
     deps
@@ -411,6 +415,22 @@ function createSelection(deps: {
       selected = null;
     },
     getSelected: () => selected,
+    /**
+     * Park the selected cone's pile before something OTHER than a selection
+     * replaces the thread — thawing a frozen chat is the one such surface.
+     * It goes through the same per-cone hold, so re-selecting the cone hands
+     * the cards back exactly as a return from a scoop does.
+     */
+    holdQueue: () => {
+      const jid = selected?.id;
+      if (!jid) return;
+      holdQueuedPile({
+        controller: deps.controller(),
+        held: heldQueues,
+        jid,
+        roster: deps.client().currentUnits(),
+      });
+    },
     selectScoop,
   };
 }
@@ -507,6 +527,7 @@ export function prepareWcShell(app: HTMLElement, floatLabel: string): WcShellBoo
     selectScoop,
     getSelected: () => selection.getSelected(),
     clearSelection: () => selection.clear(),
+    holdQueuedPile: () => selection.holdQueue(),
     watchUnit,
     getController: () => controller,
     setController: (next) => {
@@ -1211,6 +1232,7 @@ export function attachWcWorkbench(
     getSelected: () => boot.getSelected(),
     selectScoop: boot.selectScoop,
     clearSelection: boot.clearSelection,
+    holdQueuedPile: boot.holdQueuedPile,
     log,
   });
   const { refreshFreezer, openFrozen, getViewedFrozenSessionId } = freezerRail;

--- a/packages/webapp/tests/ui/wc/wc-live-freezer-cone.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live-freezer-cone.test.ts
@@ -87,6 +87,8 @@ interface Harness {
   loaded: unknown[][];
   log: { debug: Mock; info: Mock; warn: Mock; error: Mock };
   clearCalls: Array<string | undefined>;
+  /** Thread-replacing steps of a thaw, in the order they happened. */
+  order: string[];
   selected: WorkUnitSummary | null;
   selections: string[];
   files: Map<string, string>;
@@ -97,6 +99,7 @@ function harness(selected: WorkUnitSummary | null): Harness {
   const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   const files = new Map<string, string>();
   const clearCalls: Array<string | undefined> = [];
+  const order: string[] = [];
   const selections: string[] = [];
   const freezer = document.createElement('slicc-freezer');
   freezer.append(document.createElement('slicc-freezer-new'));
@@ -128,6 +131,7 @@ function harness(selected: WorkUnitSummary | null): Harness {
     loaded,
     log,
     clearCalls,
+    order,
     selected,
     selections,
     files,
@@ -150,6 +154,7 @@ function harness(selected: WorkUnitSummary | null): Harness {
       ({
         loadMessages: (messages: unknown[]) => {
           loaded.push(messages);
+          order.push('load');
         },
       }) as never,
     getSelected: () => state.selected,
@@ -160,6 +165,9 @@ function harness(selected: WorkUnitSummary | null): Harness {
     },
     clearSelection: () => {
       state.selected = null;
+    },
+    holdQueuedPile: () => {
+      order.push('hold');
     },
     log: log as never,
   });
@@ -358,6 +366,10 @@ describe('thawed chats say which cone they came from (#2272)', () => {
     await state.handles.openFrozen('research.md');
 
     expect(state.loaded).toHaveLength(1);
+    // The cone's queued pile is parked BEFORE the archive takes the thread:
+    // `loadMessages` cancels whatever is still live, and reading an archive
+    // is not the user retracting a prompt the cone is committed to running.
+    expect(state.order).toEqual(['hold', 'load']);
     const caption = state.thread.querySelector('[data-frozen-provenance]');
     expect(caption?.getAttribute('label')).toBe('Frozen chat · from cone Research');
     expect(state.freezer.querySelector('[data-frozen-provenance]')).toBeNull();

--- a/packages/webapp/tests/ui/wc/wc-live-freezer-erase.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live-freezer-erase.test.ts
@@ -79,6 +79,7 @@ function harness() {
     getUnits: () => [recordToWorkUnitSummary(research, {})],
     selectScoop: vi.fn(),
     clearSelection: vi.fn(),
+    holdQueuedPile: vi.fn(),
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
   });
   return freezer;

--- a/packages/webapp/tests/ui/wc/wc-queue-cone-switch.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-queue-cone-switch.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+/**
+ * A cone's queued pile survives a switch to ANOTHER cone.
+ *
+ * Typing while a cone works stacks the prompt on the queued pile; the backend
+ * already holds it (every send is buffered synchronously). Walking over to a
+ * second cone to read what it is doing used to CANCEL that pile — the cards
+ * vanished and the orchestrator dropped the prompts — which reads as SLICC
+ * throwing away work the user already committed to. The pile belongs to the
+ * cone that owns it, so it is held per cone and re-installed on the way back.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { installWcDomStubs } from './wc-dom-stubs.js';
+
+installWcDomStubs();
+
+import type { RegisteredScoop } from '../../../src/scoops/types.js';
+import type { ChatMessage } from '../../../src/ui/types.js';
+import { WcChatController } from '../../../src/ui/wc/wc-chat-controller.js';
+import { prepareWcShell } from '../../../src/ui/wc/wc-live.js';
+import { createWcLiveCallbacks } from '../../../src/ui/wc/wc-live-callbacks.js';
+import { recordToWorkUnitSummary } from '../../../src/work-unit/client/from-record.js';
+import type { WorkUnitSummary } from '../../../src/work-unit/client/types.js';
+import { installLeaderChatHost, leaderChatHostFakes } from './leader-chat-host.js';
+
+function unit(over: Partial<RegisteredScoop>): RegisteredScoop {
+  return {
+    jid: 'jid',
+    name: 'name',
+    folder: 'folder',
+    isCone: over.parentJid === null,
+    type: over.parentJid === null ? 'cone' : 'scoop',
+    requiresTrigger: false,
+    assistantLabel: 'label',
+    addedAt: '2026-01-01T00:00:00.000Z',
+    parentJid: 'cone-1',
+    ...over,
+  } as RegisteredScoop;
+}
+
+const summaryOf = (record: RegisteredScoop): WorkUnitSummary => recordToWorkUnitSummary(record, {});
+
+const coneA = unit({ jid: 'cone-1', name: 'sliccy', folder: 'cone', parentJid: null });
+const coneB = unit({ jid: 'cone-2', name: 'research', folder: 'cone-research', parentJid: null });
+const scoopOfB = unit({ jid: 'scoop-3', name: 'helper', folder: 'helper', parentJid: 'cone-2' });
+const roster = [coneA, coneB, scoopOfB];
+
+function fakeClient(): Record<string, unknown> {
+  let selectedScoopJid: string | null = null;
+  return {
+    get selectedScoopJid() {
+      return selectedScoopJid;
+    },
+    setSelectedScoopJid: vi.fn((jid: string) => {
+      selectedScoopJid = jid;
+    }),
+    requestScoopMessages: vi.fn(),
+    isProcessing: vi.fn(() => false),
+    deleteQueuedMessage: vi.fn(async () => undefined),
+    getScoops: vi.fn(() => roster),
+    getScoop: vi.fn((jid: string) => roster.find((record) => record.jid === jid)),
+    ...leaderChatHostFakes(),
+  };
+}
+
+/** A controller stub whose pile behaves like the real stash/restore pair. */
+function fakeController(initial: readonly { id: string }[]) {
+  let live: unknown[] = [...initial];
+  return {
+    getQueuedMessages: vi.fn(() => live),
+    stashQueued: vi.fn(() => {
+      const taken = live;
+      live = [];
+      return taken;
+    }),
+    restoreQueued: vi.fn((items: unknown[]) => {
+      live = [...items];
+    }),
+    setLickBackpressure: vi.fn(),
+    setProcessing: vi.fn(),
+    setReadOnly: vi.fn(),
+  };
+}
+
+function bootShell(controller: ReturnType<typeof fakeController>) {
+  const app = document.createElement('div');
+  document.body.append(app);
+  const boot = prepareWcShell(app, 'test');
+  const client = fakeClient();
+  boot.setClient(client as never);
+  installLeaderChatHost(boot, client);
+  boot.setController(controller as never);
+  return {
+    boot,
+    deleted: () =>
+      (client.deleteQueuedMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+  };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe('queued pile across a cone switch', () => {
+  it('holds — never cancels — when leaving a working cone for another cone', () => {
+    const controller = fakeController([{ id: 'q1' }, { id: 'q2' }]);
+    const { boot, deleted } = bootShell(controller);
+
+    boot.selectScoop(summaryOf(coneA));
+    boot.selectScoop(summaryOf(coneB));
+
+    expect(deleted()).toHaveLength(0);
+    expect(controller.stashQueued).toHaveBeenCalledOnce();
+  });
+
+  it('re-installs the pile when the user comes back to the cone', () => {
+    const controller = fakeController([{ id: 'q1' }, { id: 'q2' }]);
+    const { boot, deleted } = bootShell(controller);
+
+    boot.selectScoop(summaryOf(coneA));
+    boot.selectScoop(summaryOf(coneB));
+    boot.selectScoop(summaryOf(coneA));
+
+    expect(controller.restoreQueued).toHaveBeenCalledWith([{ id: 'q1' }, { id: 'q2' }]);
+    expect(deleted()).toHaveLength(0);
+  });
+
+  it('keeps holding across a hop through a THIRD unit', () => {
+    const controller = fakeController([{ id: 'q1' }]);
+    const { boot, deleted } = bootShell(controller);
+
+    boot.selectScoop(summaryOf(coneA));
+    boot.selectScoop(summaryOf(coneB));
+    boot.selectScoop(summaryOf(scoopOfB));
+    boot.selectScoop(summaryOf(coneA));
+
+    expect(controller.restoreQueued).toHaveBeenCalledWith([{ id: 'q1' }]);
+    expect(deleted()).toHaveLength(0);
+  });
+
+  it('holds each cone’s pile separately', () => {
+    const controller = fakeController([{ id: 'a1' }]);
+    const { boot, deleted } = bootShell(controller);
+
+    boot.selectScoop(summaryOf(coneA));
+    boot.selectScoop(summaryOf(coneB));
+    // B's own pile, typed while B works.
+    controller.restoreQueued([{ id: 'b1' }]);
+    boot.selectScoop(summaryOf(coneA));
+    expect(controller.restoreQueued).toHaveBeenLastCalledWith([{ id: 'a1' }]);
+    boot.selectScoop(summaryOf(coneB));
+    expect(controller.restoreQueued).toHaveBeenLastCalledWith([{ id: 'b1' }]);
+    expect(deleted()).toHaveLength(0);
+  });
+});
+
+describe('the whole round trip, on the real controller', () => {
+  it('brings the cards back after a detour through another cone', () => {
+    const app = document.createElement('div');
+    document.body.append(app);
+    const boot = prepareWcShell(app, 'test');
+    const client = fakeClient();
+    boot.setClient(client as never);
+    installLeaderChatHost(boot, client);
+    const callbacks = createWcLiveCallbacks(boot.wiring);
+
+    const thread = document.createElement('slicc-chat-thread');
+    document.body.append(thread);
+    const controller = new WcChatController({
+      thread,
+      agent: {
+        onEvent: () => () => undefined,
+        sendMessage: () => undefined,
+        stop: () => undefined,
+      },
+    } as never);
+    boot.setController(controller as never);
+
+    // Cone A is working; the user types anyway, so the prompt stacks.
+    boot.selectScoop(summaryOf(coneA));
+    callbacks.onScoopMessagesReplaced?.('cone-1', [] as never, []);
+    controller.setProcessing(true);
+    controller.sendUserMessage('and then deploy it');
+    const queued = controller.getQueuedMessages() as unknown as { id: string }[];
+    expect(queued).toHaveLength(1);
+    const id = queued[0]?.id as string;
+
+    // Off to cone B to see what it is up to. The pile leaves the screen…
+    boot.selectScoop(summaryOf(coneB));
+    callbacks.onScoopMessagesReplaced?.('cone-2', [] as never, []);
+    expect(controller.getQueuedMessages()).toEqual([]);
+    expect(
+      (client.deleteQueuedMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    ).toHaveLength(0);
+
+    // …and comes back with it. The replay carries the prompt because every
+    // send is buffered, and the backend still lists it as pending — so it is
+    // a card, not a bubble.
+    boot.selectScoop(summaryOf(coneA));
+    const buffered = { id, role: 'user', content: 'and then deploy it', timestamp: 1 };
+    callbacks.onScoopMessagesReplaced?.('cone-1', [buffered] as never, [id]);
+    expect(
+      (controller.getQueuedMessages() as unknown as { id: string }[]).map((m) => m.id)
+    ).toEqual([id]);
+    expect(controller.getMessages().map((m: ChatMessage) => m.id)).toEqual([]);
+    controller.dispose();
+  });
+});
+
+describe('queued pile across a Freezer detour', () => {
+  /**
+   * Thawing a frozen chat replaces the thread WITHOUT a selection change —
+   * `openFrozen` calls `loadMessages` directly and then clears the selection —
+   * so the pile used to be cancelled by the very `onQueuedCancel` path a
+   * switch no longer takes. `holdQueuedPile()` parks it under the selected
+   * cone first, and re-selecting that cone hands it back.
+   */
+  it('holds the pile when a frozen chat takes the thread, and restores it', () => {
+    const controller = fakeController([{ id: 'q1' }]);
+    const { boot, deleted } = bootShell(controller);
+
+    boot.selectScoop(summaryOf(coneA));
+    // What `openFrozen` does before it paints the archive.
+    boot.holdQueuedPile();
+    expect(controller.stashQueued).toHaveBeenCalledOnce();
+    expect(deleted()).toHaveLength(0);
+
+    // Leaving the Freezer means selecting a cone again — with NO previous
+    // selection, since the thaw cleared it.
+    boot.clearSelection();
+    boot.selectScoop(summaryOf(coneA));
+    expect(controller.restoreQueued).toHaveBeenLastCalledWith([{ id: 'q1' }]);
+  });
+
+  it('is a no-op with nothing selected', () => {
+    const controller = fakeController([{ id: 'q1' }]);
+    const { boot } = bootShell(controller);
+    boot.holdQueuedPile();
+    expect(controller.stashQueued).not.toHaveBeenCalled();
+  });
+
+  it('does not hand the pile to a different cone on the way out of the Freezer', () => {
+    const controller = fakeController([{ id: 'q1' }]);
+    const { boot } = bootShell(controller);
+
+    boot.selectScoop(summaryOf(coneA));
+    boot.holdQueuedPile();
+    boot.clearSelection();
+
+    // Out of the Freezer into cone B: B has no pile of its own and must not
+    // inherit A's.
+    boot.selectScoop(summaryOf(coneB));
+    expect(controller.restoreQueued).not.toHaveBeenCalled();
+
+    boot.selectScoop(summaryOf(coneA));
+    expect(controller.restoreQueued).toHaveBeenCalledTimes(1);
+    expect(controller.restoreQueued).toHaveBeenCalledWith([{ id: 'q1' }]);
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-queue-cone-switch.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-queue-cone-switch.test.ts
@@ -259,3 +259,62 @@ describe('queued pile across a Freezer detour', () => {
     expect(controller.restoreQueued).toHaveBeenCalledWith([{ id: 'q1' }]);
   });
 });
+
+describe('a restore that has not landed yet stays with its own cone', () => {
+  /**
+   * `restoreQueued` arms a SINGLE pending slot that carries no unit id, and
+   * the replay it waits for is asynchronous. Leaving the cone again inside
+   * that window used to leave the slot armed, so the next unit's replay —
+   * another cone, or a Freezer thaw — consumed the pile and rendered one
+   * cone's queued prompts under another's thread (Codex P1 on this PR).
+   */
+  it('re-holds an armed restore when the user leaves before the replay lands', () => {
+    const app = document.createElement('div');
+    document.body.append(app);
+    const boot = prepareWcShell(app, 'test');
+    const client = fakeClient();
+    boot.setClient(client as never);
+    installLeaderChatHost(boot, client);
+    const callbacks = createWcLiveCallbacks(boot.wiring);
+
+    const thread = document.createElement('slicc-chat-thread');
+    document.body.append(thread);
+    const controller = new WcChatController({
+      thread,
+      agent: {
+        onEvent: () => () => undefined,
+        sendMessage: () => undefined,
+        stop: () => undefined,
+      },
+    } as never);
+    boot.setController(controller as never);
+    const ids = () =>
+      (controller.getQueuedMessages() as unknown as { id: string }[]).map((m) => m.id);
+
+    boot.selectScoop(summaryOf(coneA));
+    callbacks.onScoopMessagesReplaced?.('cone-1', [] as never, []);
+    controller.setProcessing(true);
+    controller.sendUserMessage('and then deploy it');
+    const id = ids()[0] as string;
+
+    boot.selectScoop(summaryOf(coneB));
+    callbacks.onScoopMessagesReplaced?.('cone-2', [] as never, []);
+
+    // Back to A — the restore is armed — and straight out again before A's
+    // snapshot has had a chance to arrive.
+    boot.selectScoop(summaryOf(coneA));
+    boot.selectScoop(summaryOf(coneB));
+
+    // B's replay must not inherit A's pile.
+    callbacks.onScoopMessagesReplaced?.('cone-2', [] as never, []);
+    expect(ids()).toEqual([]);
+    expect(controller.getMessages()).toEqual([]);
+
+    // A still owns it.
+    boot.selectScoop(summaryOf(coneA));
+    const buffered = { id, role: 'user', content: 'and then deploy it', timestamp: 1 };
+    callbacks.onScoopMessagesReplaced?.('cone-1', [buffered] as never, [id]);
+    expect(ids()).toEqual([id]);
+    controller.dispose();
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-queue-reconcile.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-queue-reconcile.test.ts
@@ -231,6 +231,38 @@ describe('no authoritative answer', () => {
   });
 });
 
+describe('an armed restore is disarmed by the next stash', () => {
+  // `#pendingQueueRestore` carries no unit id and waits on an asynchronous
+  // replay. If the host leaves before that replay lands, the slot has to come
+  // back out with the pile — otherwise the NEXT unit's `loadMessages` consumes
+  // it and one cone's cards render under another's thread (Codex P1 on #2959).
+
+  it('hands the un-applied restore back to the stash', () => {
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1')]);
+    expect(controller.stashQueued().map((m) => m.id)).toEqual(['q1']);
+    // The slot is empty now, so a replay for some OTHER unit takes nothing.
+    controller.loadMessages([], ['q1']);
+    expect(queuedIds()).toEqual([]);
+  });
+
+  it('carries the live pile out behind the held one', () => {
+    const { controller } = makeController();
+    controller.setProcessing(true);
+    controller.sendUserMessage('typed after the selection');
+    controller.restoreQueued([prompt('q1')]);
+    const stashed = controller.stashQueued();
+    expect(stashed).toHaveLength(2);
+    expect(stashed[0]?.id).toBe('q1');
+    expect(stashed[1]?.content).toBe('typed after the selection');
+  });
+
+  it('is a no-op when neither a pile nor a restore is waiting', () => {
+    const { controller } = makeController();
+    expect(controller.stashQueued()).toEqual([]);
+  });
+});
+
 describe('one-shot', () => {
   it('does not resurrect the pile on a later reload', () => {
     const { controller, queuedIds } = makeController();

--- a/packages/webapp/tests/ui/wc/wc-readonly-scoop.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-readonly-scoop.test.ts
@@ -168,11 +168,12 @@ describe('read-only scoop view (leader)', () => {
     expect(client.deleteQueuedMessage.mock.calls).toHaveLength(0);
   });
 
-  it('cancels — never stashes — when leaving a cone for ANOTHER cone’s scoop (Codex P1)', () => {
-    // Preserving on "destination is read-only" alone was wrong: hopping from
-    // cone A straight to a scoop owned by cone B is the user going elsewhere
-    // to work, so A's queued prompt is abandoned and must not stay live on
-    // the backend just because the tab we landed on has no composer.
+  it('holds — never cancels — when leaving a cone for ANOTHER cone’s scoop', () => {
+    // Hopping from cone A straight to a scoop owned by cone B is the user
+    // going elsewhere to READ, not a retraction: A's prompt was handed to A's
+    // backend queue the moment it was typed and A is still working through it.
+    // Cancelling it here made the cards (and the work) vanish on a switch,
+    // which is the surprise this replaced.
     const boot = bootShell();
     const stashed = [{ id: 'q1' }];
     let live: unknown[] = stashed;
@@ -198,8 +199,12 @@ describe('read-only scoop view (leader)', () => {
     boot.selectScoop(summaryOf(cone));
     boot.selectScoop(summaryOf(otherScoop));
 
-    expect(controller.stashQueued).not.toHaveBeenCalled();
-    expect(client.deleteQueuedMessage.mock.calls).toEqual([['cone-1', 'q1']]);
+    expect(controller.stashQueued).toHaveBeenCalledOnce();
+    expect(client.deleteQueuedMessage.mock.calls).toHaveLength(0);
+
+    // …and it is still there on the way back.
+    boot.selectScoop(summaryOf(cone));
+    expect(controller.restoreQueued).toHaveBeenCalledWith(stashed);
   });
 
   it('keeps holding across a SIBLING scoop of the same cone, then restores', () => {
@@ -235,22 +240,25 @@ describe('read-only scoop view (leader)', () => {
     expect(client.deleteQueuedMessage.mock.calls).toHaveLength(0);
   });
 
-  it('cancels a held pile once the user lands on a DIFFERENT cone', () => {
+  it('keeps a held pile alive while the user works in a DIFFERENT cone', () => {
     const boot = bootShell();
     const stashed = [{ id: 'q1' }];
     let live: unknown[] = stashed;
-    boot.setController({
+    const controller = {
       getQueuedMessages: vi.fn(() => live),
       stashQueued: vi.fn(() => {
         const taken = live;
         live = [];
         return taken;
       }),
-      restoreQueued: vi.fn(),
+      restoreQueued: vi.fn((items: unknown[]) => {
+        live = [...items];
+      }),
       setLickBackpressure: vi.fn(),
       setProcessing: vi.fn(),
       setReadOnly: vi.fn(),
-    } as never);
+    };
+    boot.setController(controller as never);
     const client = boot.wiring.getClient() as unknown as {
       deleteQueuedMessage: { mock: { calls: unknown[][] } };
       getScoops: { mockReturnValue(v: unknown): void };
@@ -260,7 +268,9 @@ describe('read-only scoop view (leader)', () => {
     boot.selectScoop(summaryOf(worker));
     boot.selectScoop(summaryOf(otherCone));
 
-    expect(client.deleteQueuedMessage.mock.calls).toEqual([['cone-1', 'q1']]);
+    expect(client.deleteQueuedMessage.mock.calls).toHaveLength(0);
+    boot.selectScoop(summaryOf(cone));
+    expect(controller.restoreQueued).toHaveBeenLastCalledWith(stashed);
   });
 
   it('applies with the multiple-cones flag OFF — it is not part of that experiment', () => {


### PR DESCRIPTION
## Summary

Typing while a cone is working stacks the prompt as a queue card. Switching to another cone used to **clear that pile — and cancel it on the backend**, so the orchestrator dropped prompts the user had already committed to. Now a selection change never cancels: the pile is held per cone and re-installed when the user comes back to it. The Freezer's thaw, which reached the same cancel path by a different route, takes the same hold.

## Why

The pile is not a draft. `Bridge.handleUserMessage` buffers every prompt the moment it is sent, so a queued card is work the cone has already accepted and is still going to run. Glancing at a second cone is not a retraction, but `reconcileQueueForSwitch` treated it as one: it held the pile for exactly one case — a read-only detour into a scoop of the *same* cone (#2312) — and fired `deleteQueuedMessage` per id for everything else.

**Repro** (before this PR):

1. Send a prompt to cone A so it starts working.
2. Type a second prompt and hit send — it appears as a card on the queued pile.
3. Click cone B in the tab strip, then click cone A again.

- Expected: the card is still there, and A runs it when the turn ends.
- Actual: the pile is empty and the prompt is gone from A's backend queue — it never runs.

Same thing with step 3 replaced by "open a frozen chat from the Freezer, then click cone A".

## Approach / Implementation notes

- `reconcileQueueForSwitch` (`ui/wc/wc-live.ts`) no longer takes `deleteQueued` / `readOnly`. It stashes into a per-cone `heldQueues` map and restores from it; the read-only-detour special case is gone because every switch now behaves that way.
- **Ordering is load-bearing**: the stash must happen *before* the selection moves. `loadMessages` cancels whatever pile is still live via `onQueuedCancel` — correct for a session reload, wrong for a switch.
- **Keyed by the owning cone**, not the unit being left, so a hop between two of a cone's scoops cannot re-key the hold onto a jid no destination could ever match. A unit missing from the roster has no knowable owner (`rootForSelection` would fall back to the *default* root and read as some other cone's pile), so it is held under its own jid — a hold only its own unit can claim.
- **Restoring keys off the destination alone.** That is what lets the Freezer detour work: `openFrozen` clears the selection, so the return trip has no `previousJid`.
- **Coming home reuses the existing #2354 reconcile** (`#applyPendingQueueRestore`): prompts the cone consumed while the user was away arrive as bubbles, not phantom cards, and the backend's `queuedIds` order wins over the held order.
- **Pruning** of held entries runs only against a roster that demonstrably knows the current selection, so a transiently empty roster cannot eat a live pile.
- Rejected: making `clearSelection()` itself hold. The Freezer calls it *after* `loadMessages`, so it would have been too late, and moving the call earlier would have changed the meaning of the thaw's error-path fallback.
- `wireFreezerRail` was at the 150-line function ceiling, so the thawed-view chrome moved into a `paintFrozenChrome` helper. No behaviour change in that extraction.

## Cross-cutting impact

- **Floats exercised**: this is shell code (`ui/wc/`), so leader (CLI / Electron / Sliccstart / cloud) and follower share it. A tray follower reports no `queuedIds` (its queue lives on the leader) and that path is unchanged — `undefined` still means "no authority", held order stands. iOS has no queued-pile surface at all.
- **Other callers of the changed contract**: `WcChatController.stashQueued` / `restoreQueued` / `loadMessages` are unchanged; only who calls `stashQueued`, and how often, changed. `getQueuedMessages()` lost its last production caller (it was only read to build the cancel list) and remains as the read accessor the tests observe through.
- **Backend**: strictly *fewer* `deleteQueuedMessage` RPCs. The `×` dismiss button is now the only thing that cancels a queued prompt, which is the affordance that says so.
- **Persisted state**: none. `heldQueues` is in-memory for the life of the shell, bounded by the number of cones visited with a pile, and drained when a cone is re-selected or leaves the roster.
- **New dependencies**: none.

## Test plan

- [x] `npm run verify` — all 8 gates (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `npm run typecheck`
- [x] `npm run test` — 20441 passing, no new failures
- [x] `npm run test:coverage:webapp` — above floor
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] **New / changed behavior is covered by a unit test**: `npx vitest run packages/webapp/tests/ui/wc/wc-queue-cone-switch.test.ts` — 8 tests driving the real `boot.selectScoop`, including one full round trip on a real `WcChatController` through a real replay envelope (card → switch → card back, and *not* also a bubble).
  - **All 8 fail on `main`**, verified by swapping the pre-change `wc-live.ts` back in.
  - The two Freezer tests were separately mutation-checked against a neutered `holdQueuedPile` — both fail, so neither is self-satisfying.
- [x] `wc-readonly-scoop.test.ts`: the two tests that asserted cancel-on-switch now assert the hold.
- [x] `wc-live-freezer-cone.test.ts`: pins the hold-**before**-load ordering inside `openFrozen`.
- [ ] Manual smoke — not run; no visual change to record. The pile renders exactly as before, it just stops disappearing.

**Pre-existing failures**: none observed.

## Documentation

- [x] `docs/` — `docs/work-unit.md`, the read-only-scoop section that documented cancel-on-switch as intended behaviour, rewritten for the per-cone hold plus the Freezer's use of it
- [x] No other tier applies (no user-facing README surface, no shell-command or agent-skill change)

## Risk & rollback

- Blast radius: the queued pile in the WC shell, every float. A regression would show as a stale card that never clears — the #2354 reconcile is what prevents that, and it is unchanged and still covered by `wc-queue-reconcile.test.ts`.
- No feature flag, no persisted state, no migration. Reverts cleanly.
- Worth a hand check before approving: queue two prompts on a working cone, bounce through a scoop / another cone / a frozen chat, and confirm the cards come home in the backend's order and clear normally when the cone consumes them.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] Contract used by other floats: checked the follower path (no `queuedIds` authority, held order preserved) and the leader/offscreen cancel seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)
