### PR TITLE
fix(webapp): refresh hosted model picker after bootstrap

### DIFF
--- a/docs/webapp-details.md
+++ b/docs/webapp-details.md
@@ -171,7 +171,7 @@ One roster, three renderings, one vocabulary — `ui/follower-presentation.ts` o
 - **URL state**: `ctx` (active context, pushed), `at` (scroll pos, debounced replace), `ws` (open workspace surface). No global manager; the host only routes.
 - **Cherry `?cherry=1`** (`main-cherry.ts`): builds `CherryHostTransport` against `window.parent`, reads `joinUrl` from handshake, wraps `BrowserAPI`. Origin detection: see CDP section.
 - **Cherry `?cherry=1&ui-only=1`** (extension side panel): suppresses CDP target advertisement, skips `ptt`, drops "Take a photo" (mic denied in cross-origin side panel). Login/onboarding hand-off to the leader tab is gated to `isExtensionSidePanel` only.
-- **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts` reconciles accounts from `/api/hosted-bootstrap`, removing only providers tracked in `localStorage['slicc_cloud_managed']` — never user-added ones. `?connect=1` is a login-only surface (`ui/connect-surface.ts`) with no kernel.
+- **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts` reconciles accounts from `/api/hosted-bootstrap`, removing only providers tracked in `localStorage['slicc_cloud_managed']` — never user-added ones. Hosted bootstrap pre-warms dynamic provider catalogs before applying those accounts, then dispatches `slicc:accounts-changed` so the already-mounted model picker and tray rebuild from the warmed catalog; same-document storage writes do not emit `storage`. `?connect=1` is a login-only surface (`ui/connect-surface.ts`) with no kernel.
 
 ## Markdown media in messages
 

--- a/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
@@ -63,6 +63,11 @@ export async function runHostedBootstrap(deps: RunHostedBootstrapDeps): Promise<
       previouslyManaged: () => prevManaged,
     });
     localStorage.setItem('slicc_cloud_managed', JSON.stringify(accounts.map((a) => a.providerId)));
+    // The nav is already mounted by the time this delayed bootstrap pre-warms
+    // dynamic provider catalogs. Same-document localStorage writes do not emit
+    // a storage event, so announce the completed reconciliation explicitly;
+    // the picker and tray listeners can now rebuild from the warmed catalog.
+    window.dispatchEvent(new CustomEvent('slicc:accounts-changed'));
     log.info('hosted-leader: cone config applied', { count: accounts.length });
   } catch (err) {
     log.warn('hosted-leader: bootstrap fetch failed; provider needs manual login', {

--- a/packages/webapp/tests/ui/boot/setup-standalone-tray-init-hosted.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-tray-init-hosted.test.ts
@@ -100,4 +100,31 @@ describe('runHostedBootstrap — thin-bridge routing', () => {
 
     fetchSpy.mockRestore();
   });
+
+  it('announces warmed hosted accounts so the mounted model picker refreshes', async () => {
+    setLocalApiBaseUrl('http://localhost:5710');
+    setBridgeToken('tok');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          accounts: [{ providerId: 'adobe', kind: 'oauth', accessToken: 'x' }],
+        }),
+        { status: 200 }
+      )
+    );
+    const onAccountsChanged = vi.fn();
+    window.addEventListener('slicc:accounts-changed', onAccountsChanged);
+
+    try {
+      const done = runHostedBootstrap({ log });
+      await vi.advanceTimersByTimeAsync(5500);
+      await done;
+
+      expect(onAccountsChanged).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener('slicc:accounts-changed', onAccountsChanged);
+      fetchSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- notify mounted UI surfaces after hosted bootstrap warms dynamic provider catalogs and reconciles accounts
- make Adobe Presto appear in the composer model selector without a reload
- add regression coverage and document the hosted bootstrap refresh contract

## Root cause

The hosted bootstrap wrote the warmed Adobe catalog and account state after the navigation UI had mounted. Same-document localStorage writes do not emit a storage event, so the model selector kept its initial stale catalog until another accounts-changed event occurred.

## Testing

- npm run verify
- node packages/dev-tools/tools/check-touched-exemptions.mjs
- npm run typecheck
- npm run test
- npm run test:coverage
- npm run build
- npm run build -w @slicc/chrome-extension
- npm run bundle-size
- live reproduction against Sliccstart.app over CDP 9222