### PR TITLE
Fix Adobe login SW race; default dev harness to hosted origin

### DIFF
--- a/.agents/skills/cdp-smoke-test/SKILL.md
+++ b/.agents/skills/cdp-smoke-test/SKILL.md
@@ -27,21 +27,28 @@ belong to the developer's production SLICC. Never bind, reap, or kill either
 port. The smoke-test lane uses bridge `:5715`; its Chrome CDP port is
 auto-resolved.
 
+### Default mode — hosted origin (recommended)
+
+Chrome opens `https://www.sliccy.ai` with a `?bridge=ws://localhost:5715/cdp`
+parameter that routes it back to the local node-server. No wrangler needed.
+OAuth, IMS (Adobe), and all provider relays work out of the box because they
+are hosted on the production origin.
+
 ```bash
 # 1. Record production listeners before doing anything else.
 PROD_BRIDGE_PIDS=$(lsof -nP -tiTCP:5710 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
 PROD_CDP_PIDS=$(lsof -nP -tiTCP:9222 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
 printf 'production preflight: :5710=%s :9222=%s\n' "${PROD_BRIDGE_PIDS:-none}" "${PROD_CDP_PIDS:-none}"
 
-# 2. Build the latest code (cherry regenerates worker bridge assets).
+# 2. Build only node-server (no webapp build required — UI loads from sliccy.ai).
 npm install
-npm run build -w @ai-ecoverse/cherry -w @slicc/webapp -w @slicc/node-server
+npm run build -w @slicc/node-server
 
-# 3. Launch — wrangler :8787, isolated bridge :5715, ephemeral profile.
+# 3. Launch — hosted origin, isolated bridge :5715, ephemeral profile.
 #    CHROME_PATH is optional; default is a labeled Chrome for Testing clone.
 export SLICC_HARNESS_LOG=/tmp/slicc-dev-harness-5715.log
 CHROME_PATH="/Applications/Google Chrome Canary.app" \
-  PORT=5715 WRANGLER_PORT=8787 \
+  PORT=5715 \
   nohup npm run dev:standalone:fresh > "$SLICC_HARNESS_LOG" 2>&1 &
 
 # 4. Wait for boot and export the auto-resolved CDP port from this lane's log.
@@ -55,6 +62,35 @@ POST_BRIDGE_PIDS=$(lsof -nP -tiTCP:5710 -sTCP:LISTEN 2>/dev/null | sort -n | pas
 POST_CDP_PIDS=$(lsof -nP -tiTCP:9222 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
 test "$POST_BRIDGE_PIDS" = "$PROD_BRIDGE_PIDS" && test "$POST_CDP_PIDS" = "$PROD_CDP_PIDS"
 ```
+
+The browser URL will be:
+
+```text
+https://www.sliccy.ai/?bridge=ws%3A%2F%2Flocalhost%3A5715%2Fcdp&bridgeToken=<token>…
+```
+
+`bridge=` connects the hosted UI back to the local node-server; `bridgeToken=`
+gates the bridge WebSocket. The UI is always served from `sliccy.ai` — the
+local process is only the CDP/API relay.
+
+### Alternate mode — local wrangler dev server
+
+Only needed when developing the Cloudflare worker itself. Set
+`WORKER_BASE_URL` to point at your local wrangler instance. **OAuth and IMS
+(Adobe) will not work from `localhost` origins** — use the hosted-origin mode
+for any provider login testing.
+
+```bash
+export SLICC_HARNESS_LOG=/tmp/slicc-dev-harness-5715.log
+CHROME_PATH="/Applications/Google Chrome Canary.app" \
+  PORT=5715 WORKER_BASE_URL=http://localhost:8787 \
+  nohup npm run dev:standalone:fresh > "$SLICC_HARNESS_LOG" 2>&1 &
+```
+
+This also starts wrangler on `:8787` (or reuses an existing one). A full
+build (`npm run build -w @ai-ecoverse/cherry -w @slicc/webapp -w
+@slicc/node-server`) is required beforehand so wrangler has `dist/ui/` to
+serve.
 
 Attach the console watcher before testing — a clean log at the end is part
 of the pass criteria. Reset the log first (it appends, so a stale error

--- a/.agents/skills/cdp-smoke-test/SKILL.md
+++ b/.agents/skills/cdp-smoke-test/SKILL.md
@@ -34,6 +34,13 @@ parameter that routes it back to the local node-server. No wrangler needed.
 OAuth, IMS (Adobe), and all provider relays work out of the box because they
 are hosted on the production origin.
 
+> **Important:** in this mode the browser loads the **deployed production
+> webapp** from `sliccy.ai`, not your local checkout. Changes to
+> `packages/webapp/` are not exercised. Use this mode for:
+> smoke-testing the node-server bridge, provider login flows, tray and
+> scoops features, and CDP automation. Use the local-wrangler mode below
+> when you need to verify a webapp change end-to-end before deploying.
+
 ```bash
 # 1. Record production listeners before doing anything else.
 PROD_BRIDGE_PIDS=$(lsof -nP -tiTCP:5710 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
@@ -75,10 +82,14 @@ local process is only the CDP/API relay.
 
 ### Alternate mode — local wrangler dev server
 
-Only needed when developing the Cloudflare worker itself. Set
-`WORKER_BASE_URL` to point at your local wrangler instance. **OAuth and IMS
-(Adobe) will not work from `localhost` origins** — use the hosted-origin mode
-for any provider login testing.
+Use when you need to test a local **webapp** or **worker** change before
+deploying. Set `WORKER_BASE_URL` to a loopback URL; the port is derived from
+the URL automatically. **OAuth and IMS (Adobe) will not work from `localhost`
+origins** — use the hosted-origin mode for any provider login testing.
+
+For explicit non-loopback staging/alternate origins (e.g.
+`WORKER_BASE_URL=https://slicc-staging.example.workers.dev`), the script uses
+that URL directly without starting wrangler.
 
 ```bash
 export SLICC_HARNESS_LOG=/tmp/slicc-dev-harness-5715.log

--- a/packages/dev-tools/tools/dev-standalone-fresh.sh
+++ b/packages/dev-tools/tools/dev-standalone-fresh.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
-# dev:standalone:fresh — launch the two-service standalone harness
-# (wrangler UI + node-server thin-bridge) with a brand-new Chrome for
-# Testing profile. Fails fast when its bridge port is occupied and uses an
-# ephemeral profile so the session starts clean without disturbing concurrent
-# harnesses. Set SLICC_FRESH_REAP=1 to explicitly reap the bridge holder.
+# dev:standalone:fresh — launch the node-server thin-bridge with a brand-new
+# Chrome profile pointing at the leader UI origin. Fails fast when its bridge
+# port is occupied. Set SLICC_FRESH_REAP=1 to explicitly reap the holder.
+#
+# Default (recommended): UI loads from https://www.sliccy.ai — no wrangler
+# or webapp build needed. OAuth / IMS / GitHub relays work out of the box.
+#
+# Local-worker mode (worker development only): set WORKER_BASE_URL to a
+# loopback URL (e.g. http://localhost:8787). Wrangler is started at that
+# port and the webapp is served locally. OAuth will NOT work from localhost.
 #
 # Usage:
 #   npm run dev:standalone:fresh
-#   PORT=5720 npm run dev:standalone:fresh   # override bridge port
+#   PORT=5720 npm run dev:standalone:fresh
 #   CHROME_PATH="/Applications/Google Chrome Canary.app" npm run dev:standalone:fresh
-#                                            # launch your own browser instead
-#                                            # of Chrome for Testing
+#   WORKER_BASE_URL=http://localhost:8787 npm run dev:standalone:fresh  # local worker
 #
-# Prerequisites:
-#   - npm run build  (or at least webapp + node-server)
-#   - npx playwright install chromium
+# Prerequisites (hosted-origin default):
+#   - npm run build -w @slicc/node-server
+#   - npx playwright install chromium  (or set CHROME_PATH)
+#
+# Additional prerequisites for local-worker mode:
+#   - npm run build  (full build — webapp + node-server)
+#   - npx playwright install chromium  (or set CHROME_PATH)
 set -euo pipefail
 
 # Documented production bridge: valid when free, never eligible for automated reaping.
@@ -131,15 +139,39 @@ if ! BRIDGE_PORT="$(canonicalize_port "$BRIDGE_PORT_INPUT")"; then
 fi
 WRANGLER_PORT="${WRANGLER_PORT:-8787}"
 
-# Effective leader UI origin.
-# Default: the production hosted webapp (https://www.sliccy.ai) — no wrangler
-# needed, OAuth and IMS relays work out of the box.
-# Override: set WORKER_BASE_URL=http://localhost:8787 (or any wrangler URL) to
-# develop against a local worker build instead.
-EFFECTIVE_WORKER_BASE_URL="${WORKER_BASE_URL:-}"
-USE_HOSTED_ORIGIN=1
-if [ -n "$EFFECTIVE_WORKER_BASE_URL" ]; then
-	USE_HOSTED_ORIGIN=0
+# ── Classify the leader UI origin ────────────────────────────────────
+# Unset WORKER_BASE_URL → hosted origin (https://www.sliccy.ai), no wrangler.
+# Loopback WORKER_BASE_URL → local wrangler; wrangler port derived from URL.
+# Non-loopback WORKER_BASE_URL (staging, another hosted origin) → use directly,
+#   no wrangler started.
+url_host() { printf '%s' "$1" | sed -nE 's|^https?://([^/:]+).*|\1|p'; }
+url_port() { printf '%s' "$1" | sed -nE 's|^https?://[^/:]+:([0-9]+).*|\1|p'; }
+is_loopback_host() {
+	case "${1:-}" in localhost|127.0.0.1|"[::1]") return 0;; *) return 1;; esac
+}
+
+USE_LOCAL_WRANGLER=0
+if [ -z "${WORKER_BASE_URL:-}" ]; then
+	EFFECTIVE_WORKER_BASE_URL="https://www.sliccy.ai"
+elif is_loopback_host "$(url_host "$WORKER_BASE_URL")"; then
+	EFFECTIVE_WORKER_BASE_URL="$WORKER_BASE_URL"
+	USE_LOCAL_WRANGLER=1
+	# Derive the wrangler port from the URL; fail fast on a mismatch with an
+	# explicit WRANGLER_PORT override so the opened URL always matches what
+	# was started.
+	URL_PORT="$(url_port "$WORKER_BASE_URL")"
+	if [ -n "$URL_PORT" ]; then
+		if [ "${WRANGLER_PORT}" != "8787" ] && [ "$URL_PORT" != "$WRANGLER_PORT" ]; then
+			echo "❌  WORKER_BASE_URL port ($URL_PORT) conflicts with WRANGLER_PORT ($WRANGLER_PORT)" >&2
+			echo "    Either omit WRANGLER_PORT or set it to $URL_PORT." >&2
+			exit 1
+		fi
+		WRANGLER_PORT="$URL_PORT"
+	fi
+else
+	# Explicit non-loopback origin (staging, another hosted env, etc.) —
+	# use directly without starting wrangler.
+	EFFECTIVE_WORKER_BASE_URL="$WORKER_BASE_URL"
 fi
 
 # ── 1. Guard the bridge port ─────────────────────────────────────────
@@ -239,22 +271,11 @@ STAGING_GH_CLIENT_ID="Ov23liUe1b3b6GDjPGz4"
 STARTED_WRANGLER=0
 WRANGLER_PID=""
 
-if [ "$USE_HOSTED_ORIGIN" -eq 1 ]; then
-	# ── Default: use the production hosted webapp ─────────────────────
-	# https://www.sliccy.ai is the UI origin; the local node-server is only
-	# the CDP/API bridge. No wrangler needed. OAuth, IMS, and all provider
-	# relays work out of the box.
-	EFFECTIVE_WORKER_BASE_URL="https://www.sliccy.ai"
-	echo "✔  Using hosted origin: $EFFECTIVE_WORKER_BASE_URL"
-else
-	# ── Opt-in: local wrangler dev server ────────────────────────────
-	# Use WORKER_BASE_URL=http://localhost:8787 to test a local worker build.
-	# The local wrangler serves the SPA but is NOT the real OAuth relay —
-	# IMS and GitHub OAuth will not work correctly from localhost origins.
-	echo "🌐  Using local worker origin: $EFFECTIVE_WORKER_BASE_URL"
-
+if [ "$USE_LOCAL_WRANGLER" -eq 1 ]; then
+	# ── Local wrangler mode ──────────────────────────────────────────
 	# Build the leader UI — wrangler serves dist/ui via the ASSETS binding;
 	# when dist/ui/index.html is absent every route 404s.
+	echo "🌐  Using local wrangler origin: $EFFECTIVE_WORKER_BASE_URL (wrangler :${WRANGLER_PORT})"
 	if [ -f "${REPO_ROOT}/dist/ui/index.html" ]; then
 		echo "✔  Leader UI present (dist/ui/index.html)"
 	else
@@ -266,7 +287,6 @@ else
 		fi
 		echo "✔  Leader UI built (dist/ui/index.html)"
 	fi
-
 	if wrangler_up; then
 		echo "✔  Reusing existing wrangler on :${WRANGLER_PORT} (not started by us)"
 	else
@@ -297,6 +317,11 @@ else
 			sleep 1
 		done
 	fi
+else
+	# ── Hosted or explicit remote origin ───────────────────────────────
+	# UI loads from the remote origin; node-server is only the bridge.
+	# No wrangler, no local webapp build.
+	echo "✔  Using remote origin (no wrangler): $EFFECTIVE_WORKER_BASE_URL"
 fi
 
 # ── 5. Cleanup trap (kills ONLY our own processes) ───────────────────
@@ -323,7 +348,7 @@ echo ""
 # so the node-server accepts cross-origin /api requests from it. Empty string
 # for the hosted-origin mode — the node-server treats that as an empty set,
 # and https://www.sliccy.ai is already in the hard-coded BRIDGE_ALLOWED_ORIGINS.
-if [ "$USE_HOSTED_ORIGIN" -eq 0 ]; then
+if [ "$USE_LOCAL_WRANGLER" -eq 1 ]; then
 	BRIDGE_DEV_ALLOWED_ORIGINS_VAL="$EFFECTIVE_WORKER_BASE_URL"
 else
 	BRIDGE_DEV_ALLOWED_ORIGINS_VAL=""

--- a/packages/dev-tools/tools/dev-standalone-fresh.sh
+++ b/packages/dev-tools/tools/dev-standalone-fresh.sh
@@ -131,6 +131,17 @@ if ! BRIDGE_PORT="$(canonicalize_port "$BRIDGE_PORT_INPUT")"; then
 fi
 WRANGLER_PORT="${WRANGLER_PORT:-8787}"
 
+# Effective leader UI origin.
+# Default: the production hosted webapp (https://www.sliccy.ai) — no wrangler
+# needed, OAuth and IMS relays work out of the box.
+# Override: set WORKER_BASE_URL=http://localhost:8787 (or any wrangler URL) to
+# develop against a local worker build instead.
+EFFECTIVE_WORKER_BASE_URL="${WORKER_BASE_URL:-}"
+USE_HOSTED_ORIGIN=1
+if [ -n "$EFFECTIVE_WORKER_BASE_URL" ]; then
+	USE_HOSTED_ORIGIN=0
+fi
+
 # ── 1. Guard the bridge port ─────────────────────────────────────────
 if is_protected_port "$BRIDGE_PORT"; then
 	echo "❌  Bridge port :$BRIDGE_PORT is reserved for Chrome/Electron CDP and cannot be reaped" >&2
@@ -221,64 +232,71 @@ fi
 FRESH_PROFILE="$(mktemp -d)"
 echo "✔  Fresh profile: $FRESH_PROFILE"
 
-# ── 4. Wrangler config + leader UI build ─────────────────────────────
-# The local wrangler serves the SPA but is NOT the real OAuth relay.
-# Override GITHUB_CLIENT_ID → staging so the webapp picks up the correct
-# client ID, and TRAY_WORKER_BASE_URL_OVERRIDE → staging relay so the
-# runtime-config response points trayWorkerBaseUrl at the real relay
-# (not at the wrangler's own localhost origin).
+# ── 4. Leader UI origin ──────────────────────────────────────────────
 STAGING_WORKER="https://slicc-tray-hub-staging.minivelos.workers.dev"
 STAGING_GH_CLIENT_ID="Ov23liUe1b3b6GDjPGz4"
 
-# Build the leader UI (dist/ui) if missing — wrangler serves dist/ui via the
-# ASSETS binding with SPA fallback; when dist/ui/index.html is absent every
-# route 404s and the leader never loads. Build on demand (fast no-op when
-# present), hard-failing if the build does not produce it.
-if [ -f "${REPO_ROOT}/dist/ui/index.html" ]; then
-	echo "✔  Leader UI present (dist/ui/index.html)"
-else
-	echo "🏗  Building leader UI (npm run build -w @slicc/webapp)…"
-	npm run build -w @slicc/webapp
-	if [ ! -f "${REPO_ROOT}/dist/ui/index.html" ]; then
-		echo "❌  Leader UI build did not produce ${REPO_ROOT}/dist/ui/index.html"
-		exit 1
-	fi
-	echo "✔  Leader UI built (dist/ui/index.html)"
-fi
-
-
-# ── 4b. Reuse-or-start wrangler (UI / leader origin on :8787) ────────
 STARTED_WRANGLER=0
 WRANGLER_PID=""
-if wrangler_up; then
-	echo "✔  Reusing existing wrangler on :${WRANGLER_PORT} (not started by us)"
+
+if [ "$USE_HOSTED_ORIGIN" -eq 1 ]; then
+	# ── Default: use the production hosted webapp ─────────────────────
+	# https://www.sliccy.ai is the UI origin; the local node-server is only
+	# the CDP/API bridge. No wrangler needed. OAuth, IMS, and all provider
+	# relays work out of the box.
+	EFFECTIVE_WORKER_BASE_URL="https://www.sliccy.ai"
+	echo "✔  Using hosted origin: $EFFECTIVE_WORKER_BASE_URL"
 else
-	echo "🌐  Starting wrangler on :${WRANGLER_PORT}…"
-	npx wrangler dev \
-		--config "${REPO_ROOT}/packages/cloudflare-worker/wrangler.jsonc" \
-		--port "$WRANGLER_PORT" --ip 127.0.0.1 \
-		--var "GITHUB_CLIENT_ID:${STAGING_GH_CLIENT_ID}" \
-		--var "TRAY_WORKER_BASE_URL_OVERRIDE:${STAGING_WORKER}" &
-	WRANGLER_PID=$!
-	STARTED_WRANGLER=1
-	for i in $(seq 1 30); do
-		if wrangler_up; then
-			echo "✔  Wrangler ready on :${WRANGLER_PORT}"
-			break
-		fi
-		if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
-			echo "❌  Wrangler exited before binding :${WRANGLER_PORT}"
-			echo "    If something else already holds that port, it is not the SLICC"
-			echo "    worker (/status did not identify it) — stop it or set WRANGLER_PORT."
+	# ── Opt-in: local wrangler dev server ────────────────────────────
+	# Use WORKER_BASE_URL=http://localhost:8787 to test a local worker build.
+	# The local wrangler serves the SPA but is NOT the real OAuth relay —
+	# IMS and GitHub OAuth will not work correctly from localhost origins.
+	echo "🌐  Using local worker origin: $EFFECTIVE_WORKER_BASE_URL"
+
+	# Build the leader UI — wrangler serves dist/ui via the ASSETS binding;
+	# when dist/ui/index.html is absent every route 404s.
+	if [ -f "${REPO_ROOT}/dist/ui/index.html" ]; then
+		echo "✔  Leader UI present (dist/ui/index.html)"
+	else
+		echo "🏗  Building leader UI (npm run build -w @slicc/webapp)…"
+		npm run build -w @slicc/webapp
+		if [ ! -f "${REPO_ROOT}/dist/ui/index.html" ]; then
+			echo "❌  Leader UI build did not produce ${REPO_ROOT}/dist/ui/index.html"
 			exit 1
 		fi
-		[ "$i" -eq 30 ] && {
-			echo "❌  Wrangler failed to start"
-			kill "$WRANGLER_PID" 2>/dev/null || true
-			exit 1
-		}
-		sleep 1
-	done
+		echo "✔  Leader UI built (dist/ui/index.html)"
+	fi
+
+	if wrangler_up; then
+		echo "✔  Reusing existing wrangler on :${WRANGLER_PORT} (not started by us)"
+	else
+		echo "🌐  Starting wrangler on :${WRANGLER_PORT}…"
+		npx wrangler dev \
+			--config "${REPO_ROOT}/packages/cloudflare-worker/wrangler.jsonc" \
+			--port "$WRANGLER_PORT" --ip 127.0.0.1 \
+			--var "GITHUB_CLIENT_ID:${STAGING_GH_CLIENT_ID}" \
+			--var "TRAY_WORKER_BASE_URL_OVERRIDE:${STAGING_WORKER}" &
+		WRANGLER_PID=$!
+		STARTED_WRANGLER=1
+		for i in $(seq 1 30); do
+			if wrangler_up; then
+				echo "✔  Wrangler ready on :${WRANGLER_PORT}"
+				break
+			fi
+			if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
+				echo "❌  Wrangler exited before binding :${WRANGLER_PORT}"
+				echo "    If something else already holds that port, it is not the SLICC"
+				echo "    worker (/status did not identify it) — stop it or set WRANGLER_PORT."
+				exit 1
+			fi
+			[ "$i" -eq 30 ] && {
+				echo "❌  Wrangler failed to start"
+				kill "$WRANGLER_PID" 2>/dev/null || true
+				exit 1
+			}
+			sleep 1
+		done
+	fi
 fi
 
 # ── 5. Cleanup trap (kills ONLY our own processes) ───────────────────
@@ -301,11 +319,20 @@ trap cleanup EXIT INT TERM
 # ── 6. Start node-server thin-bridge ─────────────────────────────────
 echo "🔗  Starting thin-bridge on :${BRIDGE_PORT}…"
 echo ""
+# BRIDGE_DEV_ALLOWED_ORIGINS: add the wrangler origin when using a local worker
+# so the node-server accepts cross-origin /api requests from it. Empty string
+# for the hosted-origin mode — the node-server treats that as an empty set,
+# and https://www.sliccy.ai is already in the hard-coded BRIDGE_ALLOWED_ORIGINS.
+if [ "$USE_HOSTED_ORIGIN" -eq 0 ]; then
+	BRIDGE_DEV_ALLOWED_ORIGINS_VAL="$EFFECTIVE_WORKER_BASE_URL"
+else
+	BRIDGE_DEV_ALLOWED_ORIGINS_VAL=""
+fi
 CHROME_PATH="$CHROME_BIN" \
-	WORKER_BASE_URL="http://localhost:${WRANGLER_PORT}" \
+	WORKER_BASE_URL="$EFFECTIVE_WORKER_BASE_URL" \
 	SLICC_TRAY_WORKER_BASE_URL="${SLICC_TRAY_WORKER_BASE_URL:-https://slicc-tray-hub-staging.minivelos.workers.dev}" \
 	SLICC_CDP_LAUNCH_TIMEOUT_MS=30000 \
-	BRIDGE_DEV_ALLOWED_ORIGINS="http://localhost:${WRANGLER_PORT}" \
+	BRIDGE_DEV_ALLOWED_ORIGINS="$BRIDGE_DEV_ALLOWED_ORIGINS_VAL" \
 	SLICC_USER_DATA_DIR="$FRESH_PROFILE" \
 	PORT="$BRIDGE_PORT" \
 	node "${REPO_ROOT}/dist/node-server/index.js" "$@" &

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -135,34 +135,56 @@ const ADOBE_MODELS_KEY = 'slicc-adobe-models';
 function persistAdobeModels(models: EnrichedAdobeModel[]): void {
   try {
     localStorage.setItem(ADOBE_MODELS_KEY, JSON.stringify(models));
-  } catch {}
+  } catch {
+    // Intentionally swallowed: localStorage throws in private-browsing or
+    // when storage quota is full. The model list is always available from
+    // the in-memory cache; persistence is best-effort.
+  }
 }
 
 /**
- * Fetch client config from the proxy's /v1/config endpoint (unauthenticated).
- * Caches per endpoint so switching proxy URLs fetches fresh config.
- * Falls back to build-time adobeConfig values on failure.
+ * Attempt a single /v1/config fetch. Returns the parsed config on success,
+ * or `null` on any network or non-ok response (never throws).
  */
-async function fetchProxyConfig(proxyEndpoint: string): Promise<ProxyConfig> {
-  const cached = proxyConfigCache.get(proxyEndpoint);
-  if (cached) return cached;
+async function attemptFetchProxyConfig(proxyEndpoint: string): Promise<ProxyConfig | null> {
   try {
     const res = await fetch(`${proxyEndpoint}/v1/config`, {
       headers: { [SLICC_VERSION_HEADER]: __SLICC_VERSION__ },
     });
-    if (res.ok) {
-      const config = (await res.json()) as ProxyConfig;
-      proxyConfigCache.set(proxyEndpoint, config);
-      return config;
-    }
-    console.warn(
-      `[adobe] Proxy /v1/config returned ${res.status}, falling back to build-time config`
-    );
+    if (res.ok) return (await res.json()) as ProxyConfig;
+    console.warn(`[adobe] Proxy /v1/config returned ${res.status}`);
+    return null;
   } catch (err) {
     console.warn(
       '[adobe] Failed to fetch proxy config:',
       err instanceof Error ? err.message : String(err)
     );
+    return null;
+  }
+}
+
+/**
+ * Fetch client config from the proxy's /v1/config endpoint (unauthenticated).
+ * Caches per endpoint so switching proxy URLs fetches fresh config.
+ * Retries once after a short delay to handle the transient Chrome SW
+ * initialisation race (the very first cross-origin fetch through a
+ * freshly-registered service worker can fail with ERR_FAILED before the SW
+ * has resolved the bridge config from the page's client URL).
+ * Falls back to build-time adobeConfig values when both attempts fail.
+ */
+async function fetchProxyConfig(proxyEndpoint: string): Promise<ProxyConfig> {
+  const cached = proxyConfigCache.get(proxyEndpoint);
+  if (cached) return cached;
+  let config = await attemptFetchProxyConfig(proxyEndpoint);
+  if (!config) {
+    // One retry after a short pause — enough for the SW to settle without
+    // making a real proxy outage noticeably slower to report.
+    await new Promise<void>((r) => setTimeout(r, 600));
+    config = await attemptFetchProxyConfig(proxyEndpoint);
+  }
+  if (config) {
+    proxyConfigCache.set(proxyEndpoint, config);
+    return config;
   }
   // ponytail: failures are intentionally NOT cached — a transient proxy blip
   // must not poison the session-level Map and block every subsequent retry.
@@ -462,7 +484,10 @@ export const config: ProviderConfig = {
         const models = JSON.parse(persisted) as EnrichedAdobeModel[];
         if (models.length) return models;
       }
-    } catch {}
+    } catch {
+      // Intentionally swallowed: stale/corrupt localStorage data — fall through
+      // to the default model list.
+    }
     // Default before any config is fetched
     return [{ id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' }];
   },
@@ -1003,12 +1028,19 @@ async function pumpAdobeStream(
         ...model,
         baseUrl: `${getProxyEndpoint()}/v1`,
         api: 'openai-completions' as Api,
+        // SAFETY: `compat` is a pi-ai internal field on OpenAI-completions models;
+        // it is not in the public Model<Api> type but IS present at runtime. We
+        // spread it to inherit existing compat flags before overriding Adobe ones.
         compat: {
           ...(model as unknown as { compat?: OpenAICompletionsCompat }).compat,
           supportsStore: false,
           supportsDeveloperRole: false,
         },
       };
+      // SAFETY: proxyModel is structurally identical to Model<'openai-completions'>;
+      // we rebuilt it with the correct `api` literal and proxy `baseUrl`. The
+      // options cast is also safe: the caller always passes openai-shaped options
+      // to an openai-routed model, so narrowing to OpenAICompletionsOptions holds.
       const inner = streamOpenAICompletions(
         proxyModel as unknown as Model<'openai-completions'>,
         context,
@@ -1024,6 +1056,10 @@ async function pumpAdobeStream(
         baseUrl: getProxyEndpoint(),
         api: 'anthropic-messages' as Api,
       };
+      // SAFETY: proxyModel is structurally identical to Model<'anthropic-messages'>;
+      // we rebuilt it with the correct `api` literal and proxy `baseUrl`. The
+      // options cast is safe: the agent layer only sends anthropic-shaped options
+      // to an anthropic-routed model, so narrowing to AnthropicOptions holds.
       const inner = streamAnthropic(
         proxyModel as unknown as Model<'anthropic-messages'>,
         context,
@@ -1038,9 +1074,6 @@ async function pumpAdobeStream(
             ),
             'streamAdobe[anthropic]'
           )
-          // Same cross-vocabulary cast as the openai branch above: `options`
-          // arrives as the pi-ai-wide union; the agent layer only sends
-          // anthropic-shaped options to an anthropic-routed model.
         ) as unknown as AnthropicOptions
       );
       for await (const event of inner) stream.push(event);
@@ -1048,6 +1081,9 @@ async function pumpAdobeStream(
     stream.end();
   } catch (error) {
     logStreamError(error);
+    // SAFETY: makeErrorOutput returns a synthetic event that is structurally
+    // compatible with AssistantMessageEvent; the stream push only type-checks
+    // against the concrete event variant.
     stream.push(makeErrorOutput(model, error) as unknown as AssistantMessageEvent);
     stream.end();
   }
@@ -1075,12 +1111,17 @@ async function pumpSimpleAdobeStream(
         ...model,
         baseUrl: `${getProxyEndpoint()}/v1`,
         api: 'openai-completions' as Api,
+        // SAFETY: `compat` is a pi-ai internal field present at runtime on
+        // openai-completions models but absent from the public Model<Api> type.
         compat: {
           ...(model as unknown as { compat?: OpenAICompletionsCompat }).compat,
           supportsStore: false,
           supportsDeveloperRole: false,
         },
       };
+      // SAFETY: proxyModel is structurally Model<'openai-completions'> with
+      // corrected api literal and proxy baseUrl. Options narrowing is safe:
+      // this branch is only taken for openai-shaped options.
       const inner = streamSimpleOpenAICompletions(
         proxyModel as unknown as Model<'openai-completions'>,
         context,
@@ -1096,6 +1137,9 @@ async function pumpSimpleAdobeStream(
         baseUrl: getProxyEndpoint(),
         api: 'anthropic-messages' as Api,
       };
+      // SAFETY: proxyModel is structurally Model<'anthropic-messages'> with
+      // corrected api literal and proxy baseUrl. Options narrowing is safe:
+      // this branch is only taken for anthropic-shaped options.
       const inner = streamSimpleAnthropic(
         proxyModel as unknown as Model<'anthropic-messages'>,
         context,
@@ -1118,6 +1162,8 @@ async function pumpSimpleAdobeStream(
     stream.end();
   } catch (error) {
     logStreamError(error);
+    // SAFETY: makeErrorOutput returns a synthetic event compatible with
+    // AssistantMessageEvent at runtime.
     stream.push(makeErrorOutput(model, error) as unknown as AssistantMessageEvent);
     stream.end();
   }
@@ -1156,8 +1202,14 @@ function buildPiAiModelMap(): Map<string, Model<Api>> {
   const modelMap = new Map<string, Model<Api>>();
   for (const provider of getProviders()) {
     try {
-      for (const m of getModels(provider) as unknown as Model<Api>[]) modelMap.set(m.id, m);
-    } catch {}
+      // SAFETY: getModels returns an untyped array; all registered provider
+      // models satisfy the Model<Api> structural shape at runtime.
+      const providerModels = getModels(provider) as unknown as Model<Api>[];
+      for (const m of providerModels) modelMap.set(m.id, m);
+    } catch {
+      // Intentionally swallowed: some providers may fail getModels if they are
+      // still loading or unregistered. Best-effort map build.
+    }
   }
   return modelMap;
 }
@@ -1177,6 +1229,9 @@ function buildAdobeModel(
   // known model in the same family (e.g. sonnet-4-6 for sonnet-5-0)
   // so the cost counter stays functional until pi-ai is bumped.
   const cost = findFamilyCost(pm.id, modelMap);
+  // SAFETY: the object literal above satisfies the structural shape of
+  // Model<Api>; the `as Api` tag ensures the discriminant matches the
+  // concrete model variant returned to callers.
   return {
     id: pm.id,
     name: pm.name ?? pm.id,
@@ -1243,6 +1298,8 @@ const modelsCache = new Map<string, Model<Api>[]>();
 /** Anthropic-registry models tagged as Adobe — the best-effort fallback when
  * the proxy `/v1/models` fetch fails. Intentionally NOT cached by callers. */
 function adobeAnthropicFallbackModels(): Model<Api>[] {
+  // SAFETY: getModels returns an untyped array at this pi-ai version;
+  // 'anthropic' models are structurally Model<Api> at runtime.
   const anthropicModels = getModels('anthropic') as unknown as Model<Api>[];
   return anthropicModels.map((m) => ({ ...m, provider: 'adobe', api: 'adobe-anthropic' as Api }));
 }
@@ -1264,14 +1321,20 @@ export async function getAdobeModels(accessToken?: string): Promise<Model<Api>[]
 // ── Registration ────────────────────────────────────────────────────
 
 export function register(): void {
+  // pi-ai's StreamFunction<Api> type parameter is invariant, so provider-scoped
+  // stream functions require a cast to satisfy the generic slot.
   registerApiProvider({
     api: 'adobe-anthropic' as Api,
+    // SAFETY: streamAdobe matches the StreamFunction<Api> shape at runtime.
     stream: streamAdobe as unknown as StreamFunction<Api>,
+    // SAFETY: streamSimpleAdobe matches StreamFunction<Api, SimpleStreamOptions>.
     streamSimple: streamSimpleAdobe as unknown as StreamFunction<Api, SimpleStreamOptions>,
   });
   registerApiProvider({
     api: 'adobe-openai' as Api,
+    // SAFETY: streamAdobe matches the StreamFunction<Api> shape at runtime.
     stream: streamAdobe as unknown as StreamFunction<Api>,
+    // SAFETY: streamSimpleAdobe matches StreamFunction<Api, SimpleStreamOptions>.
     streamSimple: streamSimpleAdobe as unknown as StreamFunction<Api, SimpleStreamOptions>,
   });
 }

--- a/packages/webapp/tests/providers/adobe-provider.test.ts
+++ b/packages/webapp/tests/providers/adobe-provider.test.ts
@@ -741,16 +741,22 @@ describe('X-Session-Id fallback enforcement', () => {
 });
 
 describe('fetchProxyConfig caching contract', () => {
-  // Mirrors the caching logic in adobe.ts fetchProxyConfig. Same
-  // mirror-rather-than-import pattern: adobe.ts pulls in import.meta.glob
-  // and chrome globals that aren't available under vitest/node.
+  // Mirrors the caching + retry logic in adobe.ts fetchProxyConfig /
+  // attemptFetchProxyConfig. Same mirror-rather-than-import pattern: adobe.ts
+  // pulls in import.meta.glob and chrome globals unavailable under vitest/node.
   //
-  // Regression for: a failed /v1/config fetch used to cache an empty {}
-  // object, so every subsequent login retry in the same session reused the
-  // poisoned cache even after the proxy recovered — requiring a full page
-  // reload to clear it.
+  // Covers two generations of bugs:
+  //   1. Failed /v1/config used to be cached as {}, poisoning every subsequent
+  //      retry in the same session — required a full page reload to recover.
+  //   2. Transient Chrome SW timing race on a fresh profile: the very first
+  //      cross-origin fetch fired before the SW had the bridge config, which
+  //      routed to same-origin wrangler (404 "not available in worker mode") or
+  //      threw ERR_FAILED. resolveClientId({}) then threw "Could not determine
+  //      IMS client ID". Fixed by a single in-call retry after RETRY_DELAY_MS.
 
   const SLICC_VERSION_HEADER = 'X-Slicc-Version';
+  // Must match the production value in adobe.ts.
+  const RETRY_DELAY_MS = 600;
 
   interface ProxyConfig {
     clientId?: string;
@@ -758,36 +764,47 @@ describe('fetchProxyConfig caching contract', () => {
     imsEnvironment?: string;
   }
 
-  async function fetchProxyConfig(
+  // Single-attempt helper — mirrors attemptFetchProxyConfig.
+  async function attemptFetchProxyConfig(
     proxyEndpoint: string,
-    cache: Map<string, ProxyConfig>,
     fetchImpl: typeof fetch
-  ): Promise<ProxyConfig> {
-    const cached = cache.get(proxyEndpoint);
-    if (cached) return cached;
+  ): Promise<ProxyConfig | null> {
     try {
       const res = await fetchImpl(`${proxyEndpoint}/v1/config`, {
         headers: { [SLICC_VERSION_HEADER]: '1.0.0-test' },
       });
-      if (res.ok) {
-        const config = (await res.json()) as ProxyConfig;
-        cache.set(proxyEndpoint, config);
-        return config;
-      }
-      console.warn(
-        `[adobe] Proxy /v1/config returned ${res.status}, falling back to build-time config`
-      );
-    } catch (err) {
-      console.warn(
-        '[adobe] Failed to fetch proxy config:',
-        err instanceof Error ? err.message : String(err)
-      );
+      if (res.ok) return (await res.json()) as ProxyConfig;
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  // Retry wrapper — mirrors fetchProxyConfig.
+  // `delay` is injectable so tests run without real timers.
+  async function fetchProxyConfig(
+    proxyEndpoint: string,
+    cache: Map<string, ProxyConfig>,
+    fetchImpl: typeof fetch,
+    delay: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms))
+  ): Promise<ProxyConfig> {
+    const cached = cache.get(proxyEndpoint);
+    if (cached) return cached;
+    let config = await attemptFetchProxyConfig(proxyEndpoint, fetchImpl);
+    if (!config) {
+      await delay(RETRY_DELAY_MS);
+      config = await attemptFetchProxyConfig(proxyEndpoint, fetchImpl);
+    }
+    if (config) {
+      cache.set(proxyEndpoint, config);
+      return config;
     }
     // ponytail: failures are intentionally NOT cached
     return {};
   }
 
   const ENDPOINT = 'https://proxy.example.com';
+  const noDelay = async (_ms: number) => {};
 
   it('successful fetch is cached — second call does not re-fetch', async () => {
     let callCount = 0;
@@ -799,53 +816,100 @@ describe('fetchProxyConfig caching contract', () => {
       } as Response;
     };
     const cache = new Map<string, ProxyConfig>();
-    const first = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
-    const second = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
+    const first = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    const second = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
     expect(callCount).toBe(1);
     expect(first.clientId).toBe('test-client');
     expect(second.clientId).toBe('test-client');
   });
 
-  it('failed fetch (non-ok status) is NOT cached — second call re-fetches', async () => {
+  it('SW race regression — first attempt throws (ERR_FAILED), retry succeeds within single call', async () => {
+    // Regression for the Chrome SW timing race on a fresh profile: the first
+    // fetch throws before the SW has settled. The caller should receive a
+    // resolved config from the same invocation (no page reload required).
+    let callCount = 0;
+    const mockFetch = async () => {
+      callCount++;
+      if (callCount === 1) throw new TypeError('Failed to fetch'); // ERR_FAILED
+      return {
+        ok: true,
+        json: async () => ({ clientId: 'experience-catalyst-prod', scopes: 'openid' }),
+      } as Response;
+    };
+    const delayedMs: number[] = [];
+    const captureDelay = async (ms: number) => {
+      delayedMs.push(ms);
+    };
+    const cache = new Map<string, ProxyConfig>();
+    const result = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, captureDelay);
+    expect(result.clientId).toBe('experience-catalyst-prod'); // resolved from retry
+    expect(callCount).toBe(2); // one failed attempt + one successful retry
+    expect(delayedMs).toEqual([RETRY_DELAY_MS]); // exactly one delay of 600 ms
+    expect(cache.size).toBe(1); // retry result was cached
+  });
+
+  it('SW race regression — first attempt returns non-ok (wrangler 404), retry succeeds', async () => {
+    let callCount = 0;
+    const mockFetch = async () => {
+      callCount++;
+      if (callCount === 1) return { ok: false, status: 404 } as Response; // wrangler 404
+      return {
+        ok: true,
+        json: async () => ({ clientId: 'experience-catalyst-prod' }),
+      } as Response;
+    };
+    const cache = new Map<string, ProxyConfig>();
+    const result = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    expect(result.clientId).toBe('experience-catalyst-prod');
+    expect(callCount).toBe(2);
+    expect(cache.size).toBe(1);
+  });
+
+  it('both attempts fail (non-ok) — returns {} without caching, next caller re-fetches', async () => {
     let callCount = 0;
     const mockFetch = async () => {
       callCount++;
       return { ok: false, status: 503 } as Response;
     };
     const cache = new Map<string, ProxyConfig>();
-    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
-    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
-    expect(callCount).toBe(2);
-    expect(cache.size).toBe(0);
+    // Two separate caller invocations; each makes 2 fetch calls internally.
+    const first = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    const second = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    expect(first.clientId).toBeUndefined();
+    expect(second.clientId).toBeUndefined();
+    expect(callCount).toBe(4); // 2 attempts per invocation × 2 invocations
+    expect(cache.size).toBe(0); // never cached
   });
 
-  it('failed fetch (network throw) is NOT cached — second call re-fetches', async () => {
+  it('both attempts throw (network error) — returns {} without caching', async () => {
     let callCount = 0;
     const mockFetch = async () => {
       callCount++;
-      throw new Error('fetch failed');
+      throw new TypeError('Failed to fetch');
     };
     const cache = new Map<string, ProxyConfig>();
-    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
-    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
-    expect(callCount).toBe(2);
+    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    expect(callCount).toBe(4);
     expect(cache.size).toBe(0);
   });
 
-  it('recovers after a blip — retry after failure returns real clientId without reload', async () => {
+  it('recovers across separate invocations — blip then proxy up, no reload needed', async () => {
     let callCount = 0;
-    // First call: proxy down
-    // Second call: proxy recovered
     const mockFetch = async () => {
       callCount++;
-      if (callCount === 1) return { ok: false, status: 503 } as Response;
-      return { ok: true, json: async () => ({ clientId: 'experience-catalyst-prod' }) } as Response;
+      // Attempts 1+2: both fail (genuine outage, not just a SW race)
+      if (callCount <= 2) return { ok: false, status: 503 } as Response;
+      return {
+        ok: true,
+        json: async () => ({ clientId: 'experience-catalyst-prod' }),
+      } as Response;
     };
     const cache = new Map<string, ProxyConfig>();
-    const first = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
-    expect(first.clientId).toBeUndefined(); // blip: empty fallback
-    const second = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch);
-    expect(second.clientId).toBe('experience-catalyst-prod'); // recovery: real value
-    expect(callCount).toBe(2);
+    const blip = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    expect(blip.clientId).toBeUndefined();
+    const recovered = await fetchProxyConfig(ENDPOINT, cache, mockFetch as typeof fetch, noDelay);
+    expect(recovered.clientId).toBe('experience-catalyst-prod');
+    expect(cache.size).toBe(1);
   });
 });


### PR DESCRIPTION
## What

Three related fixes found during a fresh Canary smoke test.

### Adobe provider — SW timing race on first login (`adobe.ts`)

`fetchProxyConfig` failed on the very first login attempt in a fresh Chrome profile with `Failed to fetch`. The service worker intercepts the cross-origin fetch to the adobe proxy before its bridge config is settled (Chrome SW timing race on a fresh profile). In that window the SW routes to same-origin wrangler, which returns 404 (`Fetch proxy not available in worker mode`). `fetchProxyConfig` catches the rejection, returns `{}`, and `resolveClientId({})` throws:

> Login failed: Could not determine IMS client ID — proxy /v1/config did not return one and adobe-config.json is empty

**Fix:** split `fetchProxyConfig` into `attemptFetchProxyConfig` (single attempt) and a wrapper that retries once after 600 ms. The SW settles within that window so the retry goes through the bridge correctly.

Also cleaned up all pre-existing `as unknown as T` casts with `SAFETY:` comments (required by `require-safety-comment-for-as-unknown-as` which was triggered after touching the file), and documented three intentional empty catch blocks.

### Dev harness — wrong default origin (`dev-standalone-fresh.sh`)

The script always started wrangler and opened Chrome at `localhost:8787`. OAuth (IMS/Adobe, GitHub) does not work from localhost origins — IMS only allowlists `www.sliccy.ai`. The node-server already defaults to `SLICC_HOSTED_ORIGIN` when `WORKER_BASE_URL` is unset; the script was overriding that unconditionally.

**Fix:** default to the production hosted origin (`https://www.sliccy.ai`). Chrome opens `https://www.sliccy.ai/?bridge=ws://localhost:5715/cdp&bridgeToken=…` — the hosted UI connects back to the local node-server via the bridge parameter. Wrangler is only started when `WORKER_BASE_URL` is explicitly set to a localhost URL. `BRIDGE_DEV_ALLOWED_ORIGINS` is only set for the local-worker path; `sliccy.ai` is already in the hard-coded `BRIDGE_ALLOWED_ORIGINS` list.

### Skill documentation (`cdp-smoke-test/SKILL.md`)

Documented the hosted-origin mode as the **recommended default** with the correct launch command. Added explicit note that OAuth/IMS will not work from localhost origins. Wrangler / local-worker mode demoted to an opt-in alternate section.