### PR TITLE
feat(webapp): OpenRouter (Free) provider with live free catalog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,16 +23,17 @@ Validate CDP target + port before trusting them; handle disconnects.
 
 ## 5. Native / macOS permissions
 
-Native protected-resource access needs entitlements/usage descriptions, TCC checks,
-graceful denial. A File Provider appex must embed+sign every `@rpath` framework it
-links (host `Resources/` is invisible) and declare its transport's network entitlements.
-No `keychain-access-groups` on the macOS File Provider: that restricted entitlement needs
-an appex-specific Developer ID profile, else AMFI refuses launch (extensionKit error 2).
+Protected-resource access needs entitlements/usage descriptions, TCC checks,
+graceful denial. File Provider appexes must embed+sign every `@rpath` framework
+(host `Resources/` invisible) and declare transport network entitlements. No
+`keychain-access-groups` on the macOS File Provider — that restricted entitlement
+needs an appex-specific Developer ID profile, else AMFI refuses launch (error 2).
 
 ## 6. Model metadata / provider pipeline
 
-When model IDs or provider metadata change, verify reasoning, input, cost,
-thinking levels through discovery, enrichment, account storage, API effort mapping.
+Model ID/metadata changes: verify reasoning, input, cost, thinking through
+discovery→enrichment→storage→API. OpenRouter (Free): all pricing dims zero;
+stream refuses IDs not in the live free catalog.
 
 ## 7. Test coverage
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ To use SLICC, you need an LLM provider. SLICC is very much a BYOT (bring your ow
 - AWS Bedrock (because enterprise)
 - AWS Bedrock CAMP (this is Adobe-internal. Did I say "because enterprise" already?)
 - Anthropic
+- OpenRouter and OpenRouter (Free) — PKCE login; Free keeps only currently free vision+tools models from the live catalog
 
 The other providers are in YMMV territory. Please file an issue if you find them working or broken.
 

--- a/docs/oauth-intercept.md
+++ b/docs/oauth-intercept.md
@@ -96,6 +96,13 @@ PKCE verifier to `https://openrouter.ai/api/v1/auth/keys`. The response is a
 permanent OpenRouter API key, not a short-lived access token, so it has no
 refresh flow or expiry.
 
+`packages/webapp/providers/openrouter-free.ts` reuses the same PKCE exchange
+(with `providerId: 'openrouter-free'`) but exposes only currently free models
+that accept text+image, emit text, and advertise `tools` / `temperature` /
+`top_p`. The free catalog is filtered from the shared `/api/v1/models` cache
+in `openrouter-models.ts`; OpenRouter's website-only `min_tool_success_rate`
+filter is not available on that endpoint and is omitted.
+
 ## Running a one-off interception from the shell
 
 ```bash

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1811,13 +1811,16 @@ When Anthropic ships a new Claude model that isn't in the pinned pi-ai:
    Verify the inherited costs are reasonable. Once pi-ai is bumped, the real
    costs take over. **Cross-provider guard:** the `getProviderModels` branch is
    shared by _every_ provider that defines `getModelIds` (github, openrouter,
-   xai-grok, cerebras, local-llm, azure-openai, …), so inheritance is gated to
-   Anthropic-API-routed models (`pm.api !== 'openai'`). Adobe's Claude models
-   are anthropic-routed and still inherit; OpenAI-routed providers keep
-   `buildProviderRoutedModel`'s $0 default even for a Claude-style id — this
-   stops a local or free model literally named like a Claude family id (e.g. a
-   `local-llm` model called `claude-sonnet-6`) from inheriting real Anthropic
-   pricing. Reported cost (layer 2/3) still wins over the fallback either way.
+   openrouter-free, xai-grok, cerebras, local-llm, azure-openai, …), so
+   inheritance is gated to Anthropic-API-routed models (`pm.api !== 'openai'`).
+   Adobe's Claude models are anthropic-routed and still inherit; OpenAI-routed
+   providers keep `buildProviderRoutedModel`'s $0 default even for a Claude-style
+   id — this stops a local or free model literally named like a Claude family id
+   (e.g. a `local-llm` model called `claude-sonnet-6`) from inheriting real
+   Anthropic pricing. Reported cost (layer 2/3) still wins over the fallback
+   either way. OpenRouter (Free) additionally forces `$0` cost on its filtered
+catalog (`getFreeCatalog`) so picker totals stay free even if a seed entry
+   lacks pricing metadata.
 
 ## Thinking effort pipeline
 

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -180,6 +180,10 @@ on a Developer ID appex unless a profile for _that_ bundle id is embedded.
   `getModelIds`, not just Adobe. `findFamilyCost` inheritance is gated to Anthropic-API-routed
   models (`pm.api !== 'openai'`) so OpenAI-routed providers (local-llm, azure-openai) don't
   inherit Anthropic pricing for a Claude-style id; check that guard survives refactors.
+- OpenRouter (Free) (`providers/openrouter-free.ts`): catalog filter must reject any nonzero
+  pricing dimension (not just prompt/completion), and stream functions must refuse model IDs
+  absent from the current `getFreeCatalog()` so a stale cone selection cannot bill after a
+  reprice.
 - A pi-ai bump that adds new models — check if the new model's `thinkingLevelMap`, `cost`,
   and `reasoning` are correct. Also check for breaking API changes (e.g. function signature
   changes like `buildBaseOptions`).

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -106,7 +106,9 @@ Invariants a reviewer must catch; mechanism in the linked docs.
   sudo-fs Proxy advertises `MONKEYPATCH_UNSAFE_FS`; reassigning a gated method OOMs the worker.
 - **Provider quirks** (`docs/pitfalls.md`): attach the Adobe proxy's `X-Session-Id` at the call
   site (`ensureSessionIdHeader` is defense-in-depth). Claude Bedrock capability shims belong in
-  `providers/claude-model-version.ts`, never the call site.
+  `providers/claude-model-version.ts`, never the call site. OpenRouter (Free)
+  (`providers/openrouter-free.ts`) filters the shared OpenRouter catalog to currently free
+  vision+tools models — see `docs/oauth-intercept.md`.
 
 ## Key Conventions
 

--- a/packages/webapp/providers/openrouter-free.ts
+++ b/packages/webapp/providers/openrouter-free.ts
@@ -1,0 +1,114 @@
+/**
+ * OpenRouter (Free) provider — currently free multimodal tool-calling models.
+ *
+ * Reuses OpenRouter PKCE login and OpenAI-compatible streaming; the catalog is
+ * filtered from the shared `/api/v1/models` cache to models that are free,
+ * accept text+image, emit text, and advertise tools/temperature/top_p.
+ */
+
+import type {
+  Api,
+  Context,
+  Model,
+  ProviderHeaders,
+  ProviderStreamOptions,
+  SimpleStreamOptions,
+} from '@earendil-works/pi-ai';
+import {
+  registerApiProvider,
+  streamOpenAICompletions,
+  streamSimpleOpenAICompletions,
+} from '@earendil-works/pi-ai/compat';
+import { getApiKeyForProvider } from '../src/providers/account-store.js';
+import type {
+  InterceptingOAuthLauncher,
+  OAuthLoginOptions,
+  ProviderConfig,
+} from '../src/providers/types.js';
+import { saveOAuthAccount } from '../src/ui/provider-settings.js';
+import { FREE_ROUTER_FALLBACK, fetchModels, getFreeCatalog } from './openrouter-models.js';
+import { loginIntercepted } from './openrouter-oauth.js';
+
+const PROVIDER_ID = 'openrouter-free';
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const OPENAI_COMPLETIONS_API: Api = 'openai-completions';
+const OPENROUTER_FREE_API: Api = `${PROVIDER_ID}-openai` as Api;
+const ATTRIBUTION_HEADERS: ProviderHeaders = {
+  'HTTP-Referer': 'https://sliccy.ai',
+  'X-Title': 'SLICC',
+};
+
+function asOpenRouterModel(model: Model<Api>): Model<'openai-completions'> {
+  return {
+    ...model,
+    baseUrl: OPENROUTER_BASE_URL,
+    api: OPENAI_COMPLETIONS_API,
+  } as Model<'openai-completions'>;
+}
+
+function withAttribution(headers?: ProviderHeaders): ProviderHeaders {
+  return { ...(headers ?? {}), ...ATTRIBUTION_HEADERS };
+}
+
+const streamOpenRouterFree = (
+  model: Model<Api>,
+  context: Context,
+  options: ProviderStreamOptions = {}
+) =>
+  streamOpenAICompletions(asOpenRouterModel(model), context, {
+    ...options,
+    apiKey: getApiKeyForProvider(PROVIDER_ID) ?? options.apiKey,
+    headers: withAttribution(options.headers),
+  });
+
+const streamSimpleOpenRouterFree = (
+  model: Model<Api>,
+  context: Context,
+  options: SimpleStreamOptions = {}
+) =>
+  streamSimpleOpenAICompletions(asOpenRouterModel(model), context, {
+    ...options,
+    apiKey: getApiKeyForProvider(PROVIDER_ID) ?? options.apiKey,
+    headers: withAttribution(options.headers),
+  });
+
+export const config: ProviderConfig = {
+  id: PROVIDER_ID,
+  name: 'OpenRouter (Free)',
+  description:
+    'Currently free OpenRouter models that support vision and tools. Catalog refreshes from OpenRouter; paid models are excluded.',
+  requiresApiKey: false,
+  requiresBaseUrl: false,
+  isOAuth: true,
+  defaultModelId: FREE_ROUTER_FALLBACK.id,
+  oauthTokenDomains: ['openrouter.ai', '*.openrouter.ai'],
+  getModelIds: getFreeCatalog,
+  refreshModels: async () => {
+    await fetchModels();
+  },
+  onOAuthLoginIntercepted: async (
+    launcher: InterceptingOAuthLauncher,
+    onSuccess: () => void,
+    options?: OAuthLoginOptions
+  ) => {
+    await loginIntercepted(launcher, () => undefined, {
+      ...options,
+      providerId: PROVIDER_ID,
+    });
+    await fetchModels().catch(() => undefined);
+    onSuccess();
+  },
+  onOAuthLogout: async () => {
+    await saveOAuthAccount({ providerId: PROVIDER_ID, accessToken: '' });
+  },
+};
+
+export function register(): void {
+  registerApiProvider({
+    api: OPENROUTER_FREE_API,
+    stream: streamOpenRouterFree as Parameters<typeof registerApiProvider>[0]['stream'],
+    streamSimple: streamSimpleOpenRouterFree as Parameters<
+      typeof registerApiProvider
+    >[0]['streamSimple'],
+  });
+}

--- a/packages/webapp/providers/openrouter-free.ts
+++ b/packages/webapp/providers/openrouter-free.ts
@@ -4,6 +4,9 @@
  * Reuses OpenRouter PKCE login and OpenAI-compatible streaming; the catalog is
  * filtered from the shared `/api/v1/models` cache to models that are free,
  * accept text+image, emit text, and advertise tools/temperature/top_p.
+ *
+ * Stream functions re-check {@link isModelInFreeCatalog} so a cone that kept a
+ * previously free model cannot call OpenRouter after that model is repriced.
  */
 
 import type {
@@ -15,6 +18,7 @@ import type {
   SimpleStreamOptions,
 } from '@earendil-works/pi-ai';
 import {
+  createAssistantMessageEventStream,
   registerApiProvider,
   streamOpenAICompletions,
   streamSimpleOpenAICompletions,
@@ -26,7 +30,12 @@ import type {
   ProviderConfig,
 } from '../src/providers/types.js';
 import { saveOAuthAccount } from '../src/ui/provider-settings.js';
-import { FREE_ROUTER_FALLBACK, fetchModels, getFreeCatalog } from './openrouter-models.js';
+import {
+  FREE_ROUTER_FALLBACK,
+  fetchModels,
+  getFreeCatalog,
+  isModelInFreeCatalog,
+} from './openrouter-models.js';
 import { loginIntercepted } from './openrouter-oauth.js';
 
 const PROVIDER_ID = 'openrouter-free';
@@ -50,27 +59,72 @@ function withAttribution(headers?: ProviderHeaders): ProviderHeaders {
   return { ...(headers ?? {}), ...ATTRIBUTION_HEADERS };
 }
 
+function makeErrorOutput(model: Model<Api>, error: unknown) {
+  return {
+    type: 'error' as const,
+    reason: 'error' as const,
+    error: {
+      role: 'assistant' as const,
+      content: [],
+      api: OPENROUTER_FREE_API,
+      provider: PROVIDER_ID,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'error' as const,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      timestamp: Date.now(),
+    },
+  };
+}
+
+function refuseNonFreeModel(model: Model<Api>) {
+  const stream = createAssistantMessageEventStream();
+  const error = new Error(
+    `OpenRouter (Free) refused "${model.id}" — it is not in the current free catalog. Choose another free model or refresh the catalog.`
+  );
+  queueMicrotask(() => {
+    stream.push(makeErrorOutput(model, error) as never);
+    stream.end();
+  });
+  return stream;
+}
+
 const streamOpenRouterFree = (
   model: Model<Api>,
   context: Context,
   options: ProviderStreamOptions = {}
-) =>
-  streamOpenAICompletions(asOpenRouterModel(model), context, {
+) => {
+  if (!isModelInFreeCatalog(model.id)) {
+    return refuseNonFreeModel(model);
+  }
+  return streamOpenAICompletions(asOpenRouterModel(model), context, {
     ...options,
     apiKey: getApiKeyForProvider(PROVIDER_ID) ?? options.apiKey,
     headers: withAttribution(options.headers),
   });
+};
 
 const streamSimpleOpenRouterFree = (
   model: Model<Api>,
   context: Context,
   options: SimpleStreamOptions = {}
-) =>
-  streamSimpleOpenAICompletions(asOpenRouterModel(model), context, {
+) => {
+  if (!isModelInFreeCatalog(model.id)) {
+    return refuseNonFreeModel(model);
+  }
+  return streamSimpleOpenAICompletions(asOpenRouterModel(model), context, {
     ...options,
     apiKey: getApiKeyForProvider(PROVIDER_ID) ?? options.apiKey,
     headers: withAttribution(options.headers),
   });
+};
 
 export const config: ProviderConfig = {
   id: PROVIDER_ID,

--- a/packages/webapp/providers/openrouter-models.ts
+++ b/packages/webapp/providers/openrouter-models.ts
@@ -18,6 +18,15 @@ const DEFAULT_PATTERNS = ['*'] as const;
 export interface OpenRouterPricing {
   prompt?: string;
   completion?: string;
+  request?: string;
+  image?: string;
+  web_search?: string;
+  internal_reasoning?: string;
+  audio?: string;
+  /** Nested / non-charge fields — ignored by the free-price check. */
+  discount?: number | string;
+  overrides?: unknown;
+  [key: string]: unknown;
 }
 
 /** Raw model returned by OpenRouter's /api/v1/models endpoint. */
@@ -169,11 +178,22 @@ function catalogSource(): readonly OpenRouterCatalogModel[] {
   return liveCatalog ?? (cached.length > 0 ? cached : Object.values(OPENROUTER_MODELS));
 }
 
-/** True when OpenRouter reports zero prompt+completion pricing, or the id is a free variant. */
+/** True when every present numeric OpenRouter pricing dimension is zero, or the id is a free variant. */
 export function isOpenRouterFreePriced(model: OpenRouterCatalogModel): boolean {
   const pricing = model.pricing;
   if (pricing) {
-    return Number(pricing.prompt ?? NaN) === 0 && Number(pricing.completion ?? NaN) === 0;
+    // prompt + completion must be explicitly present and zero (NaN if omitted).
+    if (!(Number(pricing.prompt ?? NaN) === 0 && Number(pricing.completion ?? NaN) === 0)) {
+      return false;
+    }
+    // Reject any other charged dimension OpenRouter may advertise (image, request, …).
+    for (const [key, value] of Object.entries(pricing)) {
+      if (key === 'discount' || key === 'overrides') continue;
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'object') continue;
+      if (Number(value) !== 0) return false;
+    }
+    return true;
   }
   // Seed entries rarely carry pricing — treat OpenRouter's free-variant ids as free.
   return model.id === 'openrouter/free' || model.id.endsWith(':free');
@@ -223,4 +243,9 @@ export function getFreeCatalog(): OpenRouterModelMetadata[] {
     .map(withFreeCost);
   if (matched.length > 0) return matched;
   return [withFreeCost(toModelMetadata(FREE_ROUTER_FALLBACK))];
+}
+
+/** Whether `modelId` is currently offered by {@link getFreeCatalog}. */
+export function isModelInFreeCatalog(modelId: string): boolean {
+  return getFreeCatalog().some((entry) => entry.id === modelId);
 }

--- a/packages/webapp/providers/openrouter-models.ts
+++ b/packages/webapp/providers/openrouter-models.ts
@@ -14,6 +14,12 @@ const FILTER_STORAGE_KEY = 'slicc.openrouter.modelFilter';
 const FETCH_TIMEOUT_MS = 10_000;
 const DEFAULT_PATTERNS = ['*'] as const;
 
+/** Per-token pricing strings returned by OpenRouter (`"0"` = free). */
+export interface OpenRouterPricing {
+  prompt?: string;
+  completion?: string;
+}
+
 /** Raw model returned by OpenRouter's /api/v1/models endpoint. */
 export interface OpenRouterModel {
   id: string;
@@ -30,6 +36,7 @@ export interface OpenRouterModel {
     is_moderated?: boolean;
   };
   supported_parameters?: string[];
+  pricing?: OpenRouterPricing;
 }
 
 /** Common shape shared by live entries and pi-ai's static seed models. */
@@ -44,7 +51,28 @@ export interface OpenRouterCatalogModel {
   maxTokens?: number;
   reasoning?: boolean;
   input?: readonly string[];
+  pricing?: OpenRouterPricing;
 }
+
+/** Capabilities required by the OpenRouter (Free) provider (API-enforceable). */
+export const FREE_AGENT_REQUIRED_PARAMS = ['tools', 'temperature', 'top_p'] as const;
+
+/** Cold-start fallback when neither live nor seed catalogs expose a free agent model. */
+export const FREE_ROUTER_FALLBACK: OpenRouterCatalogModel = {
+  id: 'openrouter/free',
+  name: 'Free Models Router',
+  context_length: 200_000,
+  architecture: {
+    modality: 'text+image->text',
+    input_modalities: ['text', 'image'],
+    output_modalities: ['text'],
+  },
+  top_provider: { max_completion_tokens: 16_384 },
+  supported_parameters: [...FREE_AGENT_REQUIRED_PARAMS, 'tool_choice'],
+  pricing: { prompt: '0', completion: '0' },
+};
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
 
 export type OpenRouterModelMetadata = { id: string; name: string } & ModelMetadata;
 
@@ -136,10 +164,63 @@ export function toModelMetadata(model: OpenRouterCatalogModel): OpenRouterModelM
   };
 }
 
+function catalogSource(): readonly OpenRouterCatalogModel[] {
+  const cached = loadCache();
+  return liveCatalog ?? (cached.length > 0 ? cached : Object.values(OPENROUTER_MODELS));
+}
+
+/** True when OpenRouter reports zero prompt+completion pricing, or the id is a free variant. */
+export function isOpenRouterFreePriced(model: OpenRouterCatalogModel): boolean {
+  const pricing = model.pricing;
+  if (pricing) {
+    return Number(pricing.prompt ?? NaN) === 0 && Number(pricing.completion ?? NaN) === 0;
+  }
+  // Seed entries rarely carry pricing — treat OpenRouter's free-variant ids as free.
+  return model.id === 'openrouter/free' || model.id.endsWith(':free');
+}
+
+function hasAll(values: readonly string[] | undefined, required: readonly string[]): boolean {
+  if (!values) return false;
+  const set = new Set(values);
+  return required.every((item) => set.has(item));
+}
+
+/**
+ * Free multimodal tool-calling models suitable for a SLICC agent loop.
+ *
+ * Mirrors the OpenRouter UI filter of free + text/image input + text output +
+ * tools/temperature/top_p. `min_tool_success_rate` is website-only and is not
+ * available on `/api/v1/models`, so it is intentionally omitted.
+ */
+export function isFreeAgentCapableModel(model: OpenRouterCatalogModel): boolean {
+  if (!isOpenRouterFreePriced(model)) return false;
+  const inputs = model.architecture?.input_modalities ?? model.input ?? [];
+  const outputs = model.architecture?.output_modalities ?? ['text'];
+  return (
+    hasAll(inputs, ['text', 'image']) &&
+    hasAll(outputs, ['text']) &&
+    hasAll(model.supported_parameters, FREE_AGENT_REQUIRED_PARAMS)
+  );
+}
+
+function withFreeCost(metadata: OpenRouterModelMetadata): OpenRouterModelMetadata {
+  return { ...metadata, cost: { ...ZERO_COST } };
+}
+
 /** Synchronous catalog reader for ProviderConfig.getModelIds(). */
 export function getCatalog(): OpenRouterModelMetadata[] {
-  const cached = loadCache();
-  const source: readonly OpenRouterCatalogModel[] =
-    liveCatalog ?? (cached.length > 0 ? cached : Object.values(OPENROUTER_MODELS));
-  return filterModels(source, loadFilterPatterns()).map(toModelMetadata);
+  return filterModels(catalogSource(), loadFilterPatterns()).map(toModelMetadata);
+}
+
+/**
+ * Synchronous free-agent catalog for the OpenRouter (Free) provider.
+ * Falls back to `openrouter/free` when the live/seed catalog has no matches.
+ */
+export function getFreeCatalog(): OpenRouterModelMetadata[] {
+  const matched = catalogSource()
+    .filter(isFreeAgentCapableModel)
+    .map(toModelMetadata)
+    .map(withFreeCost);
+  if (matched.length > 0) return matched;
+  return [withFreeCost(toModelMetadata(FREE_ROUTER_FALLBACK))];
 }

--- a/packages/webapp/providers/openrouter-oauth.ts
+++ b/packages/webapp/providers/openrouter-oauth.ts
@@ -85,12 +85,17 @@ export async function exchangeCodeForKey(
   return key;
 }
 
+export type OpenRouterLoginOptions = OAuthLoginOptions & {
+  /** Account/provider id to store the permanent key under (default: `openrouter`). */
+  providerId?: string;
+};
+
 export async function loginIntercepted(
   launcher: InterceptingOAuthLauncher,
   onSuccess: () => void,
-  options?: OAuthLoginOptions
+  options?: OpenRouterLoginOptions
 ): Promise<void> {
-  void options;
+  const providerId = options?.providerId ?? 'openrouter';
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await deriveCodeChallenge(codeVerifier);
   const captured = await launcher({
@@ -104,7 +109,7 @@ export async function loginIntercepted(
   // OpenRouter exchanges the OAuth code for a permanent API key, which has no
   // OAuth scope concept, so scopes intentionally remain unknown.
   await saveOAuthAccount({
-    providerId: 'openrouter',
+    providerId,
     accessToken: key,
     tokenExpiresAt: Number.MAX_SAFE_INTEGER,
     baseUrl: OPENROUTER_API_BASE_URL,

--- a/packages/webapp/tests/providers/openrouter-free-config.test.ts
+++ b/packages/webapp/tests/providers/openrouter-free-config.test.ts
@@ -1,9 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  createAssistantMessageEventStream: vi.fn(() => {
+    const stream = {
+      push: vi.fn(),
+      end: vi.fn(),
+      [Symbol.asyncIterator]: async function* () {
+        /* empty refuse stream for tests */
+      },
+    };
+    return stream;
+  }),
   fetchModels: vi.fn(),
   getApiKeyForProvider: vi.fn<() => string | null>(() => 'stored-oauth-key'),
   getFreeCatalog: vi.fn<() => unknown[]>(() => []),
+  isModelInFreeCatalog: vi.fn<(id: string) => boolean>(() => true),
   loginIntercepted: vi.fn(),
   registerApiProvider: vi.fn(),
   saveOAuthAccount: vi.fn(),
@@ -13,6 +24,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@earendil-works/pi-ai/compat', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@earendil-works/pi-ai/compat')>()),
+  createAssistantMessageEventStream: mocks.createAssistantMessageEventStream,
   registerApiProvider: mocks.registerApiProvider,
   streamOpenAICompletions: mocks.streamOpenAICompletions,
   streamSimpleOpenAICompletions: mocks.streamSimpleOpenAICompletions,
@@ -48,6 +60,7 @@ vi.mock('../../providers/openrouter-models.js', () => ({
   FREE_ROUTER_FALLBACK: { id: 'openrouter/free', name: 'Free Models Router' },
   fetchModels: mocks.fetchModels,
   getFreeCatalog: mocks.getFreeCatalog,
+  isModelInFreeCatalog: mocks.isModelInFreeCatalog,
 }));
 
 vi.mock('../../providers/openrouter-oauth.js', () => ({
@@ -64,6 +77,17 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.getApiKeyForProvider.mockReturnValue('stored-oauth-key');
   mocks.getFreeCatalog.mockReturnValue([]);
+  mocks.isModelInFreeCatalog.mockReturnValue(true);
+  mocks.createAssistantMessageEventStream.mockImplementation(() => {
+    const stream = {
+      push: vi.fn(),
+      end: vi.fn(),
+      [Symbol.asyncIterator]: async function* () {
+        /* empty refuse stream for tests */
+      },
+    };
+    return stream;
+  });
 });
 
 describe('OpenRouter (Free) provider config', () => {
@@ -194,5 +218,35 @@ describe('OpenRouter (Free) stream registration', () => {
         },
       })
     );
+  });
+
+  it('refuses models absent from the current free catalog without calling OpenRouter', async () => {
+    mocks.isModelInFreeCatalog.mockReturnValue(false);
+    const refuseStream = {
+      push: vi.fn(),
+      end: vi.fn(),
+      [Symbol.asyncIterator]: async function* () {
+        /* empty */
+      },
+    };
+    mocks.createAssistantMessageEventStream.mockReturnValue(refuseStream);
+
+    const provider = registeredProvider();
+    provider.stream(model as never, context as never, {} as never);
+
+    expect(mocks.streamOpenAICompletions).not.toHaveBeenCalled();
+    expect(mocks.createAssistantMessageEventStream).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(refuseStream.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          error: expect.objectContaining({
+            stopReason: 'error',
+            errorMessage: expect.stringMatching(/not in the current free catalog/i),
+          }),
+        })
+      );
+      expect(refuseStream.end).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/packages/webapp/tests/providers/openrouter-free-config.test.ts
+++ b/packages/webapp/tests/providers/openrouter-free-config.test.ts
@@ -1,10 +1,9 @@
-import { OPENROUTER_MODELS } from '@earendil-works/pi-ai/providers/openrouter.models';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   fetchModels: vi.fn(),
   getApiKeyForProvider: vi.fn<() => string | null>(() => 'stored-oauth-key'),
-  getCatalog: vi.fn<() => unknown[]>(() => []),
+  getFreeCatalog: vi.fn<() => unknown[]>(() => []),
   loginIntercepted: vi.fn(),
   registerApiProvider: vi.fn(),
   saveOAuthAccount: vi.fn(),
@@ -29,8 +28,6 @@ vi.mock('../../src/ui/provider-settings.js', async (importOriginal) => ({
   saveOAuthAccount: mocks.saveOAuthAccount,
 }));
 
-// Keep the discovery assertion focused on the OpenRouter override. Loading every
-// unrelated provider here instruments their unexercised implementations.
 vi.mock('../../src/providers/built-in/azure-ai-foundry.js', () => ({ config: undefined }));
 vi.mock('../../src/providers/built-in/azure-openai.js', () => ({ config: undefined }));
 vi.mock('../../src/providers/built-in/bedrock-camp.js', () => ({ config: undefined }));
@@ -40,6 +37,7 @@ vi.mock('../../providers/cerebras.js', () => ({ config: undefined }));
 vi.mock('../../providers/github-copilot.js', () => ({ config: undefined }));
 vi.mock('../../providers/github.js', () => ({ config: undefined }));
 vi.mock('../../providers/openai-codex.js', () => ({ config: undefined }));
+vi.mock('../../providers/openrouter.js', () => ({ config: undefined }));
 vi.mock('../../providers/xai-grok-errors.js', () => ({ config: undefined }));
 vi.mock('../../providers/xai-grok-models.js', () => ({ config: undefined }));
 vi.mock('../../providers/xai-grok-sanitize.js', () => ({ config: undefined }));
@@ -47,12 +45,10 @@ vi.mock('../../providers/xai-grok.js', () => ({ config: undefined }));
 
 vi.mock('../../providers/openrouter-models.js', () => ({
   config: undefined,
+  FREE_ROUTER_FALLBACK: { id: 'openrouter/free', name: 'Free Models Router' },
   fetchModels: mocks.fetchModels,
-  getCatalog: mocks.getCatalog,
-  getFreeCatalog: () => [],
+  getFreeCatalog: mocks.getFreeCatalog,
 }));
-
-vi.mock('../../providers/openrouter-free.js', () => ({ config: undefined }));
 
 vi.mock('../../providers/openrouter-oauth.js', () => ({
   config: undefined,
@@ -60,39 +56,36 @@ vi.mock('../../providers/openrouter-oauth.js', () => ({
 }));
 
 import type { Api, Context, Model } from '@earendil-works/pi-ai';
-import { config, register } from '../../providers/openrouter.js';
+import { config, register } from '../../providers/openrouter-free.js';
 import { getProviderConfig } from '../../src/providers/account-store.js';
-import { registerProviders } from '../../src/providers/index.js';
+import { registerProviderConfig, unregisterProviderConfig } from '../../src/providers/index.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getApiKeyForProvider.mockReturnValue('stored-oauth-key');
-  mocks.getCatalog.mockReturnValue([]);
+  mocks.getFreeCatalog.mockReturnValue([]);
 });
 
-describe('OpenRouter provider config', () => {
-  it('declares PKCE OAuth UI settings and a seeded default model', () => {
+describe('OpenRouter (Free) provider config', () => {
+  it('declares PKCE OAuth UI settings and the free-router default', () => {
     expect(config).toMatchObject({
-      id: 'openrouter',
-      name: 'OpenRouter',
+      id: 'openrouter-free',
+      name: 'OpenRouter (Free)',
       isOAuth: true,
       requiresApiKey: false,
       requiresBaseUrl: false,
-      defaultModelId: 'anthropic/claude-sonnet-4.6',
+      defaultModelId: 'openrouter/free',
       oauthTokenDomains: ['openrouter.ai', '*.openrouter.ai'],
     });
-    expect(config.description).toContain('PKCE');
-    expect(Object.hasOwn(OPENROUTER_MODELS, config.defaultModelId!)).toBe(true);
+    expect(config.description).toMatch(/free/i);
   });
 
-  it('delegates synchronous model discovery to the catalog module', () => {
-    const catalog = [
-      { id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6', api: 'openai' },
-    ];
-    mocks.getCatalog.mockReturnValue(catalog);
+  it('delegates synchronous model discovery to the free catalog', () => {
+    const catalog = [{ id: 'openrouter/free', name: 'Free Models Router', api: 'openai' }];
+    mocks.getFreeCatalog.mockReturnValue(catalog);
 
     expect(config.getModelIds!()).toEqual(catalog);
-    expect(mocks.getCatalog).toHaveBeenCalledOnce();
+    expect(mocks.getFreeCatalog).toHaveBeenCalledOnce();
   });
 
   it('exposes model refresh for hosted account prewarming', async () => {
@@ -100,15 +93,19 @@ describe('OpenRouter provider config', () => {
     expect(mocks.fetchModels).toHaveBeenCalledOnce();
   });
 
-  it('is auto-discovered and overrides the pi-ai fallback config', async () => {
-    await registerProviders();
-    expect(getProviderConfig('openrouter').isOAuth).toBe(true);
-    expect(getProviderConfig('openrouter').requiresApiKey).toBe(false);
+  it('registers as an OAuth provider config when added to the runtime registry', () => {
+    registerProviderConfig(config);
+    try {
+      expect(getProviderConfig('openrouter-free').isOAuth).toBe(true);
+      expect(getProviderConfig('openrouter-free').requiresApiKey).toBe(false);
+    } finally {
+      unregisterProviderConfig('openrouter-free');
+    }
   });
 });
 
-describe('OpenRouter OAuth hooks', () => {
-  it('refreshes and caches models after token storage and before success', async () => {
+describe('OpenRouter (Free) OAuth hooks', () => {
+  it('logs in under openrouter-free and refreshes before success', async () => {
     const order: string[] = [];
     const launcher = vi.fn();
     const options = { forceReauth: true };
@@ -124,52 +121,52 @@ describe('OpenRouter OAuth hooks', () => {
 
     await config.onOAuthLoginIntercepted!(launcher, () => order.push('success'), options);
 
-    expect(mocks.loginIntercepted).toHaveBeenCalledWith(launcher, expect.any(Function), options);
+    expect(mocks.loginIntercepted).toHaveBeenCalledWith(launcher, expect.any(Function), {
+      ...options,
+      providerId: 'openrouter-free',
+    });
     expect(order).toEqual(['login', 'stored', 'refresh', 'success']);
   });
 
   it('reports OAuth success when the best-effort model refresh rejects', async () => {
-    const launcher = vi.fn();
     const onSuccess = vi.fn();
     mocks.loginIntercepted.mockResolvedValue(undefined);
     mocks.fetchModels.mockRejectedValue(new Error('catalog unavailable'));
 
-    await expect(config.onOAuthLoginIntercepted!(launcher, onSuccess)).resolves.toBeUndefined();
-
-    expect(mocks.fetchModels).toHaveBeenCalledOnce();
+    await expect(config.onOAuthLoginIntercepted!(vi.fn(), onSuccess)).resolves.toBeUndefined();
     expect(onSuccess).toHaveBeenCalledOnce();
   });
 
   it('clears the stored OAuth token on logout', async () => {
     await config.onOAuthLogout!();
     expect(mocks.saveOAuthAccount).toHaveBeenCalledWith({
-      providerId: 'openrouter',
+      providerId: 'openrouter-free',
       accessToken: '',
     });
   });
 });
 
-describe('OpenRouter stream registration', () => {
+describe('OpenRouter (Free) stream registration', () => {
   function registeredProvider() {
     register();
     return mocks.registerApiProvider.mock.calls[0][0];
   }
 
   const model = {
-    id: 'anthropic/claude-sonnet-4.6',
-    provider: 'openrouter',
-    api: 'openrouter-openai',
+    id: 'openrouter/free',
+    provider: 'openrouter-free',
+    api: 'openrouter-free-openai',
   } as Model<Api>;
   const context = { messages: [] } as unknown as Context;
 
-  it('registers the synthetic OpenRouter API with both stream functions', () => {
+  it('registers the synthetic Free API with both stream functions', () => {
     const provider = registeredProvider();
-    expect(provider.api).toBe('openrouter-openai');
+    expect(provider.api).toBe('openrouter-free-openai');
     expect(provider.stream).toBeTypeOf('function');
     expect(provider.streamSimple).toBeTypeOf('function');
   });
 
-  it('delegates streaming with the stored key, base URL, and attribution headers', () => {
+  it('delegates streaming with the stored free-provider key and attribution', () => {
     const provider = registeredProvider();
     provider.stream(
       model as never,
@@ -180,6 +177,7 @@ describe('OpenRouter stream registration', () => {
       } as never
     );
 
+    expect(mocks.getApiKeyForProvider).toHaveBeenCalledWith('openrouter-free');
     expect(mocks.streamOpenAICompletions).toHaveBeenCalledWith(
       expect.objectContaining({
         id: model.id,
@@ -191,27 +189,6 @@ describe('OpenRouter stream registration', () => {
         apiKey: 'stored-oauth-key',
         headers: {
           'X-Custom': 'kept',
-          'HTTP-Referer': 'https://sliccy.ai',
-          'X-Title': 'SLICC',
-        },
-      })
-    );
-  });
-
-  it('preserves a caller/env-resolved key for simple streaming when no OAuth key is stored', () => {
-    mocks.getApiKeyForProvider.mockReturnValue(null);
-    const provider = registeredProvider();
-    provider.streamSimple(model as never, context as never, { apiKey: 'env-key' } as never);
-
-    expect(mocks.streamSimpleOpenAICompletions).toHaveBeenCalledWith(
-      expect.objectContaining({
-        api: 'openai-completions',
-        baseUrl: 'https://openrouter.ai/api/v1',
-      }),
-      context,
-      expect.objectContaining({
-        apiKey: 'env-key',
-        headers: {
           'HTTP-Referer': 'https://sliccy.ai',
           'X-Title': 'SLICC',
         },

--- a/packages/webapp/tests/providers/openrouter-models.test.ts
+++ b/packages/webapp/tests/providers/openrouter-models.test.ts
@@ -7,6 +7,7 @@ import {
   getCatalog,
   getFreeCatalog,
   isFreeAgentCapableModel,
+  isModelInFreeCatalog,
   isOpenRouterFreePriced,
   loadCache,
   loadFilterPatterns,
@@ -131,6 +132,27 @@ describe('OpenRouter free-agent filter', () => {
     expect(isOpenRouterFreePriced({ id: 'vendor/model', name: 'Unknown' })).toBe(false);
   });
 
+  it('rejects zero token prices when image or request charges are nonzero', () => {
+    expect(
+      isOpenRouterFreePriced({
+        ...freeAgentModel,
+        pricing: { prompt: '0', completion: '0', image: '0.0001' },
+      })
+    ).toBe(false);
+    expect(
+      isOpenRouterFreePriced({
+        ...freeAgentModel,
+        pricing: { prompt: '0', completion: '0', request: '0.01' },
+      })
+    ).toBe(false);
+    expect(
+      isOpenRouterFreePriced({
+        ...freeAgentModel,
+        pricing: { prompt: '0', completion: '0', image: '0', request: '0', discount: 0 },
+      })
+    ).toBe(true);
+  });
+
   it('requires free pricing, vision input, text output, and tool params', () => {
     expect(isFreeAgentCapableModel(freeAgentModel)).toBe(true);
     expect(isFreeAgentCapableModel(paidVisionModel)).toBe(false);
@@ -172,6 +194,12 @@ describe('OpenRouter free-agent filter', () => {
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       },
     ]);
+  });
+
+  it('reports membership via isModelInFreeCatalog', () => {
+    saveCache([freeAgentModel]);
+    expect(isModelInFreeCatalog(freeAgentModel.id)).toBe(true);
+    expect(isModelInFreeCatalog('vendor/paid-elsewhere')).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/providers/openrouter-models.test.ts
+++ b/packages/webapp/tests/providers/openrouter-models.test.ts
@@ -1,9 +1,13 @@
 import { OPENROUTER_MODELS } from '@earendil-works/pi-ai/providers/openrouter.models';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  FREE_ROUTER_FALLBACK,
   fetchModels,
   filterModels,
   getCatalog,
+  getFreeCatalog,
+  isFreeAgentCapableModel,
+  isOpenRouterFreePriced,
   loadCache,
   loadFilterPatterns,
   type OpenRouterModel,
@@ -32,6 +36,26 @@ const liveModel: OpenRouterModel = {
   architecture: { input_modalities: ['text', 'image'] },
   top_provider: { max_completion_tokens: 32_000 },
   supported_parameters: ['tools', 'include_reasoning'],
+};
+
+const freeAgentModel: OpenRouterModel = {
+  id: 'vendor/free-vision:free',
+  name: 'Free Vision',
+  context_length: 128_000,
+  architecture: {
+    input_modalities: ['text', 'image'],
+    output_modalities: ['text'],
+  },
+  top_provider: { max_completion_tokens: 8_192 },
+  supported_parameters: ['tools', 'temperature', 'top_p', 'tool_choice'],
+  pricing: { prompt: '0', completion: '0' },
+};
+
+const paidVisionModel: OpenRouterModel = {
+  ...freeAgentModel,
+  id: 'vendor/paid-vision',
+  name: 'Paid Vision',
+  pricing: { prompt: '0.000001', completion: '0.000002' },
 };
 
 beforeEach(() => {
@@ -95,6 +119,59 @@ describe('OpenRouter mapping', () => {
       reasoning: false,
       input: ['text'],
     });
+  });
+});
+
+describe('OpenRouter free-agent filter', () => {
+  it('treats zero pricing and :free ids as free', () => {
+    expect(isOpenRouterFreePriced(freeAgentModel)).toBe(true);
+    expect(isOpenRouterFreePriced(paidVisionModel)).toBe(false);
+    expect(isOpenRouterFreePriced({ id: 'openrouter/free', name: 'Router' })).toBe(true);
+    expect(isOpenRouterFreePriced({ id: 'vendor/model:free', name: 'Tagged' })).toBe(true);
+    expect(isOpenRouterFreePriced({ id: 'vendor/model', name: 'Unknown' })).toBe(false);
+  });
+
+  it('requires free pricing, vision input, text output, and tool params', () => {
+    expect(isFreeAgentCapableModel(freeAgentModel)).toBe(true);
+    expect(isFreeAgentCapableModel(paidVisionModel)).toBe(false);
+    expect(
+      isFreeAgentCapableModel({
+        ...freeAgentModel,
+        architecture: { input_modalities: ['text'], output_modalities: ['text'] },
+      })
+    ).toBe(false);
+    expect(
+      isFreeAgentCapableModel({
+        ...freeAgentModel,
+        architecture: { input_modalities: ['text', 'image'], output_modalities: ['audio'] },
+      })
+    ).toBe(false);
+    expect(
+      isFreeAgentCapableModel({
+        ...freeAgentModel,
+        supported_parameters: ['temperature', 'top_p'],
+      })
+    ).toBe(false);
+  });
+
+  it('returns only free agent models from the live cache with zero cost', () => {
+    saveCache([liveModel, freeAgentModel, paidVisionModel]);
+    expect(getFreeCatalog()).toEqual([
+      {
+        ...toModelMetadata(freeAgentModel),
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    ]);
+  });
+
+  it('falls back to the free router when nothing matches', () => {
+    saveCache([liveModel, paidVisionModel]);
+    expect(getFreeCatalog()).toEqual([
+      {
+        ...toModelMetadata(FREE_ROUTER_FALLBACK),
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    ]);
   });
 });
 

--- a/packages/webapp/tests/providers/openrouter-oauth.test.ts
+++ b/packages/webapp/tests/providers/openrouter-oauth.test.ts
@@ -119,6 +119,23 @@ describe('loginIntercepted', () => {
     expect(onSuccess).toHaveBeenCalledOnce();
   });
 
+  it('stores the permanent key under an alternate provider id when requested', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ key: 'sk-or-v1-free' }), { status: 200 }))
+    );
+    const launcher = vi.fn(async () => `${OPENROUTER_CALLBACK_URL}?code=oauth-code`);
+
+    await loginIntercepted(launcher, vi.fn(), { providerId: 'openrouter-free' });
+
+    expect(saveOAuthAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: 'openrouter-free',
+        accessToken: 'sk-or-v1-free',
+      })
+    );
+  });
+
   it('does not exchange or save when the launcher is cancelled', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
## Summary

Adds an **OpenRouter (Free)** provider (`openrouter-free`) that uses the same PKCE login and OpenAI-compatible streaming as OpenRouter, but only offers models that are currently free and suitable for a SLICC agent loop (vision + tools).

## Why

Users want a provider that stays on OpenRouter’s free tier without browsing the full paid catalog. OpenRouter’s website filter for free + text/image + tools is a useful default; we enforce the parts available from `/api/v1/models` and refresh the list on login.

## Approach / Implementation notes

- New external provider: `packages/webapp/providers/openrouter-free.ts`
- Shared catalog helpers in `openrouter-models.ts`: `isFreeAgentCapableModel` / `getFreeCatalog`
- Filter: zero pricing (or `:free` / `openrouter/free`) + text+image input + text output + `tools`/`temperature`/`top_p`
- `min_tool_success_rate` is website-only and intentionally omitted
- Cold start falls back to `openrouter/free`; free catalog entries force `$0` cost metadata
- OAuth login reuses OpenRouter PKCE with `providerId: 'openrouter-free'` (separate account)

## Cross-cutting impact

- **Floats**: CLI / extension / Electron / worker — same external-provider discovery path as existing OpenRouter
- Full OpenRouter provider unchanged aside from shared helpers and optional `providerId` on login
- No persisted schema migration; uses existing OpenRouter models cache key

## Test plan

- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm test -- packages/webapp/tests/providers/openrouter` — 48 passing
- [ ] Manual smoke: Accounts → OpenRouter (Free) → login → confirm picker shows only free vision+tools models (and refreshes after catalog refresh)

## Documentation

- [x] `README.md`
- [x] `packages/webapp/CLAUDE.md`
- [x] `docs/oauth-intercept.md`, `docs/pitfalls.md`

## Risk & rollback

- Low blast radius: additive provider; existing OpenRouter accounts unaffected
- Rollback: revert this PR
- Manual OAuth round-trip not covered by unit tests

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff

Made with [Cursor](https://cursor.com)