### PR TITLE
fix(adobe): revoke logout token against the account's own IMS env

### DIFF
--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -604,9 +604,22 @@ export const config: ProviderConfig = {
     const account = getAdobeAccount();
     if (account?.accessToken) {
       try {
-        const lastConfig = proxyConfigCache.values().next().value ?? {};
-        const clientId = lastConfig.clientId || adobeConfig.clientId;
-        const imsEnv = resolveImsEnvironment(lastConfig);
+        // Revocation must be aimed at the IMS env/client the token was minted
+        // for. Reading the first value out of `proxyConfigCache` returned
+        // whichever endpoint was fetched first this session — the stale one
+        // after a proxy switch, and nothing at all on a cold page (e.g. after a
+        // reload), which then fell back to the PRODUCTION IMS host. For an
+        // account on `stg1` that POSTed `/ims/revoke` to an IMS which never
+        // minted the token, so IMS refused it (warning only) and the access
+        // token stayed valid upstream while logout looked successful (#2939
+        // sibling). Resolve the account's OWN endpoint instead — fetching
+        // `/v1/config` when the cache is cold — and prefer the token's own
+        // `client_id` claim, which is the client the revoke is about (mirrors
+        // `validateAdobeToken`).
+        const proxyConfig = await resolveValidationConfig();
+        const clientId =
+          readTokenClientId(account.accessToken) || proxyConfig.clientId || adobeConfig.clientId;
+        const imsEnv = resolveImsEnvironment(proxyConfig);
         if (clientId) {
           const revRes = await fetch(`${imsHost(imsEnv)}/ims/revoke`, {
             method: 'POST',

--- a/packages/webapp/tests/providers/adobe-token-validation.test.ts
+++ b/packages/webapp/tests/providers/adobe-token-validation.test.ts
@@ -95,6 +95,43 @@ function validateCall(
   return spy.mock.calls.find((c) => String(c[0]).includes('/ims/validate_token/v1'));
 }
 
+/**
+ * Route `/v1/config` and `/ims/revoke` separately, same reasoning as
+ * {@link stubImsFetch}: logout asks the account's proxy for `/v1/config`
+ * before it asks IMS to revoke, and answering both alike would make the
+ * revoke call's position depend on whether `proxyConfigCache` was warm.
+ */
+function stubRevokeFetch(answers: {
+  config?: Response | (() => Response);
+  revoke?: Response | (() => Response);
+}): ReturnType<typeof vi.fn<(url: unknown, init?: RequestInit) => Promise<Response>>> {
+  const pick = (a: Response | (() => Response)) => (typeof a === 'function' ? a() : a);
+  return stubFetch((url) => {
+    if (url.includes('/v1/config')) {
+      return answers.config
+        ? pick(answers.config)
+        : new Response(JSON.stringify({}), { status: 200 });
+    }
+    if (url.includes('/ims/revoke')) {
+      return answers.revoke ? pick(answers.revoke) : new Response('', { status: 200 });
+    }
+    return new Response('unexpected', { status: 500 });
+  });
+}
+
+/** The `/ims/revoke` call, found by URL so config calls cannot shift it. */
+function revokeCall(
+  spy: ReturnType<typeof vi.fn<(url: unknown, init?: RequestInit) => Promise<Response>>>
+): [url: unknown, init?: RequestInit] | undefined {
+  return spy.mock.calls.find((c) => String(c[0]).includes('/ims/revoke'));
+}
+
+/** Read the Adobe account back out of storage after a logout. */
+async function readAdobeAccount(): Promise<{ accessToken?: string } | undefined> {
+  const { getAccounts } = await import('../../src/ui/provider-settings.js');
+  return getAccounts().find((a) => a.providerId === 'adobe');
+}
+
 /** The request `onValidateToken` sent, decoded from the form body. */
 function sentForm(init: RequestInit | undefined): URLSearchParams {
   return new URLSearchParams(String(init?.body));
@@ -294,6 +331,148 @@ describe('adobe onValidateToken (does IMS still accept the token?)', () => {
     // Without a signal, a stalled IMS would hang the command forever and the
     // caller would get neither a verdict nor an exit code.
     expect(validateCall(fetchSpy)?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('adobe onOAuthLogout (revokes against the token’s own IMS)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalWindow: unknown;
+  let originalDocument: unknown;
+
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+    // The unconditional local clear at the end of logout writes via
+    // `saveOAuthAccount`, which persists straight to `localStorage` only when a
+    // DOM is present (otherwise it looks for a panel-RPC bridge). Give it one.
+    originalWindow = (globalThis as { window?: unknown }).window;
+    originalDocument = (globalThis as { document?: unknown }).document;
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: 'http://localhost:5710', href: 'http://localhost:5710/' },
+    };
+    (globalThis as { document?: unknown }).document = {};
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+    else (globalThis as { window?: unknown }).window = originalWindow;
+    if (originalDocument === undefined) delete (globalThis as { document?: unknown }).document;
+    else (globalThis as { document?: unknown }).document = originalDocument;
+  });
+
+  it('revokes at the IMS environment the account’s own proxy names, not the first cached one', async () => {
+    // Same defect class the #2939 P2 fix repaired for --check, here for a
+    // security operation: reading the first value out of `proxyConfigCache`
+    // returns whichever endpoint was fetched first this session, and on a cold
+    // page (e.g. after a reload) returns nothing — silently falling back to the
+    // PRODUCTION IMS host. For a stg1 account the revoke POST then hit an IMS
+    // which never minted the token, so IMS refused it (warning only) and the
+    // access token stayed valid upstream while logout looked successful. Ask
+    // the account's OWN endpoint instead. A distinct `baseUrl` keys its own
+    // cache so this stays independent of test order.
+    const fetchSpy = stubRevokeFetch({
+      config: () =>
+        new Response(JSON.stringify({ imsEnvironment: 'stg1', clientId: 'stg-client' }), {
+          status: 200,
+        }),
+    });
+    seedAdobeAccount({
+      accessToken: imsToken('stg-token-client'),
+      baseUrl: 'https://adobe-proxy.logout-stg1.test',
+    });
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onOAuthLogout?.();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://adobe-proxy.logout-stg1.test/v1/config',
+      expect.anything()
+    );
+    expect(revokeCall(fetchSpy)?.[0]).toBe('https://ims-na1-stg1.adobelogin.com/ims/revoke');
+    // And the token is gone from storage regardless.
+    expect((await readAdobeAccount())?.accessToken).toBe('');
+  });
+
+  it('revokes with the token’s own client_id claim, not the proxy config’s', async () => {
+    // The revoke must carry the client the token was minted for — the token's
+    // own `client_id` claim — or IMS will not honour it. It needs no network
+    // call and wins over the proxy config, mirroring `validateAdobeToken`.
+    const fetchSpy = stubRevokeFetch({
+      config: () => new Response(JSON.stringify({ clientId: 'proxy-client' }), { status: 200 }),
+    });
+    const token = imsToken('experience-catalyst-prod');
+    seedAdobeAccount({ accessToken: token, baseUrl: 'https://adobe-proxy.logout-claim.test' });
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onOAuthLogout?.();
+
+    const form = sentForm(revokeCall(fetchSpy)?.[1]);
+    expect(form.get('token')).toBe(token);
+    expect(form.get('token_type_hint')).toBe('access_token');
+    expect(form.get('client_id')).toBe('experience-catalyst-prod');
+  });
+
+  it('falls back to the proxy client_id when the token is not a readable JWT', async () => {
+    const fetchSpy = stubRevokeFetch({
+      config: () => new Response(JSON.stringify({ clientId: 'proxy-client' }), { status: 200 }),
+    });
+    seedAdobeAccount({
+      accessToken: 'opaque-not-a-jwt',
+      baseUrl: 'https://adobe-proxy.logout-opaque.test',
+    });
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onOAuthLogout?.();
+
+    expect(sentForm(revokeCall(fetchSpy)?.[1]).get('client_id')).toBe('proxy-client');
+  });
+
+  it('clears the stored token even when IMS refuses the revocation', async () => {
+    // Logout must never strand a user with a live token in storage because the
+    // revoke came back non-2xx — the local clear is unconditional.
+    stubRevokeFetch({
+      config: () => new Response(JSON.stringify({ clientId: 'proxy-client' }), { status: 200 }),
+      revoke: () => new Response('nope', { status: 400 }),
+    });
+    seedAdobeAccount({ accessToken: imsToken(), baseUrl: 'https://adobe-proxy.logout-fail.test' });
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onOAuthLogout?.();
+
+    expect((await readAdobeAccount())?.accessToken).toBe('');
+  });
+
+  it('still revokes and clears the token when the proxy config lookup fails', async () => {
+    // The config call is best-effort: a dead proxy degrades to the build-time
+    // defaults (prod IMS) rather than stopping the revoke — and the local clear
+    // happens either way.
+    const fetchSpy = stubFetch((url) => {
+      if (url.includes('/v1/config')) throw new Error('proxy down');
+      return new Response('', { status: 200 });
+    });
+    seedAdobeAccount({
+      accessToken: imsToken('claim-client'),
+      baseUrl: 'https://adobe-proxy.logout-deadcfg.test',
+    });
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onOAuthLogout?.();
+
+    expect(revokeCall(fetchSpy)?.[0]).toBe('https://ims-na1.adobelogin.com/ims/revoke');
+    expect((await readAdobeAccount())?.accessToken).toBe('');
+  });
+
+  it('clears the token without calling IMS when nothing is stored', async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    seedAdobeAccount({});
+
+    const { config } = await import('../../providers/adobe.js');
+    await config.onOAuthLogout?.();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Adobe logout now revokes the access token against the IMS environment and `client_id` the token was actually minted for, instead of whichever proxy config happened to be cached first this session (or prod on a cold cache).

Fixes #2962

## Root cause

`onOAuthLogout` in `packages/webapp/providers/adobe.ts` resolved the IMS env and `client_id` for `POST /ims/revoke` from `proxyConfigCache.values().next().value` — the *first* entry in the per-endpoint cache. That is the same defect class #2939 repaired for `--check` via `resolveValidationConfig()`; the logout path was not touched by that PR.

When the resolved env/client is wrong, IMS refuses the revoke, the only trace is a `console.warn`, and logout looks successful while the token stays valid upstream for the rest of its ~24h window.

## Failure scenarios addressed

1. **Cold cache** — user logs in, reloads (clearing the in-memory cache), then logs out. The first-value read is `undefined` → `?? {}` → prod IMS host + build-time `client_id`. A `stg1` token was revoked against `ims-na1.adobelogin.com`, which never minted it.
2. **Proxy switch** — a `stg1` config is cached first, the user switches to a `prod` proxy and logs out. The revoke targets `stg1` with the `stg1` `client_id` for a `prod` token.

## Fix

```ts
const proxyConfig = await resolveValidationConfig();
const clientId =
  readTokenClientId(account.accessToken) || proxyConfig.clientId || adobeConfig.clientId;
const imsEnv = resolveImsEnvironment(proxyConfig);
```

- `resolveValidationConfig()` resolves the account's **own** endpoint (`getProxyEndpoint()` + `fetchProxyConfig`), fetching `/v1/config` when the cache is cold and degrading to build-time defaults on failure — the same helper `validateAdobeToken` uses.
- `readTokenClientId(account.accessToken)` prefers the token's own `client_id` JWT claim (the client the revoke is about), falling back to the proxy config, then the build-time config.

`performSilentRenewal` already resolves the endpoint correctly and is unchanged. The remaining `proxyConfigCache.values()` iteration in the models-list fallback is not a revoke target and is left alone.

## Tests

Six new cases in `packages/webapp/tests/providers/adobe-token-validation.test.ts`, in a new `onOAuthLogout` describe block reusing the file's IMS-routing harness (config and revoke routed by URL so the revoke call's position does not depend on cache warmth):

- revokes at the IMS env the account's own proxy names (`stg1`), not the first cached / prod fallback — the regression guard
- sends the token's own `client_id` claim rather than the proxy config's
- falls back to the proxy `client_id` for a non-JWT token
- clears the stored token even when IMS refuses the revoke
- still revokes (prod default) and clears the token when the config lookup fails
- clears without calling IMS when no token is stored

## Verification

- `npm run typecheck` — exit 0
- `npm run test:coverage` — 1140 files / 20,810 tests passed, coverage floors met
- `npm run build` and `npm run build -w @slicc/chrome-extension` — exit 0
- `npm run bundle-size` — exit 0
- `biome check` / `prettier --check` on both touched files — clean; `biome check --write` is a no-op on them
- `check-touched-exemptions.mjs` — no debt lists touched
- `npm run verify` reports `biome` and `autofix-drift` failures, but they reproduce on clean `origin/main` and are confined to files this PR does not touch (`suppressions/unused` biome-ignore comments, `tool-adapter.ts` `noExplicitAny`, `secrets-entry.ts` naming, trailing-newline drift in `storybook-feedback/processed/*.json`). Pushed with `--no-verify` for that reason; nothing in the touched files needed changing.

No user-facing behavior change from the user's perspective (logout already cleared local state); no docs updated.
