### PR TITLE
fix(webapp): apply the loopback guard on the LLM-proxy SW bridge fallback

### DIFF
--- a/packages/webapp/src/ui/llm-proxy-sw-config.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw-config.ts
@@ -18,7 +18,10 @@
  * (see `boot/setup-sw-registration.ts`); the SW caches it in a module
  * variable. On a cache miss (e.g. SW evicted then restarted by the
  * browser, message lost), the SW falls back to parsing `bridge` /
- * `bridgeToken` from the controlling client's URL.
+ * `bridgeToken` from the controlling client's URL — via the shared
+ * `parseBridgeLaunchParams`, so the same loopback guard applies as in the
+ * page realm and an attacker-suppliable non-loopback `bridge` cannot aim the
+ * local `/api` surface at a remote host on this fallback path (#2939 / #2963).
  */
 
 import type { FetchProxyRequestMsg } from '@slicc/shared-ts';
@@ -27,11 +30,7 @@ import {
   LEADER_RUNTIME_QUERY_NAME,
   LEADER_RUNTIME_QUERY_VALUE,
 } from '../kernel/messages.js';
-import {
-  BRIDGE_TOKEN_QUERY_PARAM,
-  BRIDGE_WS_QUERY_PARAM,
-  deriveBridgeApiBaseUrl,
-} from './boot/bridge-launch-params.js';
+import { parseBridgeLaunchParams } from './boot/bridge-launch-params.js';
 
 /** `postMessage` type tag used by the page → SW config push. */
 export const SW_BRIDGE_CONFIG_MESSAGE = 'slicc:bridge-config';
@@ -75,12 +74,19 @@ export function resolveBridgeConfig(
   } catch {
     return null;
   }
-  const wsUrl = parsed.searchParams.get(BRIDGE_WS_QUERY_PARAM);
-  const token = parsed.searchParams.get(BRIDGE_TOKEN_QUERY_PARAM);
-  if (!wsUrl || !token) return null;
-  const apiBaseUrl = deriveBridgeApiBaseUrl(wsUrl);
-  if (!apiBaseUrl) return null;
-  return { apiBaseUrl: apiBaseUrl.replace(/\/+$/, ''), token };
+  // Delegate to the page-realm launch-param parser so the SW's fallback path
+  // enforces the SAME loopback guard the page does (#2939 P1 / #2963). The
+  // `bridge` query param is attacker-suppliable on a hosted-origin page and
+  // `apiBaseUrl` is derived straight from its host, so a crafted link like
+  // `https://www.sliccy.ai/?bridge=wss://attacker.example/cdp&bridgeToken=x`
+  // must degrade to the no-bridge path HERE exactly as it does in the page
+  // realm — otherwise routing an intercepted fetch through the SW's cache-miss
+  // fallback would aim the local `/api` surface (and leak the bridge token) at
+  // an attacker-controlled origin. Reusing the one parser keeps a single
+  // loopback-guarded contract instead of a re-implemented copy that can drift.
+  const params = parseBridgeLaunchParams(parsed.search);
+  if (!params?.apiBaseUrl) return null;
+  return { apiBaseUrl: params.apiBaseUrl.replace(/\/+$/, ''), token: params.token };
 }
 
 /**

--- a/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
+++ b/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
@@ -83,10 +83,45 @@ describe('resolveBridgeConfig', () => {
   });
 
   it('returns null when the bridge URL cannot derive an api base', () => {
-    // Bare hostname → URL parser fails → deriveBridgeApiBaseUrl → null.
+    // 'not-a-url' fails the ws:// scheme test in parseBridgeLaunchParams → null.
     expect(
       resolveBridgeConfig(null, 'https://www.sliccy.ai/?bridge=not-a-url&bridgeToken=t')
     ).toBeNull();
+  });
+
+  it('rejects a non-loopback bridge host (#2963 — SW parser must apply the #2939 loopback guard)', () => {
+    // The `bridge` query param is attacker-suppliable on a hosted-origin page,
+    // and `apiBaseUrl` is derived straight from its host. Without the loopback
+    // guard on THIS fallback path, an intercepted fetch would be forwarded to
+    // `{attacker}/api/fetch-proxy` with the bridge token attached. Mirrors the
+    // page-realm `parseBridgeLaunchParams` refusal (same host list).
+    for (const host of [
+      'attacker.example',
+      'bridge.example',
+      '169.254.169.254',
+      '10.0.0.5',
+      'localhost.attacker.example',
+      '127.0.0.1.attacker.example',
+    ]) {
+      const clientUrl = `https://www.sliccy.ai/?bridge=${encodeURIComponent(
+        `wss://${host}/cdp`
+      )}&bridgeToken=deadbeef`;
+      expect(resolveBridgeConfig(null, clientUrl), host).toBeNull();
+    }
+  });
+
+  it('accepts every loopback spelling a launcher may emit on the fallback path', () => {
+    // Must keep matching `isLoopbackHostname` — the servers legitimately launch
+    // with IPv6 and 127.0.0.0/8 bridge hosts, not just `localhost`.
+    for (const host of ['localhost', '127.0.0.1', '127.0.0.2', '[::1]']) {
+      const clientUrl = `https://www.sliccy.ai/?bridge=${encodeURIComponent(
+        `ws://${host}:5710/cdp`
+      )}&bridgeToken=x`;
+      expect(resolveBridgeConfig(null, clientUrl), host).toEqual({
+        apiBaseUrl: `http://${host}:5710`,
+        token: 'x',
+      });
+    }
   });
 });
 
@@ -139,6 +174,30 @@ describe('resolveBridgeFromClientUrls', () => {
 
   it('returns null when given an empty candidate list and no cache', () => {
     expect(resolveBridgeFromClientUrls(null, [])).toBeNull();
+  });
+
+  it('skips a non-loopback candidate on the window-enumeration fallback (#2963)', () => {
+    // The `readWindowClientUrls()` fallback (kernel-worker-originated fetch /
+    // post-eviction cache miss) must NOT resolve a bridge from a crafted
+    // hosted-origin window URL naming a remote host — that is the exact path
+    // #2939's page-realm guard did not cover.
+    expect(
+      resolveBridgeFromClientUrls(null, [
+        'http://localhost:5710/kernel-worker.js',
+        'https://www.sliccy.ai/?bridge=wss://attacker.example/cdp&bridgeToken=deadbeef',
+      ])
+    ).toBeNull();
+  });
+
+  it('prefers a later loopback candidate over an earlier non-loopback one', () => {
+    // A non-loopback candidate is treated as "no bridge here" and skipped, so
+    // the scan continues to the genuine loopback leader instead of latching the
+    // attacker origin.
+    const out = resolveBridgeFromClientUrls(null, [
+      'https://www.sliccy.ai/?bridge=wss://attacker.example/cdp&bridgeToken=evil',
+      'https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=good',
+    ]);
+    expect(out).toEqual({ apiBaseUrl: 'http://localhost:5710', token: 'good' });
   });
 });
 


### PR DESCRIPTION
Fixes #2963

## Summary

The LLM-proxy service worker's cache-miss fallback re-parsed `bridge` / `bridgeToken` from the client URL and derived `apiBaseUrl` without the loopback guard that #2939 added to the page realm. `resolveBridgeConfig` in `packages/webapp/src/ui/llm-proxy-sw-config.ts` now delegates to the shared `parseBridgeLaunchParams`, so the SW enforces the same loopback contract as the page and a crafted hosted-origin link like `https://www.sliccy.ai/?bridge=wss://attacker.example/cdp&bridgeToken=x` degrades to the no-bridge path on the SW fallback exactly as it already does on the page.

Legitimate loopback bridges (`localhost`, `127.0.0.0/8`, `[::1]`) resolve identically to before.

## Root cause

`main.ts` validates launch params through `parseBridgeLaunchParams` (loopback-guarded since #2939) and pushes the validated `{ apiBaseUrl, token }` to the SW via `postMessage`. That cached path was safe. But the SW has a separate recovery path for cache misses — SW eviction/restart, and kernel-worker-originated fetches whose client URL carries no params, which trigger `readWindowClientUrls()` enumeration. On that path `resolveBridgeFromClientUrls(null, urls)` → `resolveBridgeConfig(null, url)` re-parsed the raw window-client URL with its own copy of the parser: `deriveBridgeApiBaseUrl(wsUrl)` only checked that the URL parsed, with no `isLoopbackHostname` check. `forwardThroughProxy` would then attach `X-Bridge-Token` and forward the intercepted fetch to `{attackerOrigin}/api/fetch-proxy`.

This was the "one contract, re-implemented, one copy fixed" shape #2939 was meant to close — here across the page realm and the SW realm.

## The rule

> A `bridge` WS URL taken from an attacker-suppliable query string must be loopback before any local-`/api` target is derived from its host. Any code path that turns launch params into an `apiBaseUrl` must apply that guard.

Rather than add a second inline copy of the check to the SW, the fix removes the duplicated parser: the SW now reuses the one loopback-guarded `parseBridgeLaunchParams` (which also inherits its `ws://` / `wss://` scheme check), so a future change to the guard cannot drift between realms. `deriveBridgeApiBaseUrl` stays a pure scheme mapper; the guard lives where an attacker-suppliable URL becomes a local target, matching the page realm.

## Tests added (`packages/webapp/tests/ui/llm-proxy-sw-config.test.ts`)

- `resolveBridgeConfig` rejects non-loopback bridge hosts, mirroring the page-realm host list: `attacker.example`, `bridge.example`, `169.254.169.254`, `10.0.0.5`, `localhost.attacker.example`, `127.0.0.1.attacker.example`.
- `resolveBridgeConfig` still accepts every loopback spelling a launcher may emit: `localhost`, `127.0.0.1`, `127.0.0.2`, `[::1]`.
- `resolveBridgeFromClientUrls` skips a non-loopback candidate on the window-enumeration fallback (the exact path the page-realm guard did not cover).
- `resolveBridgeFromClientUrls` prefers a later loopback candidate over an earlier non-loopback one instead of latching the attacker origin.
- Corrected the stale comment on the existing "cannot derive an api base" test.

## Verification

- `npm run verify` — biome (clean on the touched files), prettier, custom lints, boy-scout debt, manifest, knip, knip production, autofix drift
- `node packages/dev-tools/tools/check-touched-exemptions.mjs` — exit 0; `llm-proxy-sw-config.ts` is on no debt list
- `npm run typecheck` — all 9 tsconfig projects, exit 0 (includes the `tsconfig.webapp-worker.json` SW bundle)
- `npm run test` — 1140 files, 20808 tests passed
- `npm run test:coverage:webapp` — 900 files, 16554 tests passed, coverage floors met
- `npm run build` and `npm run build -w @slicc/chrome-extension` — exit 0
- `npm run bundle-size` — within budget
