### PR TITLE
fix(webapp): do not clobber MCP/plugin registries on read faults

### DIFF
--- a/packages/webapp/src/shell/mcp/store.ts
+++ b/packages/webapp/src/shell/mcp/store.ts
@@ -113,7 +113,13 @@ function normalize(raw: unknown): McpServersFile {
   return { version, servers };
 }
 
-/** Read the entire `servers.json`. Returns an empty file if missing/invalid. */
+/**
+ * Read the entire `servers.json`. A missing file or malformed JSON is empty
+ * (nothing durable to lose). Any other read fault propagates — treating EIO /
+ * EACCES / transient OPFS as empty would let `setServer` / `deleteServer`
+ * rewrite the registry from a truncated base and drop every other server
+ * (including its OAuth auth block).
+ */
 export async function readServersFile(injectedFs?: MinimalFs | null): Promise<McpServersFile> {
   try {
     const fs = await openFs(injectedFs);
@@ -128,10 +134,7 @@ export async function readServersFile(injectedFs?: MinimalFs | null): Promise<Mc
     }
   } catch (err) {
     if (err instanceof FsError && err.code === 'ENOENT') return emptyFile();
-    log.warn('Failed to read servers.json', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return emptyFile();
+    throw err;
   }
 }
 

--- a/packages/webapp/src/shell/plugins/store.ts
+++ b/packages/webapp/src/shell/plugins/store.ts
@@ -91,7 +91,12 @@ function normalize(raw: unknown): PluginsFile {
   return { version, plugins };
 }
 
-/** Read the entire `plugins.json`. Returns an empty file if missing/invalid. */
+/**
+ * Read the entire `plugins.json`. A missing file or malformed JSON is empty
+ * (nothing durable to lose). Any other read fault propagates — treating EIO /
+ * EACCES / transient OPFS as empty would let `setInstalledPlugin` /
+ * `deleteInstalledPlugin` rewrite the registry from a truncated base.
+ */
 export async function readPluginsFile(injectedFs?: MinimalFs | null): Promise<PluginsFile> {
   try {
     const fs = await openFs(injectedFs);
@@ -104,8 +109,7 @@ export async function readPluginsFile(injectedFs?: MinimalFs | null): Promise<Pl
     }
   } catch (err) {
     if (err instanceof FsError && err.code === 'ENOENT') return emptyFile();
-    // Unreadable registry — treat as empty rather than blocking the shell.
-    return emptyFile();
+    throw err;
   }
 }
 

--- a/packages/webapp/tests/shell/mcp/provider.test.ts
+++ b/packages/webapp/tests/shell/mcp/provider.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../../src/providers/oauth-service.js', async (importOriginal) => {
   };
 });
 
+import { FsError } from '../../../src/fs/types.js';
 import {
   getRegisteredProviderConfig,
   unregisterProviderConfig,
@@ -55,7 +56,7 @@ function makeFakeFsModule(storeJson: string | null) {
   const fakeFs = {
     readFile: async (path: string) => {
       if (path !== '/workspace/.mcp/servers.json' || storeJson === null) {
-        throw new Error('ENOENT');
+        throw new FsError('ENOENT', 'missing MCP registry', path);
       }
       return storeJson;
     },

--- a/packages/webapp/tests/shell/mcp/store.test.ts
+++ b/packages/webapp/tests/shell/mcp/store.test.ts
@@ -1,6 +1,7 @@
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { GLOBAL_FS_DB_NAME } from '../../../src/fs/global-db.js';
+import { FsError } from '../../../src/fs/types.js';
 import { VirtualFS } from '../../../src/fs/virtual-fs.js';
 import {
   deleteServer,
@@ -15,6 +16,22 @@ import {
   writeServersFile,
 } from '../../../src/shell/mcp/store.js';
 import type { McpServerEntry } from '../../../src/shell/mcp/types.js';
+
+function faultingMcpFs(code: 'ENOENT' | 'EIO' | 'EACCES') {
+  const writes: string[] = [];
+  return {
+    writes,
+    fs: {
+      async readFile(): Promise<string> {
+        throw new FsError(code, `${code} reading MCP registry`, MCP_STORE_PATH);
+      },
+      async writeFile(_path: string, content: string | Uint8Array): Promise<void> {
+        writes.push(typeof content === 'string' ? content : 'binary');
+      },
+      async mkdir(): Promise<void> {},
+    },
+  };
+}
 
 describe('mcp store', () => {
   beforeEach(async () => {
@@ -188,5 +205,50 @@ describe('mcp store', () => {
     await setServer('no-auth', { url: 'https://b.example' });
     const all = await readMcpAuthEntries();
     expect(all.map((e) => e.name)).toEqual(['with-auth']);
+  });
+});
+
+describe('mcp store read-modify-write faults', () => {
+  it('readServersFile treats ENOENT as empty and does not write', async () => {
+    const { fs, writes } = faultingMcpFs('ENOENT');
+    await expect(readServersFile(fs)).resolves.toEqual({ version: 1, servers: {} });
+    expect(writes).toEqual([]);
+  });
+
+  it('readServersFile treats invalid JSON as empty', async () => {
+    const writes: string[] = [];
+    const fs = {
+      async readFile(): Promise<string> {
+        return 'not json at all';
+      },
+      async writeFile(_path: string, content: string | Uint8Array): Promise<void> {
+        writes.push(typeof content === 'string' ? content : 'binary');
+      },
+      async mkdir(): Promise<void> {},
+    };
+    await expect(readServersFile(fs)).resolves.toEqual({ version: 1, servers: {} });
+    expect(writes).toEqual([]);
+  });
+
+  it('setServer from ENOENT writes the new entry onto an empty registry', async () => {
+    const { fs, writes } = faultingMcpFs('ENOENT');
+    await setServer('foo', { url: 'https://foo.example' }, fs);
+    expect(writes).toHaveLength(1);
+    const payload = JSON.parse(writes[0]) as { servers: Record<string, { url: string }> };
+    expect(payload.servers.foo.url).toBe('https://foo.example');
+  });
+
+  it('setServer propagates a non-ENOENT FsError and does not truncate the registry', async () => {
+    const { fs, writes } = faultingMcpFs('EIO');
+    await expect(setServer('foo', { url: 'https://foo.example' }, fs)).rejects.toThrow(
+      'EIO reading MCP registry'
+    );
+    expect(writes).toEqual([]);
+  });
+
+  it('deleteServer propagates a non-ENOENT FsError and does not truncate the registry', async () => {
+    const { fs, writes } = faultingMcpFs('EACCES');
+    await expect(deleteServer('foo', fs)).rejects.toThrow('EACCES reading MCP registry');
+    expect(writes).toEqual([]);
   });
 });

--- a/packages/webapp/tests/shell/plugins/store.test.ts
+++ b/packages/webapp/tests/shell/plugins/store.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { FsError } from '../../../src/fs/types.js';
+import {
+  deleteInstalledPlugin,
+  PLUGINS_STORE_PATH,
+  readPluginsFile,
+  setInstalledPlugin,
+} from '../../../src/shell/plugins/store.js';
+import type { InstalledPluginEntry } from '../../../src/shell/plugins/types.js';
+
+const SAMPLE: InstalledPluginEntry = {
+  root: '/workspace/.plugins/sources/reports-plugin',
+  version: '1.2.0',
+  installedAt: '2026-05-20T00:00:00.000Z',
+};
+
+function faultingPluginsFs(code: 'ENOENT' | 'EIO' | 'EACCES') {
+  const writes: string[] = [];
+  return {
+    writes,
+    fs: {
+      async readFile(): Promise<string> {
+        throw new FsError(code, `${code} reading plugins registry`, PLUGINS_STORE_PATH);
+      },
+      async writeFile(_path: string, content: string | Uint8Array): Promise<void> {
+        writes.push(typeof content === 'string' ? content : 'binary');
+      },
+      async mkdir(): Promise<void> {},
+    },
+  };
+}
+
+describe('plugins store read-modify-write faults', () => {
+  it('readPluginsFile treats ENOENT as empty and does not write', async () => {
+    const { fs, writes } = faultingPluginsFs('ENOENT');
+    await expect(readPluginsFile(fs)).resolves.toEqual({ version: 1, plugins: {} });
+    expect(writes).toEqual([]);
+  });
+
+  it('readPluginsFile treats invalid JSON as empty', async () => {
+    const writes: string[] = [];
+    const fs = {
+      async readFile(): Promise<string> {
+        return 'not json at all';
+      },
+      async writeFile(_path: string, content: string | Uint8Array): Promise<void> {
+        writes.push(typeof content === 'string' ? content : 'binary');
+      },
+      async mkdir(): Promise<void> {},
+    };
+    await expect(readPluginsFile(fs)).resolves.toEqual({ version: 1, plugins: {} });
+    expect(writes).toEqual([]);
+  });
+
+  it('setInstalledPlugin from ENOENT writes the new entry onto an empty registry', async () => {
+    const { fs, writes } = faultingPluginsFs('ENOENT');
+    await setInstalledPlugin('reports-plugin', SAMPLE, fs);
+    expect(writes).toHaveLength(1);
+    const payload = JSON.parse(writes[0]) as {
+      plugins: Record<string, InstalledPluginEntry>;
+    };
+    expect(payload.plugins['reports-plugin'].root).toBe(SAMPLE.root);
+  });
+
+  it('setInstalledPlugin propagates a non-ENOENT FsError and does not truncate the registry', async () => {
+    const { fs, writes } = faultingPluginsFs('EIO');
+    await expect(setInstalledPlugin('reports-plugin', SAMPLE, fs)).rejects.toThrow(
+      'EIO reading plugins registry'
+    );
+    expect(writes).toEqual([]);
+  });
+
+  it('deleteInstalledPlugin propagates a non-ENOENT FsError and does not truncate the registry', async () => {
+    const { fs, writes } = faultingPluginsFs('EACCES');
+    await expect(deleteInstalledPlugin('reports-plugin', fs)).rejects.toThrow(
+      'EACCES reading plugins registry'
+    );
+    expect(writes).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #2972

## Summary

A transient VFS read during `mcp refresh` / `mcp add` / `plugin install` no longer wipes every other configured MCP server (and its OAuth auth block). `readServersFile` and `readPluginsFile` now treat only a missing file or malformed JSON as empty; any other `FsError` (EIO, EACCES, transient OPFS) propagates so the read-modify-write caller aborts instead of rewriting the registry from an empty base.

## Why

`readServersFile` distinguished ENOENT correctly, but the outer catch swallowed every other read fault and returned `emptyFile()`. `setServer` / `deleteServer` then unconditionally rewrote the whole registry. One OPFS/EACCES blip during a routine `mcp refresh foo` could persist only `foo` and drop every other server, including `clientId` / `scope` / `redirectUri` that cost an interactive re-auth to reconstruct.

Same shape in `readPluginsFile` → `setInstalledPlugin` / `deleteInstalledPlugin` (lower blast radius, no credentials). Canonical pattern already used in `readSessionsIndexForWrite` / #2703 / #2400 / #1357.

**Repro (before):**
1. Configure two MCP servers, one with an OAuth auth block.
2. Make `readFile('/workspace/.mcp/servers.json')` throw `FsError('EIO')` during `mcp refresh` of the other server.
3. Expected: the refresh fails; both servers remain on disk.
4. Actual: the write persisted only the refreshed server; the other (and its auth block) was gone.

## Approach / Implementation notes

```ts
} catch (err) {
  if (err instanceof FsError && err.code === 'ENOENT') return emptyFile();
  throw err;
}
```

Inner invalid-JSON catch still returns empty (nothing durable to lose). Dropped the `log.warn` + empty fallback on real I/O errors.

## Cross-cutting impact

- **Floats:** CLI and Chrome extension share these stores via global VFS. No float-specific branching.
- **Callers of `setServer` / `deleteServer`:** `mcp add` / `mcp refresh` / `mcp delete` (`mcp-command.ts`) and `plugin install` / `plugin remove` (`plugin-command.ts`) now fail closed on a real read fault instead of clobbering. ENOENT still seeds an empty registry on first add.
- **`ensureMcpProviderRegistered`:** the provider-test stub that threw a generic `Error('ENOENT')` now throws `FsError('ENOENT')`, matching production VFS. A generic `Error` is no longer treated as empty.
- Did not touch #2962 / #2963 (PRs #2975 / #2976), #2942, or #2417.

## Test plan

- [x] `npm run verify` — 8/8 (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists touched
- [x] `npm run typecheck` — all 9 tsconfig projects
- [x] `npm run test` — 1141 files, 20822 passed, 53 skipped
- [x] `npm run test:coverage` and `npm run test:coverage:webapp` — floors met
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — +0.0 kB vs merge-base on both graphs
- [x] New tests: non-ENOENT `FsError` from `readFile` propagates out of `setServer` / `deleteServer` / `setInstalledPlugin` / `deleteInstalledPlugin` and does **not** produce a truncated write. ENOENT still empty; invalid JSON still empty; ENOENT on upsert still writes onto an empty registry. Existing MCP OAuth / refresh tests in `mcp-command.test.ts` stay green.

No UI change; no screencast.

## Documentation

- [x] No documentation changes needed — internal durability contract; user-visible command surfaces are unchanged except that a real I/O error now fails instead of silently deleting config.

## Risk & rollback

- Blast radius: all floats that persist MCP/plugin registries. Failure mode is fail-closed (command errors, durable state kept) rather than silent data loss.
- Rollback: revert this PR. No persisted schema migration.
- CI cannot inject a real OPFS `NotReadableError`; the unit tests drive the same `FsError` codes production VFS emits.

## Checklist

- [x] Commits are focused and package-local (`webapp` store + tests)
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Dual-mode: CLI + extension share this store