### PR TITLE
fix(webapp): serve node:module createRequire in the JS realm

### DIFF
--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -240,14 +240,14 @@ and `import { createRequire } from 'node:module'` succeed. Enough of the
 surface for resolution-oriented consumers (meow, cosmiconfig, resolve-from,
 stylelint, import-meta-resolve):
 
-| API                       | Notes                                                                                      |
-| ------------------------- | ------------------------------------------------------------------------------------------ |
-| `createRequire(filename)` | Returns a `require` resolved relative to `filename` (absolute path, `file:` URL, or `URL`) |
-| `require.resolve(id)`     | Resolves without loading; `options.paths` is honoured                                      |
-| `builtinModules`          | Frozen list of unprefixed Node built-in names                                              |
-| `isBuiltin(name)`         | True for bare or `node:`-prefixed built-ins                                                |
-| `_nodeModulePaths(from)`  | POSIX ancestor walk; skips a directory named `node_modules`                                |
-| `findPnpApi`              | **Absent** (undefined), so Yarn PnP probes fall through                                    |
+| API                       | Notes                                                                                                                                                                                        |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createRequire(filename)` | Returns a `require` resolved relative to `filename` (absolute path, `file:` URL, or `URL`)                                                                                                   |
+| `require.resolve(id)`     | Resolves without loading; `options.paths` is honoured. Node builtins (including unavailable ones) return the specifier. Bare packages walk nearest `node_modules` over the loaded CJS graph. |
+| `builtinModules`          | Frozen list of unprefixed Node built-in names                                                                                                                                                |
+| `isBuiltin(name)`         | True for bare or `node:`-prefixed built-ins                                                                                                                                                  |
+| `_nodeModulePaths(from)`  | POSIX ancestor walk; skips a directory named `node_modules`                                                                                                                                  |
+| `findPnpApi`              | **Absent** (undefined), so Yarn PnP probes fall through                                                                                                                                      |
 
 `filename` must be an absolute path, a `file:` URL string, or a `URL` object —
 the same three Node accepts. Relative `require()` from the created function

--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -233,6 +233,29 @@ and `WriteStream` are inert stubs provided for Node API-shape compatibility.
 `URL`, `URLSearchParams` (re-exported globals), `fileURLToPath(url)`,
 `pathToFileURL(path)`.
 
+### `module`
+
+Partial Node `module` builtin so `require('module')` / `require('node:module')`
+and `import { createRequire } from 'node:module'` succeed. Enough of the
+surface for resolution-oriented consumers (meow, cosmiconfig, resolve-from,
+stylelint, import-meta-resolve):
+
+| API                       | Notes                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| `createRequire(filename)` | Returns a `require` resolved relative to `filename` (absolute path, `file:` URL, or `URL`) |
+| `require.resolve(id)`     | Resolves without loading; `options.paths` is honoured                                      |
+| `builtinModules`          | Frozen list of unprefixed Node built-in names                                              |
+| `isBuiltin(name)`         | True for bare or `node:`-prefixed built-ins                                                |
+| `_nodeModulePaths(from)`  | POSIX ancestor walk; skips a directory named `node_modules`                                |
+| `findPnpApi`              | **Absent** (undefined), so Yarn PnP probes fall through                                    |
+
+`filename` must be an absolute path, a `file:` URL string, or a `URL` object —
+the same three Node accepts. Relative `require()` from the created function
+looks up the already-loaded CJS graph (VFS `require()` already works).
+
+**Not available:** `Module._compile` / `_load` / `_resolveFilename`,
+`syncBuiltinESMExports`, `register`, Source Map helpers.
+
 ### `zlib`
 
 Backed by `pako` (pure JS):

--- a/packages/webapp/src/kernel/realm/helpers/node-module.ts
+++ b/packages/webapp/src/kernel/realm/helpers/node-module.ts
@@ -1,0 +1,164 @@
+/**
+ * Partial `node:module` / `module` builtin for the browser JS realm.
+ *
+ * Consumers (meow, cosmiconfig, resolve-from, stylelint, import-meta-resolve)
+ * want `createRequire` for resolution, `builtinModules` / `isBuiltin` for
+ * probes, and `findPnpApi` absent so Yarn PnP fallthrough works. Module
+ * internals (`_compile`, `_load`, …) are out of scope.
+ */
+
+import { isNodeBuiltin, NODE_BUILTINS } from '../node-builtins.js';
+import { nodePath } from './node-path.js';
+import { nodeUrl } from './node-url.js';
+
+/** CJS `require` function returned by `createRequire`. */
+export interface NodeRequireFunction {
+  (id: string): unknown;
+  resolve(id: string, options?: { paths?: readonly string[] }): string;
+}
+
+/**
+ * The realm's `require('module')` export: Node's CJS shape is the `Module`
+ * constructor with statics (`createRequire`, `builtinModules`, …) and a
+ * circular `.Module` self-reference.
+ */
+export type NodeModuleApi = ((id?: string) => NodeModuleInstance) & {
+  createRequire: (filename: unknown) => NodeRequireFunction;
+  builtinModules: readonly string[];
+  isBuiltin: (name: unknown) => boolean;
+  _nodeModulePaths: (from: string) => string[];
+  Module: NodeModuleApi;
+};
+
+export interface NodeModuleInstance {
+  exports: object;
+  id: string;
+  filename: string;
+  loaded: boolean;
+}
+
+/**
+ * Per-realm host that actually loads / resolves specifiers. Bound to the
+ * realm's CJS graph so `createRequire(filename)` reuses VFS `require()`.
+ */
+export interface NodeModuleHost {
+  requireFrom(fromPath: string, specifier: string): unknown;
+  resolveFrom(fromPath: string, specifier: string): string;
+}
+
+/** Frozen copy of {@link NODE_BUILTINS} — Node's `builtinModules` has no `node:` prefix. */
+export const BUILTIN_MODULES: readonly string[] = Object.freeze([...NODE_BUILTINS]);
+
+export function isBuiltinName(name: unknown): boolean {
+  return typeof name === 'string' && isNodeBuiltin(name);
+}
+
+/**
+ * Node-faithful `Module._nodeModulePaths` on POSIX: walk ancestors, emit a
+ * `node_modules` dir at each step, and skip a directory that is itself named
+ * `node_modules` (so `/a/node_modules/pkg` does not yield
+ * `/a/node_modules/node_modules`).
+ */
+export function nodeModulePaths(from: string): string[] {
+  const paths: string[] = [];
+  let current = from;
+  while (true) {
+    const base = current === '/' ? '' : current.slice(current.lastIndexOf('/') + 1);
+    if (base !== 'node_modules') {
+      paths.push(current === '/' || current === '' ? '/node_modules' : `${current}/node_modules`);
+    }
+    if (current === '/' || current === '') break;
+    const idx = current.lastIndexOf('/');
+    current = idx <= 0 ? (idx === 0 ? '/' : '') : current.slice(0, idx);
+  }
+  return paths;
+}
+
+/**
+ * Turn `createRequire`'s `filename` into a POSIX path. Accepts an absolute
+ * path, a `file:` URL string, or a `URL` object — the same three Node takes.
+ */
+export function filenameToPath(filename: unknown): string {
+  if (filename instanceof URL) return nodeUrl.fileURLToPath(filename);
+  if (typeof filename === 'string') {
+    if (filename.startsWith('file:')) return nodeUrl.fileURLToPath(filename);
+    if (filename.startsWith('/')) return filename;
+  }
+  throw new TypeError(
+    `The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ${String(filename)}`
+  );
+}
+
+/**
+ * Candidate absolute paths Node's CJS loader would try for `specifier`
+ * resolved from `fromDir`. Exact `.js`/`.json`/`.cjs`/`.mjs` specifiers skip
+ * extension probing.
+ */
+export function resolveFileCandidates(fromDir: string, specifier: string): string[] {
+  const base = specifier.startsWith('/')
+    ? nodePath.normalize(specifier)
+    : nodePath.resolve(fromDir, specifier);
+  if (/\.(?:js|json|cjs|mjs)$/.test(base)) return [base];
+  return [
+    base,
+    `${base}.js`,
+    `${base}.json`,
+    `${base}.cjs`,
+    `${base}/index.js`,
+    `${base}/index.json`,
+  ];
+}
+
+export function pickExistingCandidate(
+  fromDir: string,
+  specifier: string,
+  exists: (path: string) => boolean
+): string | undefined {
+  for (const candidate of resolveFileCandidates(fromDir, specifier)) {
+    if (exists(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+export function isPathSpecifier(specifier: string): boolean {
+  return specifier.startsWith('.') || specifier.startsWith('/');
+}
+
+export function createNodeModule(host: NodeModuleHost): NodeModuleApi {
+  function ModuleCtor(id?: string): NodeModuleInstance {
+    return { exports: {}, id: id ?? '', filename: id ?? '', loaded: false };
+  }
+  const api = ModuleCtor as NodeModuleApi;
+  api.createRequire = (filename) => makeRequire(host, filename);
+  api.builtinModules = BUILTIN_MODULES;
+  api.isBuiltin = isBuiltinName;
+  api._nodeModulePaths = nodeModulePaths;
+  api.Module = api;
+  return api;
+}
+
+function makeRequire(host: NodeModuleHost, filename: unknown): NodeRequireFunction {
+  const parentPath = filenameToPath(filename);
+  const req = ((id: string) => host.requireFrom(parentPath, id)) as NodeRequireFunction;
+  req.resolve = (id, options) => {
+    if (options?.paths && options.paths.length > 0) {
+      let lastError: unknown;
+      for (const dir of options.paths) {
+        try {
+          return host.resolveFrom(directoryAsFilename(dir), id);
+        } catch (err) {
+          lastError = err;
+        }
+      }
+      throw lastError instanceof Error ? lastError : new Error(`Cannot find module '${id}'`);
+    }
+    return host.resolveFrom(parentPath, id);
+  };
+  return req;
+}
+
+/** `require.resolve(id, { paths: [dir] })` treats each path as a directory. */
+function directoryAsFilename(dir: string): string {
+  const trimmed = dir.endsWith('/') && dir !== '/' ? dir.slice(0, -1) : dir;
+  return `${trimmed}/noop.js`;
+}

--- a/packages/webapp/src/kernel/realm/helpers/node-module.ts
+++ b/packages/webapp/src/kernel/realm/helpers/node-module.ts
@@ -92,7 +92,10 @@ export function filenameToPath(filename: unknown): string {
 /**
  * Candidate absolute paths Node's CJS loader would try for `specifier`
  * resolved from `fromDir`. Exact `.js`/`.json`/`.cjs`/`.mjs` specifiers skip
- * extension probing.
+ * extension probing. `.mjs` is in the skip regex so `require('./x.mjs')` is
+ * not rewritten, but is never *emitted* as a candidate — Node's CJS
+ * `LOAD_AS_FILE`/`LOAD_INDEX` set is `.js`/`.json`/`.node`, and require-of-ESM
+ * throws in Node anyway.
  */
 export function resolveFileCandidates(fromDir: string, specifier: string): string[] {
   const base = specifier.startsWith('/')
@@ -116,6 +119,24 @@ export function pickExistingCandidate(
 ): string | undefined {
   for (const candidate of resolveFileCandidates(fromDir, specifier)) {
     if (exists(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Nearest-`node_modules` walk for a bare specifier, over files already in the
+ * loaded CJS graph. Used when `createRequire(filename)` has a synthetic
+ * `filename` with no `graph.edges` entry (resolve-from / cosmiconfig /
+ * `require.resolve(id, { paths })`).
+ */
+export function pickBarePackage(
+  fromDir: string,
+  specifier: string,
+  exists: (path: string) => boolean
+): string | undefined {
+  for (const nm of nodeModulePaths(fromDir)) {
+    const hit = pickExistingCandidate(nm, specifier, exists);
+    if (hit) return hit;
   }
   return undefined;
 }

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -33,6 +33,7 @@ export type {
 export {
   createNodeModule,
   isPathSpecifier,
+  pickBarePackage,
   pickExistingCandidate,
 } from './helpers/node-module.js';
 export type { NodeOs } from './helpers/node-os.js';

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -24,6 +24,17 @@ export { createNodeChildProcess } from './helpers/node-child-process.js';
 export type { NodeCrypto, NodeHash } from './helpers/node-crypto.js';
 export { nodeCrypto } from './helpers/node-crypto.js';
 export { nodeEvents } from './helpers/node-events.js';
+export type {
+  NodeModuleApi,
+  NodeModuleHost,
+  NodeModuleInstance,
+  NodeRequireFunction,
+} from './helpers/node-module.js';
+export {
+  createNodeModule,
+  isPathSpecifier,
+  pickExistingCandidate,
+} from './helpers/node-module.js';
 export type { NodeOs } from './helpers/node-os.js';
 export { createNodeOs, DEFAULT_HOME, nodeOs } from './helpers/node-os.js';
 export type { NodePath, NodePathParsed } from './helpers/node-path.js';

--- a/packages/webapp/src/kernel/realm/node-builtins.ts
+++ b/packages/webapp/src/kernel/realm/node-builtins.ts
@@ -43,6 +43,7 @@ export const NODE_BUILTIN_AVAILABLE: ReadonlySet<string> = new Set([
   'util',
   'readline',
   'readline/promises',
+  'module',
 ]);
 
 /**

--- a/packages/webapp/src/kernel/realm/realm-module-system.ts
+++ b/packages/webapp/src/kernel/realm/realm-module-system.ts
@@ -7,8 +7,11 @@
 
 import type { NodeReadlineModule } from './helpers/node-readline.js';
 import {
+  createNodeModule,
   fmt,
+  isPathSpecifier,
   type NodeChildProcess,
+  type NodeModuleApi,
   type NodeOs,
   type NodeUtil,
   nodeAssert,
@@ -22,6 +25,7 @@ import {
   nodeUrl,
   nodeUtil,
   nodeZlib,
+  pickExistingCandidate,
   pool,
   time,
 } from './js-realm-helpers.js';
@@ -191,6 +195,11 @@ export function createModuleSystem(opts: {
   const kindByPath = new Map(graph.files.map((f) => [f.path, f.kind]));
   const cache = new Map<string, { exports: ModuleExports }>();
 
+  const nodeModule: NodeModuleApi = createNodeModule({
+    requireFrom: (fromPath, specifier) => loadFromParent(fromPath, specifier),
+    resolveFrom: (fromPath, specifier) => resolveFromParent(fromPath, specifier),
+  });
+
   const resolveBuiltin = (id: string): { hit: boolean; value?: unknown } => {
     if (typeof id === 'string' && id.startsWith(SLICCY_SCHEME)) {
       return { hit: true, value: resolveSliccyModule(id, sliccyModules) };
@@ -203,6 +212,7 @@ export function createModuleSystem(opts: {
       nodeOsModule,
       nodeUtilModule,
       nodeReadline,
+      nodeModule,
     });
     if (served.hit) return served;
     if (NODE_NATIVE_PACKAGES.has(bareId)) throw nativePackageError(id, bareId);
@@ -269,6 +279,36 @@ export function createModuleSystem(opts: {
     return moduleObj.exports;
   }
 
+  function graphHas(path: string): boolean {
+    return sourceByPath.has(path);
+  }
+
+  /**
+   * Resolve `specifier` as if required from `fromPath`. Builtins, the
+   * host-resolved edge map for that file, and a runtime relative/absolute
+   * lookup against the already-loaded graph (so `createRequire(filename)`
+   * can load a sibling that a static `require()` already pulled in).
+   */
+  function resolveFromParent(fromPath: string, specifier: string): string {
+    const builtin = resolveBuiltin(specifier);
+    if (builtin.hit) return specifier;
+    const edged = graph.edges[fromPath]?.[specifier];
+    if (edged) return edged;
+    if (isPathSpecifier(specifier)) {
+      const resolved = pickExistingCandidate(dirnameOf(fromPath), specifier, graphHas);
+      if (resolved) return resolved;
+    }
+    const deferred = graph.edgeErrors?.[fromPath]?.[specifier];
+    if (deferred) throw new Error(deferred);
+    throw cannotFindModuleError(specifier);
+  }
+
+  function loadFromParent(fromPath: string, specifier: string): unknown {
+    const builtin = resolveBuiltin(specifier);
+    if (builtin.hit) return builtin.value;
+    return requireFile(resolveFromParent(fromPath, specifier));
+  }
+
   return {
     require: (id: string): unknown => requireFromEdges(graph.entryMap, id, null),
   };
@@ -295,10 +335,18 @@ function resolveServedBuiltin(
     nodeOsModule: NodeOs;
     nodeUtilModule: NodeUtil;
     nodeReadline?: NodeReadlineModule;
+    nodeModule?: NodeModuleApi;
   }
 ): { hit: boolean; value?: unknown } {
-  const { fsBridge, processShim, childProcess, nodeOsModule, nodeUtilModule, nodeReadline } =
-    served;
+  const {
+    fsBridge,
+    processShim,
+    childProcess,
+    nodeOsModule,
+    nodeUtilModule,
+    nodeReadline,
+    nodeModule,
+  } = served;
   if (bareId === 'fs') return { hit: true, value: fsBridge };
   // Same object — fsBridge is already Promise-based; callback/sync APIs are not shimmed here.
   if (bareId === 'fs/promises') return { hit: true, value: fsBridge };
@@ -324,6 +372,7 @@ function resolveServedBuiltin(
   if (bareId === 'readline/promises' && nodeReadline) {
     return { hit: true, value: nodeReadline.promises };
   }
+  if (bareId === 'module' && nodeModule) return { hit: true, value: nodeModule };
   return { hit: false };
 }
 

--- a/packages/webapp/src/kernel/realm/realm-module-system.ts
+++ b/packages/webapp/src/kernel/realm/realm-module-system.ts
@@ -25,11 +25,12 @@ import {
   nodeUrl,
   nodeUtil,
   nodeZlib,
+  pickBarePackage,
   pickExistingCandidate,
   pool,
   time,
 } from './js-realm-helpers.js';
-import { NODE_BUILTINS_UNAVAILABLE } from './node-builtins.js';
+import { isNodeBuiltin, NODE_BUILTINS_UNAVAILABLE } from './node-builtins.js';
 import { createPlaywrightShim } from './playwright-shim.js';
 import { dirnameOf, NodeExitError } from './realm-node-shims.js';
 import type { RealmRpcClient } from './realm-rpc.js';
@@ -284,18 +285,24 @@ export function createModuleSystem(opts: {
   }
 
   /**
-   * Resolve `specifier` as if required from `fromPath`. Builtins, the
-   * host-resolved edge map for that file, and a runtime relative/absolute
-   * lookup against the already-loaded graph (so `createRequire(filename)`
-   * can load a sibling that a static `require()` already pulled in).
+   * Resolve `specifier` as if required from `fromPath`. Node builtins
+   * (including unavailable ones) return the specifier without loading —
+   * Node's `require.resolve('net')` does the same. Then the host-resolved
+   * edge map, a runtime relative/absolute lookup, and a nearest-node_modules
+   * walk over the already-loaded graph (so `createRequire(filename)` with a
+   * synthetic filename can still resolve a bare package that a static
+   * `require()` already pulled in).
    */
   function resolveFromParent(fromPath: string, specifier: string): string {
-    const builtin = resolveBuiltin(specifier);
-    if (builtin.hit) return specifier;
+    if (isNodeBuiltin(specifier)) return specifier;
     const edged = graph.edges[fromPath]?.[specifier];
     if (edged) return edged;
+    const fromDir = dirnameOf(fromPath);
     if (isPathSpecifier(specifier)) {
-      const resolved = pickExistingCandidate(dirnameOf(fromPath), specifier, graphHas);
+      const resolved = pickExistingCandidate(fromDir, specifier, graphHas);
+      if (resolved) return resolved;
+    } else {
+      const resolved = pickBarePackage(fromDir, specifier, graphHas);
       if (resolved) return resolved;
     }
     const deferred = graph.edgeErrors?.[fromPath]?.[specifier];

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -859,6 +859,47 @@ describe('node:module shim', () => {
     expect(out.stdout.trim()).toBe('true false');
   });
 
+  it('createRequire from a synthetic filename resolves a bare package already in the graph', async () => {
+    const ctx = makeCtx({
+      files: {
+        '/workspace/node_modules/foo/package.json': JSON.stringify({
+          name: 'foo',
+          version: '1.0.0',
+          main: 'index.js',
+        }),
+        '/workspace/node_modules/foo/index.js': "module.exports = 'from-foo';",
+      },
+    });
+    const out = await runCode(
+      `require('foo');
+       const { createRequire } = require('module');
+       const req = createRequire('/workspace/other/noop.js');
+       console.log(req.resolve('foo'), req('foo'));
+       console.log(req.resolve('foo', { paths: ['/workspace/other'] }));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('Cannot find module');
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual([
+      '/workspace/node_modules/foo/index.js from-foo',
+      '/workspace/node_modules/foo/index.js',
+    ]);
+  });
+
+  it('createRequire().resolve returns unavailable builtins without loading them', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const { createRequire } = require('module');
+       const req = createRequire('/workspace/noop.js');
+       console.log(req.resolve('net'), req.resolve('node:net'));
+       try { req('net'); console.log('LOADED'); }
+       catch (e) { console.log(/not available in the browser/.test(e.message)); }`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual(['net node:net', 'true']);
+  });
+
   it('ESM named import { createRequire } from node:module works', async () => {
     const ctx = makeCtx();
     const out = await runCode(

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -754,6 +754,124 @@ describe('node:stream shim', () => {
   });
 });
 
+describe('node:module shim', () => {
+  it('require("module") and require("node:module") return the SAME object', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const m = require('module');
+       const aliased = require('node:module');
+       console.log(m === aliased, typeof m.createRequire, Array.isArray(m.builtinModules));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('not available in the browser');
+    expect(out.stderr).not.toContain('Cannot find module');
+    expect(out.stdout.trim()).toBe('true function true');
+  });
+
+  it('isBuiltin distinguishes Node built-ins from packages; findPnpApi is absent', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const m = require('module');
+       console.log(m.isBuiltin('fs'), m.isBuiltin('node:fs'), m.isBuiltin('stylelint'));
+       console.log(typeof m.findPnpApi, 'findPnpApi' in m);`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual(['true true false', 'undefined false']);
+  });
+
+  it('Module._nodeModulePaths walks POSIX ancestors', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const { _nodeModulePaths } = require('module');
+       console.log(_nodeModulePaths('/workspace/pkg/lib').join(','));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe(
+      '/workspace/pkg/lib/node_modules,/workspace/pkg/node_modules,/workspace/node_modules,/node_modules'
+    );
+  });
+
+  it('createRequire loads a relative file resolved against filename, not cwd', async () => {
+    const ctx = makeCtx({
+      files: {
+        '/workspace/a/msg.js': "module.exports = 'from-a';",
+        '/workspace/b/msg.js': "module.exports = 'from-b';",
+      },
+    });
+    // Static absolute requires pull both files into the graph; createRequire
+    // then picks between them by resolving `./msg.js` against each filename.
+    const out = await runCode(
+      `require('/workspace/a/msg.js');
+       require('/workspace/b/msg.js');
+       const { createRequire } = require('module');
+       const a = createRequire('/workspace/a/index.js');
+       const b = createRequire('/workspace/b/index.js');
+       console.log(a('./msg.js'), b('./msg.js'));
+       console.log(a.resolve('./msg.js'));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('not available in the browser');
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual([
+      'from-a from-b',
+      '/workspace/a/msg.js',
+    ]);
+  });
+
+  it('createRequire accepts a file: URL string', async () => {
+    const ctx = makeCtx({
+      files: {
+        '/workspace/pkg/helper.js': "module.exports = 'via-url';",
+      },
+    });
+    const out = await runCode(
+      `require('/workspace/pkg/helper.js');
+       const { createRequire } = require('module');
+       const req = createRequire('file:///workspace/pkg/index.js');
+       console.log(req('./helper.js'));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('via-url');
+  });
+
+  it('a node_modules package that internally requires module loads and runs', async () => {
+    const ctx = makeCtx({
+      files: {
+        '/workspace/node_modules/usesmodule/package.json': JSON.stringify({
+          name: 'usesmodule',
+          version: '1.0.0',
+          main: 'index.js',
+        }),
+        '/workspace/node_modules/usesmodule/index.js':
+          "const { isBuiltin } = require('module'); module.exports = (n) => isBuiltin(n);",
+      },
+    });
+    const out = await runCode(
+      "const u = require('usesmodule'); console.log(u('fs'), u('stylelint'));",
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('not available in the browser');
+    expect(out.stdout.trim()).toBe('true false');
+  });
+
+  it('ESM named import { createRequire } from node:module works', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `import { createRequire, isBuiltin, builtinModules } from 'node:module';
+       console.log(typeof createRequire, isBuiltin('fs'), builtinModules.includes('module'));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('not available in the browser');
+    expect(out.stdout.trim()).toBe('function true true');
+  });
+});
+
 describe('node:fs/promises alias', () => {
   it('require("fs/promises") returns the same object as require("fs")', async () => {
     const ctx = makeCtx();

--- a/packages/webapp/tests/kernel/realm/helpers/node-module.test.ts
+++ b/packages/webapp/tests/kernel/realm/helpers/node-module.test.ts
@@ -12,6 +12,7 @@ import {
   filenameToPath,
   isBuiltinName,
   nodeModulePaths,
+  pickBarePackage,
   pickExistingCandidate,
   resolveFileCandidates,
 } from '../../../../src/kernel/realm/helpers/node-module.js';
@@ -103,6 +104,32 @@ describe('resolveFileCandidates / pickExistingCandidate', () => {
     expect(
       pickExistingCandidate('/workspace/pkg', './missing', (p) => files.has(p))
     ).toBeUndefined();
+  });
+});
+
+describe('pickBarePackage', () => {
+  it('walks nearest node_modules and prefers the closer copy', () => {
+    const files = new Set([
+      '/workspace/node_modules/foo/index.js',
+      '/workspace/a/node_modules/foo/index.js',
+    ]);
+    expect(pickBarePackage('/workspace/a/lib', 'foo', (p) => files.has(p))).toBe(
+      '/workspace/a/node_modules/foo/index.js'
+    );
+    expect(pickBarePackage('/workspace/other', 'foo', (p) => files.has(p))).toBe(
+      '/workspace/node_modules/foo/index.js'
+    );
+  });
+
+  it('resolves a scoped package and a deep subpath', () => {
+    const files = new Set(['/workspace/node_modules/@scope/pkg/lib/main.js']);
+    expect(pickBarePackage('/workspace', '@scope/pkg/lib/main.js', (p) => files.has(p))).toBe(
+      '/workspace/node_modules/@scope/pkg/lib/main.js'
+    );
+  });
+
+  it('returns undefined when the package is not in the graph', () => {
+    expect(pickBarePackage('/workspace', 'missing', () => false)).toBeUndefined();
   });
 });
 

--- a/packages/webapp/tests/kernel/realm/helpers/node-module.test.ts
+++ b/packages/webapp/tests/kernel/realm/helpers/node-module.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Direct unit tests for the realm's partial `node:module` shim: filename
+ * coercion, `isBuiltin`, `_nodeModulePaths`, and relative-path candidates.
+ * End-to-end `require('module')` / `createRequire` coverage lives in
+ * `cjs-require-bare-builtins.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  BUILTIN_MODULES,
+  createNodeModule,
+  filenameToPath,
+  isBuiltinName,
+  nodeModulePaths,
+  pickExistingCandidate,
+  resolveFileCandidates,
+} from '../../../../src/kernel/realm/helpers/node-module.js';
+
+describe('isBuiltinName', () => {
+  it('accepts bare and node:-prefixed built-ins', () => {
+    expect(isBuiltinName('fs')).toBe(true);
+    expect(isBuiltinName('node:fs')).toBe(true);
+    expect(isBuiltinName('module')).toBe(true);
+  });
+
+  it('rejects packages and non-strings', () => {
+    expect(isBuiltinName('stylelint')).toBe(false);
+    expect(isBuiltinName('node:stylelint')).toBe(false);
+    expect(isBuiltinName(1)).toBe(false);
+    expect(isBuiltinName(undefined)).toBe(false);
+  });
+});
+
+describe('BUILTIN_MODULES', () => {
+  it('lists unprefixed Node built-ins including module', () => {
+    expect(BUILTIN_MODULES).toContain('fs');
+    expect(BUILTIN_MODULES).toContain('module');
+    expect(BUILTIN_MODULES).not.toContain('node:fs');
+  });
+});
+
+describe('nodeModulePaths', () => {
+  it('walks POSIX ancestors', () => {
+    expect(nodeModulePaths('/workspace/pkg/lib')).toEqual([
+      '/workspace/pkg/lib/node_modules',
+      '/workspace/pkg/node_modules',
+      '/workspace/node_modules',
+      '/node_modules',
+    ]);
+  });
+
+  it('skips a directory that is itself named node_modules', () => {
+    expect(nodeModulePaths('/workspace/node_modules/pkg')).toEqual([
+      '/workspace/node_modules/pkg/node_modules',
+      '/workspace/node_modules',
+      '/node_modules',
+    ]);
+  });
+
+  it('handles the filesystem root', () => {
+    expect(nodeModulePaths('/')).toEqual(['/node_modules']);
+  });
+});
+
+describe('filenameToPath', () => {
+  it('accepts absolute paths, file: strings, and URL objects', () => {
+    expect(filenameToPath('/workspace/a.js')).toBe('/workspace/a.js');
+    expect(filenameToPath('file:///workspace/a.js')).toBe('/workspace/a.js');
+    expect(filenameToPath(new URL('file:///workspace/hello%20world.js'))).toBe(
+      '/workspace/hello world.js'
+    );
+  });
+
+  it('rejects relative paths and non-file URLs', () => {
+    expect(() => filenameToPath('relative.js')).toThrow(/absolute path string/);
+    expect(() => filenameToPath(new URL('https://example.com/x.js'))).toThrow(/not a file URL/);
+  });
+});
+
+describe('resolveFileCandidates / pickExistingCandidate', () => {
+  it('probes extensions for extension-less specifiers', () => {
+    expect(resolveFileCandidates('/workspace/pkg', './helper')).toEqual([
+      '/workspace/pkg/helper',
+      '/workspace/pkg/helper.js',
+      '/workspace/pkg/helper.json',
+      '/workspace/pkg/helper.cjs',
+      '/workspace/pkg/helper/index.js',
+      '/workspace/pkg/helper/index.json',
+    ]);
+  });
+
+  it('does not re-probe an already-extended specifier', () => {
+    expect(resolveFileCandidates('/workspace/pkg', './helper.js')).toEqual([
+      '/workspace/pkg/helper.js',
+    ]);
+  });
+
+  it('picks the first candidate that exists', () => {
+    const files = new Set(['/workspace/pkg/helper.js']);
+    expect(pickExistingCandidate('/workspace/pkg', './helper', (p) => files.has(p))).toBe(
+      '/workspace/pkg/helper.js'
+    );
+    expect(
+      pickExistingCandidate('/workspace/pkg', './missing', (p) => files.has(p))
+    ).toBeUndefined();
+  });
+});
+
+describe('createNodeModule', () => {
+  it('exposes createRequire, builtinModules, isBuiltin, and no findPnpApi', () => {
+    const loaded: string[] = [];
+    const api = createNodeModule({
+      requireFrom: (fromPath, specifier) => {
+        loaded.push(`${fromPath}::${specifier}`);
+        return { fromPath, specifier };
+      },
+      resolveFrom: (fromPath, specifier) => `${fromPath}=>${specifier}`,
+    });
+    expect(api.createRequire).toBeTypeOf('function');
+    expect(api.builtinModules).toContain('fs');
+    expect(api.isBuiltin('fs')).toBe(true);
+    expect(api.isBuiltin('stylelint')).toBe(false);
+    expect((api as { findPnpApi?: unknown }).findPnpApi).toBeUndefined();
+    expect('findPnpApi' in api).toBe(false);
+    expect(api.Module).toBe(api);
+
+    const req = api.createRequire('/workspace/pkg/index.js');
+    expect(req('./helper.js')).toEqual({
+      fromPath: '/workspace/pkg/index.js',
+      specifier: './helper.js',
+    });
+    expect(req.resolve('./helper.js')).toBe('/workspace/pkg/index.js=>./helper.js');
+    expect(req.resolve('foo', { paths: ['/workspace/other'] })).toBe(
+      '/workspace/other/noop.js=>foo'
+    );
+    expect(loaded).toEqual(['/workspace/pkg/index.js::./helper.js']);
+  });
+});


### PR DESCRIPTION
Closes #2980.

## Summary

`require('module')` / `require('node:module')` hard-failed in the browser JS realm with `Node built-in 'module' is not available in the browser environment`. That blocked stylelint (and meow / cosmiconfig / import-meta-resolve / resolve-from / require-from-string / css-tree) at import time — even `stylelint --version` died.

The realm now serves a partial `Module` object with `createRequire`, `builtinModules`, `isBuiltin`, and `_nodeModulePaths`. `findPnpApi` is absent so Yarn PnP probes fall through instead of crashing.

## Why

This is the **browser js-realm**, not workerd `createRequire` for e2b (#1591 / #1596). The builtin was missing outright, so any user-installed package that touches `node:module` could not load. A targeted stub of stylelint's own `findPnpApi` import is not enough — five more packages in the graph need the builtin.

**Repro (before):**

```
$ node -e 'require("node:module")'
Error: require('node:module'): Node built-in 'module' is not available in the browser environment.
```

**After:** `require('module')` and `require('node:module')` return the same object; `createRequire(filename)` loads a relative file resolved against `filename`.

## Approach / Implementation notes

- Add `'module'` to `NODE_BUILTIN_AVAILABLE` so it is no longer in the unavailable set.
- New helper `packages/webapp/src/kernel/realm/helpers/node-module.ts` implements the partial Node surface.
- `createModuleSystem` wires it like the other served builtins and binds `createRequire` to the already-loaded CJS graph (VFS `require()` already works).
- Relative/absolute specifiers from `createRequire(filename)` resolve against `dirname(filename)` with Node-like extension probing over graph files.
- `bsh-watchdog.ts` is left alone: its unavailable table is the page-context `.bsh` subset, not a duplicate of the realm registry.
- Does **not** steal #2981 (console methods) or #2978.

A full Module implementation (`_compile`, `_load`, `_resolveFilename`) is out of scope. Consumers want `createRequire` for resolution.

## Cross-cutting impact

- **Floats exercised:** every float that runs the JS realm (`js-realm-shared.ts`) — CLI, Chrome extension (hosted leader kernel worker), Electron, Sliccstart. No float-specific fork.
- **Shell contexts:** `.jsh` / `node -e` / `ipx` bins in the realm. `.bsh` (CDP page) is unchanged.
- **Bundle size:** kernel-worker first-load +1.9 kB vs merge-base (allowance 5 kB).

## Test plan

- [x] `npm run verify` — all 8 checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [x] `npm run test` — 20956 passed, 53 skipped
- [x] `npm run test:coverage:webapp` — floors held (lines 85.66%)
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK
- [x] New tests: `require('module')` / `node:module` succeed and are the same object; `createRequire` loads a relative file against `filename` not cwd; `isBuiltin('fs')` true / `isBuiltin('stylelint')` false; `findPnpApi` undefined; ESM named import; `_nodeModulePaths`

`stylelint --version` after `ipk add` is still optional/heavy; remaining realm gaps (console methods #2981, `stream/promises`, `v8`, `path.posix`, `process.execPath`, …) are tracked separately.

## Documentation

- [x] `docs/node-compat-shims.md` — new `module` section

## Risk & rollback

- Blast radius: JS realm `require()` of `module` / `node:module` only. Unavailable builtins other than `module` are unchanged.
- Rollback: revert this PR.
- `createRequire` of a file that was never pulled into the host graph still throws `Cannot find module` (same as an unresolved `require()`). That is enough for the issue's pin; on-demand VFS loads of undiscovered files are follow-up.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] Linear history (rebased onto origin/main)
- [x] Dual-mode: same worker realm in CLI and extension