### PR TITLE
fix(renovate): stop the reconcile push cancelling its own run

### DIFF
--- a/.github/workflows/renovate-lockfile-reconcile.yml
+++ b/.github/workflows/renovate-lockfile-reconcile.yml
@@ -122,8 +122,12 @@ jobs:
           fi
           npm run lint:lockfile
 
+      # Best-effort: the push below is the point of this workflow, and a
+      # transient `gh` failure here would otherwise fail the job and skip it,
+      # stranding a verified repair on the runner.
       - name: Comment the outcome
         if: steps.detect.outputs.stale == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/renovate-lockfile-reconcile.yml
+++ b/.github/workflows/renovate-lockfile-reconcile.yml
@@ -48,6 +48,11 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
+  # The repair push below is itself a `synchronize`, so it starts a successor
+  # run in this group that cancels the run that pushed it. Everything that has
+  # to happen — verify, comment — therefore happens BEFORE the push, and the
+  # push is the last step. (The successor run re-runs the guard on the pushed
+  # result and no-ops, which is the post-push verification.)
   group: renovate-lockfile-reconcile-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
@@ -105,26 +110,17 @@ jobs:
         if: steps.detect.outputs.stale == 'true'
         run: npm install --ignore-scripts --no-audit --no-fund
 
-      - name: Push the lockfile
+      # The regenerated tree has to satisfy the guard, or the PR is still red for
+      # a reason this workflow cannot fix. Checked before the push, because the
+      # push cancels this run (see the concurrency note).
+      - name: Verify the regenerated lockfile
         if: steps.detect.outputs.stale == 'true'
         run: |
           if git diff --quiet -- package-lock.json; then
             echo "npm install produced no lockfile change — the mismatch is not a stale lockfile." >&2
             exit 1
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Only the lockfile: Renovate owns the package.json bump, and an
-          # install can touch other generated files.
-          git add package-lock.json
-          git commit -m "fix(deps): sync package-lock.json (renovate-lockfile-reconcile)"
-          git push
-
-      # The guard has to pass on the pushed result, or the PR is still red for
-      # a reason this workflow cannot fix.
-      - name: Verify the lockfile is in sync
-        if: steps.detect.outputs.stale == 'true'
-        run: npm run lint:lockfile
+          npm run lint:lockfile
 
       - name: Comment the outcome
         if: steps.detect.outputs.stale == 'true'
@@ -132,4 +128,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr comment "${{ github.event.pull_request.number }}" --body \
-            "🔒 Renovate shipped this bump without a matching \`package-lock.json\` (every job would fail at \`npm ci\` with EUSAGE), so I ran \`npm install\` and pushed the lockfile. See \`.github/workflows/renovate-lockfile-reconcile.yml\`."
+            "🔒 Renovate shipped this bump without a matching \`package-lock.json\` (every job would fail at \`npm ci\` with EUSAGE), so I ran \`npm install\` and am pushing the lockfile. See \`.github/workflows/renovate-lockfile-reconcile.yml\`."
+
+      # Last step: this push fires the PR's `synchronize`, which re-runs the
+      # full check suite on the repaired commit and cancels this run.
+      - name: Push the lockfile
+        if: steps.detect.outputs.stale == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Only the lockfile: Renovate owns the package.json bump, and an
+          # install can touch other generated files.
+          git add package-lock.json
+          git commit -m "fix(deps): sync package-lock.json (renovate-lockfile-reconcile)"
+          git push

--- a/.github/workflows/renovate-patch-reconcile.yml
+++ b/.github/workflows/renovate-patch-reconcile.yml
@@ -53,8 +53,14 @@ on:
     types: [opened, synchronize, reopened, labeled]
 
 concurrency:
+  # NOT cancel-in-progress: Claude pushes its reconcile commit from inside the
+  # step below, and that push is a `synchronize` this workflow now runs on
+  # (PR-author gate). Cancelling would kill the reconcile run mid-flight —
+  # between Claude's push and the "Verify reconciliation" fast-fail. The
+  # successor run instead queues, re-detects, finds no orphan and exits before
+  # Claude, so the cost of queueing is one cheap detect step.
   group: renovate-patch-reconcile-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write # push the reconciliation commit to the PR branch

--- a/packages/dev-tools/tools/check-lockfile-sync.mjs
+++ b/packages/dev-tools/tools/check-lockfile-sync.mjs
@@ -52,6 +52,13 @@ export function exactVersion(spec) {
  * Prefers the package-local `<dir>/node_modules/<dep>` copy, then the hoisted
  * root one, mirroring npm's own resolution: with two workspaces on different
  * versions only one of them can be hoisted.
+ *
+ * Deliberately does NOT fall back to an arbitrary nested copy the way
+ * `patch-reconcile/lib.mjs` → `lockedVersion()` does. That helper answers "what
+ * version of this package is installed anywhere", for a patch that may be
+ * applied to a transitive dependency. This one answers "what will THIS package
+ * resolve to", and any other location is not that package's copy — reporting it
+ * as missing is the honest answer, and still fails.
  */
 export function resolvedVersion(lock, dir, dep) {
   const packages = lock?.packages ?? {};


### PR DESCRIPTION
Follow-up to #2986, fixing the one defect both reviewers flagged there (Codex P2 and the Claude review's observation 1).

## The bug

The repair push uses `BOT_PAT` on purpose — that is what fires the PR's `synchronize` so the full check suite re-runs on the repaired commit. But that `synchronize` also starts a **successor run in the same concurrency group**, and `cancel-in-progress: true` then cancels the run that pushed it, mid "verify" and "comment". The repair itself always lands (the push is what triggers the cancellation), so this is a reliability/observability defect rather than a correctness one — the 🔒 explanatory comment and the post-push verification frequently just never run.

## The fix, per workflow

**`renovate-lockfile-reconcile.yml`** — keep the cancellation (a rapid Renovate force-push series *should* supersede an in-flight repair) and move everything that must happen to **before** the push:

```
detect → install → verify the regenerated tree → comment → push   (push is last)
```

The "did `npm install` actually change the lockfile" bail-out moves into the verify step, where it belongs. The successor run re-runs the guard on the pushed result and no-ops — that is the post-push verification, and it now happens in a run that isn't about to be cancelled.

**`renovate-patch-reconcile.yml`** — `cancel-in-progress: false` instead. Claude pushes from inside its own step, so the work cannot be reordered around the push, and since #2986 flipped this workflow to the PR-author gate its self-push *does* now start a successor — which would cancel the run in the window between Claude's push and the `Verify reconciliation` fast-fail. Queueing instead costs one cheap `Detect orphaned patches` step, which finds no orphan and exits before Claude.

The other three reconcile workflows (`format`, `swift-pin`, `skill-pin`) are left alone: they push from a step with nothing after it, so cancellation there costs nothing.

## Also

Documents why `check-lockfile-sync.mjs` → `resolvedVersion` deliberately does **not** walk arbitrary nested copies the way `patch-reconcile/lib.mjs` → `lockedVersion` does (review observation 2). They answer different questions — "what will *this* package resolve to" vs "what version is installed anywhere, for a patch that may target a transitive dep" — and they look parallel enough to invite a "fix" that would be wrong.

## Verification

`npm run lint:lockfile` ✅, `prettier --check` on the workflows ✅, `biome check` ✅, YAML parses with the expected step order ✅. Workflow-only behaviour change otherwise; the `dev-tools` vitest project passes apart from the pre-existing sandbox `mktemp` failure in `check-skill-router-sync.test.mjs` (unrelated, passes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
