### PR TITLE
fix(webapp): keep the compaction seam across a reload

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -191,7 +191,7 @@ a **derivation**, never a parallel write.
 | `types.ts`     | `ConversationEntry` (`user` / `assistant` / `tool-call` / `tool-result` / `external-event` / `child-result`), the record, its version |
 | `key.ts`       | identity — `<workspaceId>::<workUnitId>`, workspace root × jid                                                                        |
 | `entries.ts`   | ingest from Pi messages (live path) and from a chat transcript (migration only)                                                       |
-| `derive.ts`    | `toAgentMessages` (Pi), `toChatMessages` (UI), `toTranscriptText` (tray / archives), `toChildResultSummary`                           |
+| `derive.ts`    | `toAgentMessages` (Pi), `toChatMessages` (UI), `toTranscriptText` (tray / archives), `toChildResultSummary`, `interleaveMarkers`      |
 | `store.ts`     | the `slicc-work-units` IndexedDB store + the migration cursor                                                                         |
 | `migration.ts` | the versioned, resumable pass over the legacy stores                                                                                  |
 
@@ -208,6 +208,22 @@ entries with ascending `seq` and never edits one. Compaction (and
 divergence, is applied as a replace, and is counted on `rewrites`.
 Interleaving the two would splice a pre-compaction conversation into a
 post-compaction one.
+
+**Markers are not entries.** A compaction row (`<slicc-compaction-marker>`,
+the iOS `CompactionMarkerRow`) records something that happened TO the
+conversation, so it lives in `record.markers`, outside the entry
+reconciliation — an entry would be erased by the very compaction it announces,
+and Pi must never be shown a row saying its own context was summarized. The
+kernel writes one per round (`Bridge.recordCompactionRow`, keyed by the row id
+so the terminal phase settles it in place and a `discarded` round deletes it);
+`toChatMessages` folds them back by `timestamp` alone, because no entry
+survives a rewrite to anchor to. The rendering side is unchanged: the row is a
+`ChatMessage` carrying `compaction`, and `messageEls` keys on that field.
+
+The phase→row decision itself belongs to `scoops/compaction-rows.ts`
+(`CompactionRowTracker`), driven by BOTH the panel (which renders the row) and
+the kernel (which persists it), so a reload cannot show a different seam than
+the live thread did.
 
 **Two origins, because you cannot invent Pi messages.** A record built from
 `agent-sessions` (`origin: 'agent-history'`) derives faithfully to both Pi

--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -215,15 +215,35 @@ conversation, so it lives in `record.markers`, outside the entry
 reconciliation — an entry would be erased by the very compaction it announces,
 and Pi must never be shown a row saying its own context was summarized. The
 kernel writes one per round (`Bridge.recordCompactionRow`, keyed by the row id
-so the terminal phase settles it in place and a `discarded` round deletes it);
-`toChatMessages` folds them back by `timestamp` alone, because no entry
-survives a rewrite to anchor to. The rendering side is unchanged: the row is a
-`ChatMessage` carrying `compaction`, and `messageEls` keys on that field.
+so a `discarded` round deletes it); `toChatMessages` folds them back by
+`timestamp` alone, because no entry survives a rewrite to anchor to. The
+rendering side is unchanged: the row is a `ChatMessage` carrying `compaction`,
+and `messageEls` keys on that field.
+
+**Only a SETTLED round is durable.** The kernel writes nothing on the opening
+phase and `interleaveMarkers` restores `summarized` / `fallback` only. The
+compaction phase stream does not replay, so a `summarizing` marker left behind
+by a tab that reloaded mid-round has nothing alive to settle it and would
+breathe "compacting history…" for the rest of the conversation. The in-flight
+row is the panel's, rendered live and forgotten with the realm that drew it.
+
+A settled marker whose record does not exist yet (a cone can compact before its
+first checkpoint — one oversized prompt does it) is held in
+`Bridge.pendingMarkers` and retried when the turn ends, by which point the
+history sync has created the conversation it annotates.
 
 The phase→row decision itself belongs to `scoops/compaction-rows.ts`
 (`CompactionRowTracker`), driven by BOTH the panel (which renders the row) and
 the kernel (which persists it), so a reload cannot show a different seam than
-the live thread did.
+the live thread did. The kernel's tracker runs FIRST and mints the row id,
+which rides the wire (`CompactionStateMsg.rowId`) for the panel to adopt: two
+id spaces for one round would leave a replayed seam that the panel's terminal
+phase cannot find, and a second row appended beside it.
+
+Marker writes are serialized per key with the history writes
+(`WorkUnitConversationStore.serialize`). A round settles its marker at the same
+moment its caller persists the compacted history, and both are
+read-modify-write over the whole record.
 
 **Two origins, because you cannot invent Pi messages.** A record built from
 `agent-sessions` (`origin: 'agent-history'`) derives faithfully to both Pi

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -57,7 +57,9 @@ Invariants a reviewer must catch; mechanism in the linked docs.
   it); never make a canonical read fatal or delete a still-written legacy record. A transcript row
   that annotates the conversation instead of belonging to it (the compaction seam) is a
   `record.markers` entry, NEVER a `ConversationEntry` — compaction replaces entries wholesale and
-  would erase the row announcing it. **Users never
+  would erase the row announcing it. Only a SETTLED round is written down (the phase stream does
+  not replay, so a persisted in-flight seam could never be settled), under the row id the KERNEL
+  minted and the wire carried. **Users never
   talk to a scoop**: a selected scoop is READ-ONLY (`isReadOnlyUnit`); asks go to the OWNING
   cone. Layout from `workspaceFor` ALONE (never hardcode `/workspace`); memory per cone.
   Privileged-float detection via `CapabilityBroker`, not `isExtensionRealm`, in scoops.

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -54,7 +54,10 @@ Invariants a reviewer must catch; mechanism in the linked docs.
 - **Cone and scoop are roles over one `WorkUnit`** (`docs/work-unit.md`):
   `RegisteredScoop.parentJid` required — `null` is THE root test (`isRootUnit`); no role field.
   The CONVERSATION is the one canonical append-only record (history/UI/transcripts DERIVE from
-  it); never make a canonical read fatal or delete a still-written legacy record. **Users never
+  it); never make a canonical read fatal or delete a still-written legacy record. A transcript row
+  that annotates the conversation instead of belonging to it (the compaction seam) is a
+  `record.markers` entry, NEVER a `ConversationEntry` — compaction replaces entries wholesale and
+  would erase the row announcing it. **Users never
   talk to a scoop**: a selected scoop is READ-ONLY (`isReadOnlyUnit`); asks go to the OWNING
   cone. Layout from `workspaceFor` ALONE (never hardcode `/workspace`); memory per cone.
   Privileged-float detection via `CapabilityBroker`, not `isExtensionRealm`, in scoops.

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -16,10 +16,12 @@ import { createLogger } from '../base/logger.js';
 import type { BrowserAPI } from '../cdp/index.js';
 import type { AgentEvent } from '../core/agent-types.js';
 import type { MessageAttachment } from '../core/attachments.js';
+import type { CompactionState, CompactionStateDetail } from '../core/context-compaction.js';
 import { getBudgetWindowSnapshot, refreshBudgetWindow } from '../providers/budget-usage-source.js';
 import { AGENT_BRIDGE_GLOBAL_KEY, type AgentBridge } from '../scoops/agent-bridge.js';
 import { SessionStore } from '../scoops/chat-session-store.js';
 import type { ChatMessage } from '../scoops/chat-types.js';
+import { CompactionRowTracker } from '../scoops/compaction-rows.js';
 import { HIDDEN_TOOL_NAMES } from '../scoops/hidden-tools.js';
 import { formatLickEventForCone } from '../scoops/lick-formatting.js';
 import type { Orchestrator, OrchestratorCallbacks } from '../scoops/orchestrator.js';
@@ -33,6 +35,7 @@ import type { FollowerSyncManager } from '../scoops/tray-follower-sync.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../scoops/types.js';
 import { getSprinkleRoute } from '../shell/sprinkle-routes.js';
 import { TOOL_UI_MOUNTED_ACTION, toolUIRegistry } from '../tools/tool-ui.js';
+import type { ConversationMarker } from '../work-unit/conversation/types.js';
 import { buildWorkUnitRecord } from '../work-unit/manager.js';
 import { isRootUnit, rootOwnerOf, rootsOf } from '../work-unit/policy.js';
 import {
@@ -137,6 +140,12 @@ interface BufferedChatMessage {
   isStreaming?: boolean;
   model?: string;
   usage?: ChatMessage['usage'];
+  /**
+   * Compaction-marker row: bookkeeping about the conversation rather than a
+   * message in it. Carried so the row survives the round trip through the UI
+   * store — the view renders on this field alone (`messageEls`).
+   */
+  compaction?: ChatMessage['compaction'];
 }
 
 export class Bridge implements KernelFacade {
@@ -169,6 +178,16 @@ export class Bridge implements KernelFacade {
   private readonly conesBeingCreated = new Map<string, Promise<void>>();
   /** Current assistant message ID per scoop */
   private currentMessageId = new Map<string, string>();
+  /**
+   * Compaction-row bookkeeping for the DURABLE copy of each round's marker
+   * ({@link recordCompactionRow}). A separate instance from the panel's, on
+   * purpose: the two consumers see the same phases but keep their own row
+   * ids, and a kernel that reused a panel's id would be trusting a realm it
+   * cannot see restart.
+   */
+  private readonly compactionRows = new CompactionRowTracker(
+    (scoopJid) => `compaction-${scoopJid}-${uid()}`
+  );
   /** Panel-facing scoop state and projection. */
   private readonly scoopPresentation = new ScoopPresentation();
   /** Post-transport agent-event translation and fan-out. */
@@ -335,6 +354,11 @@ export class Bridge implements KernelFacade {
           ...(detail.transcriptPath ? { transcriptPath: detail.transcriptPath } : {}),
           ...(detail.roundId ? { roundId: detail.roundId } : {}),
         });
+        // The panel renders the row from the emission above; this DURABLY
+        // records the same round, because a compaction marker exists nowhere
+        // in Pi's history and a reload would otherwise erase the seam it
+        // announces (#2843).
+        void bridge.recordCompactionRow(scoopJid, state, detail);
       },
 
       onError: (scoopJid, error) => {
@@ -941,7 +965,30 @@ export class Bridge implements KernelFacade {
     const chatMessages = agentMessagesToChatMessages(agentMessages, {
       source: sourceLabelFor(scoop),
     });
-    return toBufferedChatMessages(chatMessages);
+    // Pi's history holds no compaction rows — it cannot, they are bookkeeping
+    // about it — so the canonical record's markers are folded back in here.
+    // Without this a rebuild from live agent state (every boot seed) would be
+    // the transcript MINUS its seams, and persist that over the UI store.
+    const { interleaveMarkers } = await import('../work-unit/conversation/derive.js');
+    return toBufferedChatMessages(
+      interleaveMarkers(chatMessages, await this.loadConversationMarkers(scoop))
+    );
+  }
+
+  /**
+   * A unit's stored {@link ConversationMarker}s, or `undefined` when there is
+   * no canonical store, no record, or nothing annotated. Never throws — the
+   * store's reads already answer instead of failing, and a missing marker
+   * costs a seam, not a transcript.
+   */
+  private async loadConversationMarkers(
+    scoop: RegisteredScoop
+  ): Promise<ConversationMarker[] | undefined> {
+    const store = this.orchestrator?.getConversationStore?.();
+    if (!store) return undefined;
+    const { conversationKeyFor } = await import('../work-unit/conversation/key.js');
+    const record = await store.load(conversationKeyFor(scoop));
+    return record?.markers;
   }
 
   /**
@@ -1459,6 +1506,67 @@ export class Bridge implements KernelFacade {
     }
 
     empty();
+  }
+
+  /**
+   * Record one compaction phase durably: as a marker on the unit's canonical
+   * record, and as a row in the unit's message buffer + UI store.
+   *
+   * Both writes are needed and neither is redundant. The buffer is what the
+   * panel replays from for the rest of this session (and what `persistScoop`
+   * writes to `browser-coding-agent`); the canonical marker is what survives
+   * the compaction ITSELF — `syncAgentMessages` replaces the record's entries
+   * wholesale on the next turn, and every boot re-seeds the buffer from Pi's
+   * history, which never held the row (#2843).
+   *
+   * The phase→row decision comes from the same {@link CompactionRowTracker}
+   * the panel uses, so the persisted seam and the rendered one cannot drift.
+   */
+  private async recordCompactionRow(
+    scoopJid: string,
+    state: CompactionState,
+    detail: CompactionStateDetail
+  ): Promise<void> {
+    const action = this.compactionRows.apply(scoopJid, state, detail);
+    if (!action) return;
+    const scoop = this.orchestrator?.getScoops().find((s) => s.jid === scoopJid);
+    if (!scoop) return;
+    const buf = this.getBuffer(scoopJid);
+    if (action.kind === 'retract') {
+      // Spliced in place: `getBuffer` handed this array out by reference, and
+      // swapping in a copy would leave a holder appending to a detached one.
+      const at = buf.findIndex((m) => m.id === action.messageId);
+      if (at >= 0) buf.splice(at, 1);
+    } else {
+      const existing = buf.find((m) => m.id === action.messageId);
+      if (existing) existing.compaction = action.marker;
+      else {
+        buf.push({
+          id: action.messageId,
+          role: 'assistant',
+          content: '',
+          timestamp: Date.now(),
+          compaction: action.marker,
+        });
+      }
+    }
+    this.persistScoop(scoopJid);
+    const store = this.orchestrator?.getConversationStore?.();
+    if (!store) return;
+    const { conversationKeyFor } = await import('../work-unit/conversation/key.js');
+    const key = conversationKeyFor(scoop);
+    if (action.kind === 'retract') {
+      await store.deleteMarker(key, action.messageId);
+      return;
+    }
+    await store.putMarker(key, {
+      id: action.messageId,
+      kind: 'compaction',
+      // Stamped per phase so a settled marker sorts AFTER the summary message
+      // the round just wrote — which is where the seam belongs.
+      timestamp: Date.now(),
+      compaction: action.marker,
+    });
   }
 
   /**
@@ -2243,5 +2351,6 @@ function toBufferedChatMessages(chatMessages: readonly ChatMessage[]): BufferedC
     model: m.model,
     usage: m.usage,
     isStreaming: false,
+    compaction: m.compaction,
   }));
 }

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -16,12 +16,11 @@ import { createLogger } from '../base/logger.js';
 import type { BrowserAPI } from '../cdp/index.js';
 import type { AgentEvent } from '../core/agent-types.js';
 import type { MessageAttachment } from '../core/attachments.js';
-import type { CompactionState, CompactionStateDetail } from '../core/context-compaction.js';
 import { getBudgetWindowSnapshot, refreshBudgetWindow } from '../providers/budget-usage-source.js';
 import { AGENT_BRIDGE_GLOBAL_KEY, type AgentBridge } from '../scoops/agent-bridge.js';
 import { SessionStore } from '../scoops/chat-session-store.js';
 import type { ChatMessage } from '../scoops/chat-types.js';
-import { CompactionRowTracker } from '../scoops/compaction-rows.js';
+import { type CompactionRowAction, CompactionRowTracker } from '../scoops/compaction-rows.js';
 import { HIDDEN_TOOL_NAMES } from '../scoops/hidden-tools.js';
 import { formatLickEventForCone } from '../scoops/lick-formatting.js';
 import type { Orchestrator, OrchestratorCallbacks } from '../scoops/orchestrator.js';
@@ -84,6 +83,14 @@ const log = createLogger('kernel-bridge');
  * proxy costs one late counter, never a missing one.
  */
 const FIRST_BUDGET_PROBE_MS = 2_500;
+
+/**
+ * How many settled compaction markers wait for a canonical record to exist
+ * (`pendingMarkers`). A young conversation compacts once or twice before its
+ * first checkpoint; anything beyond that is a record that will never accept a
+ * write, and holding more would be hoarding.
+ */
+const MAX_PENDING_MARKERS = 4;
 
 interface FacadeLickManager {
   setForwarder(forwarder: ((event: ForwardedLickEvent) => void) | null): void;
@@ -180,14 +187,23 @@ export class Bridge implements KernelFacade {
   private currentMessageId = new Map<string, string>();
   /**
    * Compaction-row bookkeeping for the DURABLE copy of each round's marker
-   * ({@link recordCompactionRow}). A separate instance from the panel's, on
-   * purpose: the two consumers see the same phases but keep their own row
-   * ids, and a kernel that reused a panel's id would be trusting a realm it
-   * cannot see restart.
+   * ({@link recordCompactionRow}). This instance is the one that MINTS the row
+   * id: the kernel outlives every panel, so its verdict is the one the wire
+   * carries and the panel adopts (`CompactionStateMsg.rowId`).
    */
   private readonly compactionRows = new CompactionRowTracker(
     (scoopJid) => `compaction-${scoopJid}-${uid()}`
   );
+  /**
+   * Settled markers whose canonical record did not exist yet, per scoop.
+   *
+   * A cone can compact before its conversation is first checkpointed — one
+   * oversized opening prompt is enough — and a marker has nothing to annotate
+   * until then, so `putMarker` declines. Holding it here and retrying when the
+   * turn ends means the seam lands on the record the history sync just
+   * created, instead of being lost until the next compaction (#2843).
+   */
+  private readonly pendingMarkers = new Map<string, ConversationMarker[]>();
   /** Panel-facing scoop state and projection. */
   private readonly scoopPresentation = new ScoopPresentation();
   /** Post-transport agent-event translation and fan-out. */
@@ -297,6 +313,10 @@ export class Bridge implements KernelFacade {
         }
 
         bridge.persistScoop(scoopJid);
+        // The turn is over, so the session checkpoint has had its chance to
+        // create the canonical record a seam from earlier in this turn could
+        // not be written to yet.
+        void bridge.flushPendingMarkers(scoopJid);
 
         bridge.emit({
           type: 'agent-event',
@@ -346,6 +366,10 @@ export class Bridge implements KernelFacade {
       },
 
       onCompactionStateChange: (scoopJid, state, detail) => {
+        // The tracker runs BEFORE the emission so the row id rides the wire:
+        // the panel renders the row this kernel will persist and replay, under
+        // the same id, instead of minting a second one for the same round.
+        const action = bridge.compactionRows.apply(scoopJid, state, detail);
         bridge.emit({
           type: 'compaction-state',
           scoopJid,
@@ -353,12 +377,13 @@ export class Bridge implements KernelFacade {
           trigger: detail.trigger,
           ...(detail.transcriptPath ? { transcriptPath: detail.transcriptPath } : {}),
           ...(detail.roundId ? { roundId: detail.roundId } : {}),
+          ...(action ? { rowId: action.messageId } : {}),
         });
         // The panel renders the row from the emission above; this DURABLY
         // records the same round, because a compaction marker exists nowhere
         // in Pi's history and a reload would otherwise erase the seam it
         // announces (#2843).
-        void bridge.recordCompactionRow(scoopJid, state, detail);
+        void bridge.recordCompactionRow(scoopJid, action);
       },
 
       onError: (scoopJid, error) => {
@@ -1509,8 +1534,8 @@ export class Bridge implements KernelFacade {
   }
 
   /**
-   * Record one compaction phase durably: as a marker on the unit's canonical
-   * record, and as a row in the unit's message buffer + UI store.
+   * Record one SETTLED compaction round durably: as a marker on the unit's
+   * canonical record, and as a row in the unit's message buffer + UI store.
    *
    * Both writes are needed and neither is redundant. The buffer is what the
    * panel replays from for the rest of this session (and what `persistScoop`
@@ -1519,16 +1544,18 @@ export class Bridge implements KernelFacade {
    * wholesale on the next turn, and every boot re-seeds the buffer from Pi's
    * history, which never held the row (#2843).
    *
-   * The phase→row decision comes from the same {@link CompactionRowTracker}
-   * the panel uses, so the persisted seam and the rendered one cannot drift.
+   * An OPENING phase is deliberately not written anywhere durable. The panel
+   * renders the in-flight row live from the same tracker's verdict, and the
+   * phase stream does not replay: a tab that reloaded between the opening
+   * write and the round's terminal phase would restore a seam stuck
+   * "compacting history…" with nothing left alive to settle it. Only a round
+   * that finished is a fact about the conversation.
    */
   private async recordCompactionRow(
     scoopJid: string,
-    state: CompactionState,
-    detail: CompactionStateDetail
+    action: CompactionRowAction | null
   ): Promise<void> {
-    const action = this.compactionRows.apply(scoopJid, state, detail);
-    if (!action) return;
+    if (!action || action.kind === 'open') return;
     const scoop = this.orchestrator?.getScoops().find((s) => s.jid === scoopJid);
     if (!scoop) return;
     const buf = this.getBuffer(scoopJid);
@@ -1556,17 +1583,62 @@ export class Bridge implements KernelFacade {
     const { conversationKeyFor } = await import('../work-unit/conversation/key.js');
     const key = conversationKeyFor(scoop);
     if (action.kind === 'retract') {
+      this.dropPendingMarker(scoopJid, action.messageId);
       await store.deleteMarker(key, action.messageId);
       return;
     }
-    await store.putMarker(key, {
+    const marker: ConversationMarker = {
       id: action.messageId,
       kind: 'compaction',
-      // Stamped per phase so a settled marker sorts AFTER the summary message
-      // the round just wrote — which is where the seam belongs.
+      // Stamped when the round settles so the marker sorts AFTER the summary
+      // message it produced — which is where the seam belongs.
       timestamp: Date.now(),
       compaction: action.marker,
-    });
+    };
+    if (!(await store.putMarker(key, marker))) this.holdPendingMarker(scoopJid, marker);
+  }
+
+  /**
+   * Keep a marker the canonical record could not take yet — see
+   * {@link pendingMarkers}. Capped, oldest first: the retry is a courtesy for
+   * a young conversation, not a durable queue.
+   */
+  private holdPendingMarker(scoopJid: string, marker: ConversationMarker): void {
+    const held = this.pendingMarkers.get(scoopJid) ?? [];
+    this.pendingMarkers.set(
+      scoopJid,
+      [...held.filter((m) => m.id !== marker.id), marker].slice(-MAX_PENDING_MARKERS)
+    );
+  }
+
+  /** A retracted round stops waiting to be written down. */
+  private dropPendingMarker(scoopJid: string, markerId: string): void {
+    const held = this.pendingMarkers.get(scoopJid);
+    if (!held) return;
+    const kept = held.filter((m) => m.id !== markerId);
+    if (kept.length === 0) this.pendingMarkers.delete(scoopJid);
+    else this.pendingMarkers.set(scoopJid, kept);
+  }
+
+  /**
+   * Retry the markers whose record did not exist when their round settled.
+   * Called at the end of a turn, by which point the session checkpoint has
+   * created the conversation the seam belongs to.
+   */
+  private async flushPendingMarkers(scoopJid: string): Promise<void> {
+    const held = this.pendingMarkers.get(scoopJid);
+    if (!held || held.length === 0) return;
+    const store = this.orchestrator?.getConversationStore?.();
+    const scoop = this.orchestrator?.getScoops().find((s) => s.jid === scoopJid);
+    if (!store || !scoop) return;
+    const { conversationKeyFor } = await import('../work-unit/conversation/key.js');
+    const key = conversationKeyFor(scoop);
+    const stuck: ConversationMarker[] = [];
+    for (const marker of held) {
+      if (!(await store.putMarker(key, marker))) stuck.push(marker);
+    }
+    if (stuck.length === 0) this.pendingMarkers.delete(scoopJid);
+    else this.pendingMarkers.set(scoopJid, stuck);
   }
 
   /**

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -1249,6 +1249,12 @@ export interface ScoopMessagesReplacedMsg {
     isStreaming?: boolean;
     model?: string;
     usage?: ChatMessage['usage'];
+    /**
+     * Compaction-marker row (#2843): the replay's record of a compaction
+     * round. On the wire because a replay is the ONLY way the row reaches a
+     * remounted panel or a follower — no agent event replays it.
+     */
+    compaction?: ChatMessage['compaction'];
   }>;
   /**
    * Ids of the messages still pending in the orchestrator's queue for this

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -1103,6 +1103,15 @@ export interface CompactionStateMsg {
    * compaction row is currently on the transcript (#2843).
    */
   roundId?: string;
+  /**
+   * Id of the transcript row this phase acts on, minted by the kernel's
+   * `CompactionRowTracker` — the SAME id it persists as a marker and replays
+   * in the message buffer. The panel adopts it so a row it rendered live and
+   * a row a replay hands it are one row, not two. Absent when the phase is
+   * not a row at all (`extracting-memory`), and on envelopes from a kernel
+   * older than this field, where the panel mints its own.
+   */
+  rowId?: string;
 }
 
 /**

--- a/packages/webapp/src/scoops/compaction-rows.ts
+++ b/packages/webapp/src/scoops/compaction-rows.ts
@@ -13,6 +13,10 @@
  * (`ui/offscreen-client.ts`) and the kernel persists it (`kernel/facade.ts`),
  * and a second opinion on either side would mean a transcript whose seams
  * change when you reload it.
+ *
+ * The kernel runs first and MINTS the row id; the panel adopts it off the wire
+ * (`CompactionStateMsg.rowId`). Two id spaces for one round would mean the
+ * panel's terminal phase targeting a row no replay contains.
  */
 
 import type { CompactionState, CompactionStateDetail } from '../core/context-compaction.js';
@@ -68,14 +72,24 @@ export class CompactionRowTracker {
   /** `mintId` is injectable so tests (and two floats) can be deterministic. */
   constructor(private readonly mintId: (unitId: string) => string) {}
 
-  /** Decide what one phase does to `unitId`'s transcript. */
+  /**
+   * Decide what one phase does to `unitId`'s transcript.
+   *
+   * `rowId` is the id the round already has somewhere else — the kernel mints
+   * it, the panel receives it on the wire. Supplying it does two things: a
+   * round this tracker never saw OPEN can still be settled (the panel mounted
+   * mid-round), and both sides name the same row, so the terminal phase
+   * updates the replayed seam instead of appending a second one. A row this
+   * tracker is already tracking wins, because that is the row it is showing.
+   */
   apply(
     unitId: string,
     state: CompactionState,
-    detail: CompactionStateDetail
+    detail: CompactionStateDetail,
+    rowId?: string
   ): CompactionRowAction | null {
     if (state === 'extracting-memory') return null;
-    const existing = this.open.get(unitId) ?? this.lateRetraction(unitId, state, detail);
+    const existing = this.open.get(unitId) ?? this.lateRetraction(unitId, state, detail) ?? rowId;
     // A terminal phase with no open row is a round whose opening phase never
     // reached this consumer (it started before the tab attached, or against a
     // unit that was not selected). There is nothing to settle or retract.

--- a/packages/webapp/src/scoops/compaction-rows.ts
+++ b/packages/webapp/src/scoops/compaction-rows.ts
@@ -1,0 +1,120 @@
+/**
+ * The compaction-row reducer: compaction PHASES in, transcript-row actions
+ * out (#2843).
+ *
+ * One round produces one row. The opening phase (`summarizing`) mints it, a
+ * terminal phase settles it in place, and a round that kept nothing retracts
+ * it — including the LATE retraction only the idle timer produces, which
+ * decides adoption after the compactor has already returned and so has to
+ * name the round it is taking back.
+ *
+ * This lives at the `scoops/` layer because two consumers need the identical
+ * verdict from the identical event stream: the panel renders the row
+ * (`ui/offscreen-client.ts`) and the kernel persists it (`kernel/facade.ts`),
+ * and a second opinion on either side would mean a transcript whose seams
+ * change when you reload it.
+ */
+
+import type { CompactionState, CompactionStateDetail } from '../core/context-compaction.js';
+import type { ChatCompactionMarker, CompactionMarkerState } from './chat-types.js';
+
+/**
+ * Compaction PHASE (what the round is doing) → marker STATE (what the row
+ * says). `extracting-memory` is absent on purpose: it is a phase of a round
+ * whose row is already up, and it changes nothing the row shows.
+ */
+const MARKER_STATE: Record<Exclude<CompactionState, 'extracting-memory'>, CompactionMarkerState> = {
+  summarizing: 'summarizing',
+  fallback: 'fallback',
+  cancelled: 'discarded',
+  // `idle` is the resting state the compactor reaches after a round it did
+  // NOT abort — so for a row still open, the history really was summarized.
+  idle: 'summarized',
+};
+
+/** What a phase does to the transcript. `null` means: nothing at all. */
+export type CompactionRowAction =
+  /** Add a row for a round that just started. */
+  | { kind: 'open'; messageId: string; marker: ChatCompactionMarker }
+  /** Update the row this round already owns. */
+  | { kind: 'settle'; messageId: string; marker: ChatCompactionMarker }
+  /** Take the row back: the round kept nothing. */
+  | { kind: 'retract'; messageId: string };
+
+interface SettledRow {
+  messageId: string;
+  roundId: string;
+}
+
+/**
+ * Per-unit row bookkeeping for the compaction phase stream. Stateful but
+ * pure — it touches no DOM, no store and no clock beyond the id factory it
+ * is handed.
+ */
+export class CompactionRowTracker {
+  /** Row of the round currently in flight, per unit. */
+  private readonly open = new Map<string, string>();
+  /**
+   * Row a late `cancelled` is allowed to take back: one this unit already
+   * settled, belonging to the SAME round as the retraction.
+   *
+   * Only the idle timer produces the `summarizing` → `idle` → `cancelled`
+   * sequence. Matching on the round id keeps a discarded round that never
+   * opened a row — nothing to summarize, so the compactor emitted nothing —
+   * from retracting a previous round's honest row (#2843).
+   */
+  private readonly settled = new Map<string, SettledRow>();
+
+  /** `mintId` is injectable so tests (and two floats) can be deterministic. */
+  constructor(private readonly mintId: (unitId: string) => string) {}
+
+  /** Decide what one phase does to `unitId`'s transcript. */
+  apply(
+    unitId: string,
+    state: CompactionState,
+    detail: CompactionStateDetail
+  ): CompactionRowAction | null {
+    if (state === 'extracting-memory') return null;
+    const existing = this.open.get(unitId) ?? this.lateRetraction(unitId, state, detail);
+    // A terminal phase with no open row is a round whose opening phase never
+    // reached this consumer (it started before the tab attached, or against a
+    // unit that was not selected). There is nothing to settle or retract.
+    if (state !== 'summarizing' && !existing) return null;
+    if (state !== 'summarizing') {
+      this.open.delete(unitId);
+      this.settled.delete(unitId);
+    }
+    const messageId = existing ?? this.mintId(unitId);
+    if (state === 'summarizing') this.open.set(unitId, messageId);
+    // A round that named itself keeps its settled row retractable: its own
+    // adoption verdict has not arrived yet (see {@link settled}).
+    if ((state === 'idle' || state === 'fallback') && detail.roundId) {
+      this.settled.set(unitId, { messageId, roundId: detail.roundId });
+    }
+    if (state === 'cancelled') return { kind: 'retract', messageId };
+    const marker: ChatCompactionMarker = {
+      trigger: detail.trigger,
+      state: MARKER_STATE[state],
+      ...(detail.transcriptPath ? { transcriptPath: detail.transcriptPath } : {}),
+    };
+    return state === 'summarizing'
+      ? { kind: 'open', messageId, marker }
+      : { kind: 'settle', messageId, marker };
+  }
+
+  /** Forget a unit — it was dropped, or its transcript was cleared. */
+  forget(unitId: string): void {
+    this.open.delete(unitId);
+    this.settled.delete(unitId);
+  }
+
+  private lateRetraction(
+    unitId: string,
+    state: CompactionState,
+    detail: CompactionStateDetail
+  ): string | undefined {
+    if (state !== 'cancelled' || !detail.roundId) return undefined;
+    const settled = this.settled.get(unitId);
+    return settled?.roundId === detail.roundId ? settled.messageId : undefined;
+  }
+}

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -10,6 +10,7 @@
 
 import { createLogger } from '../base/logger.js';
 import type { MessageAttachment } from '../core/attachments.js';
+import type { CompactionState } from '../core/context-compaction.js';
 import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 import type {
   AgentEventMsg,
@@ -44,6 +45,7 @@ import type {
 import { createPanelChromeRuntimeTransport } from '../kernel/transport-chrome-runtime.js';
 import type { KernelClientFacade, KernelTransport } from '../kernel/types.js';
 import type { AgentSpawnOptions, AgentSpawnResult } from '../scoops/agent-bridge.js';
+import { CompactionRowTracker } from '../scoops/compaction-rows.js';
 import type { LickEvent, WebhookDeliveryDisposition } from '../scoops/lick-manager.js';
 import { setFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
 import { setLeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
@@ -70,27 +72,9 @@ import {
  */
 const WEBHOOK_DELIVERY_ACK_TIMEOUT_MS = 2000;
 
-import type { CompactionMarkerState } from '../scoops/chat-types.js';
 import type { AgentHandle, ChatMessage, AgentEvent as UIAgentEvent } from './types.js';
 
 const log = createLogger('offscreen-client');
-
-/**
- * Compaction PHASE (what the round is doing) → marker STATE (what the row
- * says). `extracting-memory` never reaches this map: it is a phase of a round
- * whose row is already up, and it changes nothing the row shows.
- */
-const COMPACTION_MARKER_STATE: Record<
-  'summarizing' | 'fallback' | 'cancelled' | 'idle',
-  CompactionMarkerState
-> = {
-  summarizing: 'summarizing',
-  fallback: 'fallback',
-  cancelled: 'discarded',
-  // `idle` is the resting state the compactor reaches after a round it did
-  // NOT abort — so for a row still open, the history really was summarized.
-  idle: 'summarized',
-};
 
 // Compile-time guard: the real `LickEvent`'s carrier fields must stay
 // assignable to the wire mirror `ForwardedLickEvent` (messages.ts can't import
@@ -216,33 +200,18 @@ export class OffscreenClient implements KernelClientFacade {
   private scoopStatuses = new Map<string, ScoopTabState['status']>();
   private currentMessageId = new Map<string, string>();
   /**
-   * Transcript-row id of each scoop's OPEN compaction round, keyed by jid.
-   * Set by the round's opening phase and consumed by its terminal one, so a
-   * round is exactly one row that settles (or retracts) in place instead of a
-   * fresh bubble per phase. Deliberately separate from `currentMessageId`: a
-   * compaction row must never become the target a real assistant stream
-   * appends to (#2843).
-   */
-  private compactionNoticeIds = new Map<string, string>();
-  /**
-   * Transcript-row id of the round a scoop has already SETTLED but whose fate
-   * is still open, keyed by jid, together with the round that owns it.
+   * Per-scoop compaction-row bookkeeping — one row per round, settled or
+   * retracted in place (`scoops/compaction-rows.ts`). Deliberately separate
+   * from `currentMessageId`: a compaction row must never become the target a
+   * real assistant stream appends to (#2843).
    *
-   * The idle timer decides adoption after the compactor has returned, so a
-   * round that summarized fine still emits its terminal state (`idle` →
-   * "Compacted while idle") before anyone knows whether the conversation kept
-   * the result. When it did not, the retraction arrives here as a `cancelled`
-   * with no open row left to remove. Remembering the settled row — and the
-   * round id it belongs to — is what lets that late `cancelled` take the row
-   * back instead of leaving the transcript claiming a compaction that was
-   * thrown away (#2843).
-   *
-   * The round id is load-bearing, not decoration: a round that finds nothing
-   * to summarize never opens a row and still reports itself discarded, so an
-   * unqualified "remove the last compaction row" would delete a PREVIOUS
-   * round's honest one.
+   * The kernel drives an identical tracker to PERSIST the same row, so the
+   * verdict this panel renders and the one a reload restores come from one
+   * reducer rather than two readings of the phase stream.
    */
-  private compactionSettledRows = new Map<string, { messageId: string; roundId: string }>();
+  private readonly compactionRows = new CompactionRowTracker(
+    (scoopJid) => `compaction-${scoopJid}-${uid()}`
+  );
   /**
    * Tool calls in flight per scoop — incremented on `tool_start`, decremented
    * on the matching `tool_end`. A scoop is in the `tool` phase while this is
@@ -1404,68 +1373,29 @@ export class OffscreenClient implements KernelClientFacade {
    * also prose on the wire, so it could not be restyled, retracted, or
    * rendered by a follower that words things differently (#2843).
    *
-   * One row per ROUND: `noticeIds` holds the id from the opening phase so the
-   * terminal phase updates that row instead of appending a second one, and
-   * `cancelled` retracts it entirely.
+   * One row per ROUND, and the phase→row decision belongs to
+   * `CompactionRowTracker` so the kernel's persisted copy of the same row
+   * cannot disagree with the rendered one.
    */
   private renderCompactionNotice(
     scoopJid: string,
-    state: 'summarizing' | 'extracting-memory' | 'fallback' | 'cancelled' | 'idle',
+    state: CompactionState,
     detail: CompactionNoticeDetail
   ): void {
-    // `extracting-memory` is a phase of a round already announced by
-    // `summarizing`; it changes nothing the row shows.
-    if (state === 'extracting-memory') return;
-    const existing =
-      this.compactionNoticeIds.get(scoopJid) ?? this.lateRetraction(scoopJid, state, detail);
-    // A terminal phase with no open row is a round whose opening phase never
-    // reached this panel (it started before the tab attached, or against a
-    // scoop that was not selected). There is nothing to settle or retract.
-    if (state !== 'summarizing' && !existing) return;
-    if (state === 'idle' || state === 'cancelled' || state === 'fallback') {
-      this.compactionNoticeIds.delete(scoopJid);
-      this.compactionSettledRows.delete(scoopJid);
-    }
-    const messageId = existing ?? `compaction-${scoopJid}-${uid()}`;
-    if (state === 'summarizing') this.compactionNoticeIds.set(scoopJid, messageId);
-    // A round that named itself keeps its settled row retractable: its own
-    // adoption verdict has not arrived yet (see `compactionSettledRows`).
-    if ((state === 'idle' || state === 'fallback') && detail.roundId) {
-      this.compactionSettledRows.set(scoopJid, { messageId, roundId: detail.roundId });
-    }
-    // Selection is checked AFTER the bookkeeping so a round that spans a scoop
-    // switch still closes its own id out; the row itself belongs to the
+    // The tracker runs BEFORE the selection check so a round that spans a
+    // scoop switch still closes its own id out; the row itself belongs to the
     // selected thread only.
+    const action = this.compactionRows.apply(scoopJid, state, detail);
+    if (!action) return;
     if (scoopJid !== this.selectedScoopJid) return;
     this.emitToUI({
       type: 'compaction_notice',
-      messageId,
-      marker: {
-        trigger: detail.trigger,
-        state: COMPACTION_MARKER_STATE[state],
-        ...(detail.transcriptPath ? { transcriptPath: detail.transcriptPath } : {}),
-      },
+      messageId: action.messageId,
+      // A retraction rides the same event: `discarded` is what tells the chat
+      // controller to REMOVE the row rather than relabel it.
+      marker:
+        action.kind === 'retract' ? { trigger: detail.trigger, state: 'discarded' } : action.marker,
     });
-  }
-
-  /**
-   * The row a late `cancelled` is allowed to take back: one this scoop already
-   * settled, belonging to the SAME round as the retraction.
-   *
-   * Only the idle timer produces this sequence (`summarizing` → `idle` →
-   * `cancelled`), because only it decides adoption after the compactor has
-   * returned. Matching on the round id keeps a discarded round that never
-   * opened a row — nothing to summarize, so the compactor emitted nothing —
-   * from retracting a previous round's honest row (#2843).
-   */
-  private lateRetraction(
-    scoopJid: string,
-    state: 'summarizing' | 'fallback' | 'cancelled' | 'idle',
-    detail: CompactionNoticeDetail
-  ): string | undefined {
-    if (state !== 'cancelled' || !detail.roundId) return undefined;
-    const settled = this.compactionSettledRows.get(scoopJid);
-    return settled?.roundId === detail.roundId ? settled.messageId : undefined;
   }
 
   /** Decode one compaction phase and hand it to both the host and the thread. */

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -207,7 +207,9 @@ export class OffscreenClient implements KernelClientFacade {
    *
    * The kernel drives an identical tracker to PERSIST the same row, so the
    * verdict this panel renders and the one a reload restores come from one
-   * reducer rather than two readings of the phase stream.
+   * reducer rather than two readings of the phase stream. The kernel's id
+   * wins (`CompactionStateMsg.rowId`); this tracker only mints one for a
+   * kernel too old to send it.
    */
   private readonly compactionRows = new CompactionRowTracker(
     (scoopJid) => `compaction-${scoopJid}-${uid()}`
@@ -1380,12 +1382,13 @@ export class OffscreenClient implements KernelClientFacade {
   private renderCompactionNotice(
     scoopJid: string,
     state: CompactionState,
-    detail: CompactionNoticeDetail
+    detail: CompactionNoticeDetail,
+    rowId?: string
   ): void {
     // The tracker runs BEFORE the selection check so a round that spans a
     // scoop switch still closes its own id out; the row itself belongs to the
     // selected thread only.
-    const action = this.compactionRows.apply(scoopJid, state, detail);
+    const action = this.compactionRows.apply(scoopJid, state, detail, rowId);
     if (!action) return;
     if (scoopJid !== this.selectedScoopJid) return;
     this.emitToUI({
@@ -1406,7 +1409,11 @@ export class OffscreenClient implements KernelClientFacade {
       ...(msg.roundId ? { roundId: msg.roundId } : {}),
     };
     this.callbacks.onCompactionStateChange?.(msg.scoopJid, msg.state, detail);
-    this.renderCompactionNotice(msg.scoopJid, msg.state, detail);
+    // `msg.rowId` is the kernel's id for this round's row — the one it
+    // persists and replays. Adopting it keeps the rendered seam and the
+    // restored one the same row; without it, a panel that mounted mid-round
+    // would append a second seam next to the replayed one (#2843).
+    this.renderCompactionNotice(msg.scoopJid, msg.state, detail, msg.rowId);
   }
 
   private handleScoopStatus(msg: ScoopStatusMsg): void {

--- a/packages/webapp/src/work-unit/conversation/derive.ts
+++ b/packages/webapp/src/work-unit/conversation/derive.ts
@@ -14,7 +14,7 @@
 
 import type { AgentMessage } from '../../core/index.js';
 import type { ChatMessage } from '../../scoops/chat-types.js';
-import type { ConversationEntry, WorkUnitConversationRecord } from './types.js';
+import type { ConversationEntry, ConversationMarker, WorkUnitConversationRecord } from './types.js';
 import { isReadableRecord } from './types.js';
 
 /**
@@ -47,6 +47,10 @@ export function toAgentMessages(record: WorkUnitConversationRecord | null): Agen
  * pi-ai types out of every caller's eager closure.
  *
  * For a `ui-projection` record the stored chat messages ARE the projection.
+ *
+ * Either way the record's {@link ConversationMarker}s are folded back in
+ * ({@link interleaveMarkers}) — they are transcript rows no message list can
+ * carry, so this is the only place they can rejoin the thread.
  */
 export async function toChatMessages(
   record: WorkUnitConversationRecord | null,
@@ -59,12 +63,74 @@ export async function toChatMessages(
       if (entry.kind === 'tool-call') continue;
       if (entry.chat) out.push(entry.chat);
     }
-    return out;
+    return interleaveMarkers(out, record.markers);
   }
   const messages = toAgentMessages(record);
   if (messages.length === 0) return [];
   const { agentMessagesToChatMessages } = await import('../../scoops/agent-message-to-chat.js');
-  return agentMessagesToChatMessages(messages, options);
+  return interleaveMarkers(agentMessagesToChatMessages(messages, options), record.markers);
+}
+
+/**
+ * Fold marker rows into a projected transcript, ordered by `timestamp`.
+ *
+ * A marker goes BEFORE the first message stamped later than it, and at the
+ * end when there is none — the position a compaction seam belongs in, since
+ * the round is recorded after the summary message it produced. `discarded`
+ * markers are dropped: a retracted round must not be announced by a reload
+ * even if a crash left its marker behind.
+ *
+ * Pure and total: no markers returns the input array itself.
+ */
+export function interleaveMarkers(
+  messages: ChatMessage[],
+  markers: readonly ConversationMarker[] | undefined
+): ChatMessage[] {
+  const live = (markers ?? []).filter((m) => m.compaction.state !== 'discarded');
+  if (live.length === 0) return messages;
+  const sorted = [...live].sort((a, b) => a.timestamp - b.timestamp);
+  const out: ChatMessage[] = [];
+  let next = 0;
+  for (const message of messages) {
+    const at = messageTime(message);
+    while (next < sorted.length && sorted[next].timestamp <= at) {
+      out.push(markerRow(sorted[next++]));
+    }
+    out.push(message);
+  }
+  while (next < sorted.length) out.push(markerRow(sorted[next++]));
+  return out;
+}
+
+/**
+ * Epoch ms of a projected message, for comparison against a marker.
+ *
+ * The earliest `agent-sessions` writes stamped messages with ISO STRINGS and
+ * those profiles are still out there, so a raw `<=` would compare a number
+ * against a string and quietly answer `false` for every message. Anything
+ * unstampable sorts BEFORE every marker, which puts the seams at the end of a
+ * transcript that cannot place them — the honest fallback, since a compaction
+ * is the most recent thing that happened to it.
+ */
+function messageTime(message: ChatMessage): number {
+  const raw: unknown = message.timestamp;
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string') {
+    const parsed = Date.parse(raw);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return Number.NEGATIVE_INFINITY;
+}
+
+/** A marker as the row the chat view renders (`messageEls` keys on `compaction`). */
+function markerRow(marker: ConversationMarker): ChatMessage {
+  return {
+    id: marker.id,
+    role: 'assistant',
+    content: '',
+    timestamp: marker.timestamp,
+    compaction: marker.compaction,
+  };
 }
 
 /**

--- a/packages/webapp/src/work-unit/conversation/derive.ts
+++ b/packages/webapp/src/work-unit/conversation/derive.ts
@@ -13,9 +13,18 @@
  */
 
 import type { AgentMessage } from '../../core/index.js';
-import type { ChatMessage } from '../../scoops/chat-types.js';
+import type { ChatMessage, CompactionMarkerState } from '../../scoops/chat-types.js';
 import type { ConversationEntry, ConversationMarker, WorkUnitConversationRecord } from './types.js';
 import { isReadableRecord } from './types.js';
+
+/**
+ * Marker states a reload may put back on the transcript: the two that mean the
+ * round finished and kept something. See {@link interleaveMarkers}.
+ */
+const RESTORABLE_STATES: ReadonlySet<CompactionMarkerState> = new Set<CompactionMarkerState>([
+  'summarized',
+  'fallback',
+]);
 
 /**
  * Pi history. Lossless for an `agent-history` record: the verbatim messages
@@ -76,9 +85,13 @@ export async function toChatMessages(
  *
  * A marker goes BEFORE the first message stamped later than it, and at the
  * end when there is none — the position a compaction seam belongs in, since
- * the round is recorded after the summary message it produced. `discarded`
- * markers are dropped: a retracted round must not be announced by a reload
- * even if a crash left its marker behind.
+ * the round is recorded after the summary message it produced.
+ *
+ * Only a SETTLED seam is restored ({@link RESTORABLE_STATES}). A `discarded`
+ * round must not be announced by a reload, and neither must an in-flight one:
+ * the phase stream does not replay, so a `summarizing` marker left behind by a
+ * tab that reloaded mid-round has nothing left to settle it and would breathe
+ * "compacting history…" forever.
  *
  * Pure and total: no markers returns the input array itself.
  */
@@ -86,7 +99,7 @@ export function interleaveMarkers(
   messages: ChatMessage[],
   markers: readonly ConversationMarker[] | undefined
 ): ChatMessage[] {
-  const live = (markers ?? []).filter((m) => m.compaction.state !== 'discarded');
+  const live = (markers ?? []).filter((m) => RESTORABLE_STATES.has(m.compaction.state));
   if (live.length === 0) return messages;
   const sorted = [...live].sort((a, b) => a.timestamp - b.timestamp);
   const out: ChatMessage[] = [];

--- a/packages/webapp/src/work-unit/conversation/store.ts
+++ b/packages/webapp/src/work-unit/conversation/store.ts
@@ -35,6 +35,12 @@
  * annotate the conversation rather than belonging to it, so an entry replace
  * leaves them standing — which is the only way a compaction marker can
  * survive the compaction that produced it.
+ *
+ * Every read-modify-write path here is SERIALIZED per key ({@link serialize}).
+ * A compaction settles its marker at the same moment the round's caller
+ * persists the freshly compacted history, and both paths read the record and
+ * then save a whole copy; overlapping reads would let the later save drop the
+ * marker or reinstate the pre-compaction entries.
  */
 
 import type { AgentMessage } from '../../core/index.js';
@@ -108,6 +114,12 @@ export interface ConversationIdentity {
 export class WorkUnitConversationStore {
   private dbPromise: Promise<IDBDatabase> | null = null;
   private readonly dbName: string;
+  /**
+   * Tail of the in-flight write chain per canonical key — see
+   * {@link serialize}. Empty in the common case: an entry is dropped as soon
+   * as its chain drains.
+   */
+  private readonly writeChains = new Map<string, Promise<unknown>>();
 
   /** `dbName` is injectable so tests get one database per suite. */
   constructor(options: { dbName?: string } = {}) {
@@ -251,6 +263,15 @@ export class WorkUnitConversationStore {
   ): Promise<WorkUnitConversationRecord | null> {
     const now = options.now ?? Date.now();
     const next = entriesFromAgentMessages(messages);
+    return this.serialize(identity.key, () => this.ingestEntries(identity, next, options, now));
+  }
+
+  private async ingestEntries(
+    identity: ConversationIdentity,
+    next: ConversationEntry[],
+    options: { createdAt?: number },
+    now: number
+  ): Promise<WorkUnitConversationRecord | null> {
     try {
       const current = await this.read(identity.key);
       if (current.status === 'incompatible' || current.status === 'error') {
@@ -284,7 +305,10 @@ export class WorkUnitConversationStore {
    * not to, and none of them is an error worth surfacing: the same
    * never-overwrite guards {@link syncAgentMessages} applies, plus an ABSENT
    * record — a marker annotates a conversation, and there is nothing to
-   * annotate before the conversation itself is stored.
+   * annotate before the conversation itself is stored. `false` is the caller's
+   * cue to hold the marker and retry once history has been written
+   * (`Bridge.flushPendingMarkers`), which is how a cone that compacts before
+   * its first checkpoint still keeps its seam.
    */
   async putMarker(key: string, marker: ConversationMarker): Promise<boolean> {
     return this.withRecord(key, (record) => {
@@ -311,7 +335,14 @@ export class WorkUnitConversationStore {
    * Read-modify-write one record under the write guards. `mutate` returning
    * `null` means "nothing to change", which writes nothing at all.
    */
-  private async withRecord(
+  private withRecord(
+    key: string,
+    mutate: (record: WorkUnitConversationRecord) => WorkUnitConversationRecord | null
+  ): Promise<boolean> {
+    return this.serialize(key, () => this.mutateRecord(key, mutate));
+  }
+
+  private async mutateRecord(
     key: string,
     mutate: (record: WorkUnitConversationRecord) => WorkUnitConversationRecord | null
   ): Promise<boolean> {
@@ -329,6 +360,33 @@ export class WorkUnitConversationStore {
       log.warn('Conversation marker write failed', { key, error: errorText(err) });
       return false;
     }
+  }
+
+  /**
+   * Run `op` after every write already queued for `key` has finished.
+   *
+   * IndexedDB gives each transaction its own consistency, not each
+   * read-modify-write: two callers that read the same record and then save a
+   * whole copy both succeed, and the second silently discards whatever the
+   * first added. That is exactly the shape of a compaction — its marker
+   * settles while the round's caller persists the compacted history — so
+   * every RMW path here queues per key instead.
+   *
+   * A rejected op does not break the chain (`then(op, op)`), and the entry is
+   * dropped once it is the tail, so the map cannot grow with idle keys.
+   */
+  private serialize<T>(key: string, op: () => Promise<T>): Promise<T> {
+    const prior = this.writeChains.get(key) ?? Promise.resolve();
+    const run = prior.then(op, op);
+    const settled = run.then(
+      () => undefined,
+      () => undefined
+    );
+    this.writeChains.set(key, settled);
+    void settled.then(() => {
+      if (this.writeChains.get(key) === settled) this.writeChains.delete(key);
+    });
+    return run;
   }
 
   /** Read the cursor of a versioned migration, or `null` if it never ran. */

--- a/packages/webapp/src/work-unit/conversation/store.ts
+++ b/packages/webapp/src/work-unit/conversation/store.ts
@@ -30,6 +30,11 @@
  * entries do not extend the stored prefix. That is detected, counted on
  * `rewrites`, and applied as a replace; silently interleaving the two would
  * splice a pre-compaction conversation into a post-compaction one.
+ *
+ * `markers` sit OUTSIDE that reconciliation ({@link putMarker}): they
+ * annotate the conversation rather than belonging to it, so an entry replace
+ * leaves them standing — which is the only way a compaction marker can
+ * survive the compaction that produced it.
  */
 
 import type { AgentMessage } from '../../core/index.js';
@@ -37,6 +42,7 @@ import { createLogger } from '../../core/index.js';
 import { entriesFromAgentMessages } from './entries.js';
 import type {
   ConversationEntry,
+  ConversationMarker,
   ConversationOrigin,
   LegacyConversationKeys,
   WorkUnitConversationRecord,
@@ -49,6 +55,14 @@ export const CONVERSATION_DB_NAME = 'slicc-work-units';
 const DB_VERSION = 1;
 const CONVERSATIONS_STORE = 'conversations';
 const MIGRATIONS_STORE = 'migrations';
+
+/**
+ * How many {@link ConversationMarker}s one record keeps. A marker is tiny and
+ * a session compacts a handful of times, so the cap exists only so a runaway
+ * compaction loop cannot grow the record without bound. Oldest go first — the
+ * seams a user can still scroll to are the recent ones.
+ */
+const MAX_MARKERS = 64;
 
 /** Resumable cursor of a versioned migration into the canonical store. */
 export interface ConversationMigrationState {
@@ -259,6 +273,61 @@ export class WorkUnitConversationStore {
         error: errorText(err),
       });
       return null;
+    }
+  }
+
+  /**
+   * Upsert one {@link ConversationMarker} on a unit's record, keyed by `id`
+   * so a round's terminal phase settles the row its opening phase created.
+   *
+   * Returns `true` when the record was written. `false` covers every reason
+   * not to, and none of them is an error worth surfacing: the same
+   * never-overwrite guards {@link syncAgentMessages} applies, plus an ABSENT
+   * record — a marker annotates a conversation, and there is nothing to
+   * annotate before the conversation itself is stored.
+   */
+  async putMarker(key: string, marker: ConversationMarker): Promise<boolean> {
+    return this.withRecord(key, (record) => {
+      const kept = (record.markers ?? []).filter((m) => m.id !== marker.id);
+      kept.push(marker);
+      kept.sort((a, b) => a.timestamp - b.timestamp);
+      return { ...record, markers: kept.slice(-MAX_MARKERS) };
+    });
+  }
+
+  /**
+   * Retract a marker — a compaction round that kept nothing must stop
+   * claiming it happened (#2843). A no-op when the marker is already gone.
+   */
+  async deleteMarker(key: string, markerId: string): Promise<boolean> {
+    return this.withRecord(key, (record) => {
+      const kept = (record.markers ?? []).filter((m) => m.id !== markerId);
+      if (kept.length === (record.markers?.length ?? 0)) return null;
+      return { ...record, markers: kept };
+    });
+  }
+
+  /**
+   * Read-modify-write one record under the write guards. `mutate` returning
+   * `null` means "nothing to change", which writes nothing at all.
+   */
+  private async withRecord(
+    key: string,
+    mutate: (record: WorkUnitConversationRecord) => WorkUnitConversationRecord | null
+  ): Promise<boolean> {
+    try {
+      const current = await this.read(key);
+      // `absent` joins `incompatible` / `error` here rather than creating a
+      // record: an annotation with no conversation under it would derive to a
+      // transcript that is nothing but seams.
+      if (current.status !== 'ok') return false;
+      const next = mutate(current.record);
+      if (!next) return false;
+      await this.save({ ...next, updatedAt: Date.now() });
+      return true;
+    } catch (err) {
+      log.warn('Conversation marker write failed', { key, error: errorText(err) });
+      return false;
     }
   }
 

--- a/packages/webapp/src/work-unit/conversation/types.ts
+++ b/packages/webapp/src/work-unit/conversation/types.ts
@@ -28,7 +28,7 @@
 
 import type { LickChannel } from '../../base/lick-channels.js';
 import type { AgentMessage } from '../../core/index.js';
-import type { ChatMessage } from '../../scoops/chat-types.js';
+import type { ChatCompactionMarker, ChatMessage } from '../../scoops/chat-types.js';
 
 /**
  * Schema version of a persisted record. Bumping it makes every older record
@@ -117,6 +117,29 @@ export interface ToolResultConversationEntry extends MessageEntryBase {
   isError?: boolean;
 }
 
+/**
+ * A transcript row that records something that happened TO the conversation
+ * rather than in it — today, one context-compaction round (#2843).
+ *
+ * Markers are NOT entries, and that is the whole point. `syncAgentMessages`
+ * re-ingests Pi's message list and replaces `entries` wholesale on a
+ * compaction, so a marker living in that list would be erased by the very
+ * event it announces. It also has no place in Pi's history: the model must
+ * never be shown a row saying its own context was summarized.
+ *
+ * Anchored by `timestamp` alone, because no entry survives a rewrite to
+ * anchor to. Recorded when the round SETTLES, so the marker sorts after the
+ * summary message compaction just wrote and lands exactly on the seam.
+ */
+export interface ConversationMarker {
+  /** Stable across the round's phases: the opening phase mints it. */
+  id: string;
+  kind: 'compaction';
+  /** Epoch ms — the only anchor; see the interface doc. */
+  timestamp: number;
+  compaction: ChatCompactionMarker;
+}
+
 export type ConversationEntry =
   | UserConversationEntry
   | ExternalEventConversationEntry
@@ -160,6 +183,13 @@ export interface WorkUnitConversationRecord {
   folder: string;
   origin: ConversationOrigin;
   entries: ConversationEntry[];
+  /**
+   * Transcript rows that annotate the conversation instead of belonging to
+   * it ({@link ConversationMarker}). Absent on every record written before
+   * markers existed, which reads as "no annotations" — the UI derivation is
+   * then exactly what it was.
+   */
+  markers?: ConversationMarker[];
   createdAt: number;
   updatedAt: number;
   /** Which legacy store the record was first built from, if migrated. */

--- a/packages/webapp/tests/e2e/compaction-robustness.test.ts
+++ b/packages/webapp/tests/e2e/compaction-robustness.test.ts
@@ -99,6 +99,24 @@ test.describe('compaction robustness', () => {
     await expect(
       page.locator('slicc-agent-message', { hasText: 'compacting history' })
     ).toHaveCount(0);
+
+    // …and the seam SURVIVES a reload. The row lives in no message list — Pi's
+    // history cannot hold bookkeeping about itself — so a reload used to
+    // rebuild the transcript minus its seams and persist that over the UI
+    // store. The canonical record's `markers` are what carry it back.
+    // Twice, because the two boots fail differently. The first reload replays
+    // the row the kernel buffered before the tab went away; the second sees a
+    // kernel whose boot seed has already REBUILT the UI store from Pi's
+    // history, which is where an unrecorded seam is lost for good.
+    for (const pass of [1, 2]) {
+      await gotoLeader(page);
+      await waitForSW(page);
+      await page.waitForSelector('slicc-input-card');
+      const replayed = page.locator('slicc-chat-thread slicc-compaction-marker');
+      await expect(replayed, `seam survived reload ${pass}`).toHaveCount(1, { timeout: 30_000 });
+      await expect(replayed).toHaveAttribute('state', 'summarized');
+      await expect(replayed).toHaveAttribute('trigger', 'threshold');
+    }
   });
 
   test('summary-call failure degrades to naive drop; the turn still completes (#1985)', async ({

--- a/packages/webapp/tests/kernel/compaction-row-persistence.test.ts
+++ b/packages/webapp/tests/kernel/compaction-row-persistence.test.ts
@@ -6,6 +6,10 @@
  * tests pin the three writes that make a seam survive a reload: the message
  * buffer, the `browser-coding-agent` store, and the canonical record's
  * `markers`, plus the rebuild that folds a stored marker back in.
+ *
+ * They also pin WHEN: only a round that settled is written down, under an id
+ * the wire carries, and a marker the record could not take yet is retried at
+ * the end of the turn.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -121,40 +125,61 @@ describe('kernel compaction-row persistence', () => {
     callbacks = Bridge.createCallbacks(bridge);
   });
 
-  it('records an opening round as a marker and a row', async () => {
+  // An in-flight round is not a fact about the conversation yet. Writing it
+  // down is what left a reloaded tab breathing "compacting history…" forever:
+  // the phase stream does not replay, so nothing alive could ever settle it.
+  it('writes nothing durable for a round that has only started', async () => {
     phase('summarizing', { transcriptPath: '/sessions/cone/before.md' });
-    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalled());
+    await vi.waitFor(() => expect(sentMessages.length).toBeGreaterThan(0));
+
+    expect(conversationStore.putMarker).not.toHaveBeenCalled();
+    expect(persisted().filter((m) => m.compaction)).toEqual([]);
+  });
+
+  it('records the round once it settles, as a marker and a row', async () => {
+    phase('summarizing', { transcriptPath: '/sessions/cone/before.md' });
+    phase('idle', { transcriptPath: '/sessions/cone/before.md' });
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
 
     expect(conversationStore.markers).toEqual([
       expect.objectContaining({
         kind: 'compaction',
         compaction: {
           trigger: 'idle',
-          state: 'summarizing',
+          state: 'summarized',
           transcriptPath: '/sessions/cone/before.md',
         },
       }),
     ]);
     // The same row is in the buffer the panel replays from, and in the UI
     // store a reload reads.
-    expect(persisted().at(-1)).toMatchObject({
-      role: 'assistant',
-      content: '',
-      compaction: { state: 'summarizing' },
-    });
-  });
-
-  it('settles the round in place rather than stacking a second seam', async () => {
-    phase('summarizing');
-    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
-    phase('idle');
-    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(2));
-
-    expect(conversationStore.markers).toHaveLength(1);
-    expect(conversationStore.markers[0].compaction.state).toBe('summarized');
     const rows = persisted().filter((m) => m.compaction);
     expect(rows).toHaveLength(1);
-    expect(rows[0].compaction?.state).toBe('summarized');
+    expect(rows[0]).toMatchObject({
+      role: 'assistant',
+      content: '',
+      compaction: { state: 'summarized' },
+    });
+    // One row, under the id the panel was told to render — see the wire test
+    // below.
+    expect(rows[0].id).toBe(conversationStore.markers[0].id);
+  });
+
+  // The row id is minted ONCE, by the kernel, and rides the wire so the panel
+  // renders the row this kernel persists. Two id spaces for one round meant a
+  // terminal phase targeting a row no replay contained (#2843).
+  it('emits the row id it will persist under', async () => {
+    phase('summarizing');
+    phase('idle');
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
+
+    const emitted = sentMessages
+      .map((m) => (m as { payload: { type: string; rowId?: string } }).payload)
+      .filter((p) => p.type === 'compaction-state');
+    expect(emitted.map((p) => p.rowId)).toEqual([
+      conversationStore.markers[0].id,
+      conversationStore.markers[0].id,
+    ]);
   });
 
   it('retracts a round that kept nothing, from the record AND the buffer', async () => {
@@ -163,9 +188,8 @@ describe('kernel compaction-row persistence', () => {
     // but the retracted row could not show the write either way.
     callbacks.onResponse?.('cone_1', 'shipped', false);
     phase('summarizing', { roundId: 'idle-1' });
-    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
     phase('idle', { roundId: 'idle-1' });
-    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
     phase('cancelled', { roundId: 'idle-1' });
     await vi.waitFor(() => expect(conversationStore.deleteMarker).toHaveBeenCalled());
 
@@ -180,6 +204,44 @@ describe('kernel compaction-row persistence', () => {
 
     expect(conversationStore.putMarker).not.toHaveBeenCalled();
     expect(conversationStore.deleteMarker).not.toHaveBeenCalled();
+  });
+
+  // A cone can compact before its conversation is ever checkpointed — one
+  // oversized opening prompt does it — and a marker has nothing to annotate
+  // until the record exists. Losing it there meant the next boot rebuilt the
+  // transcript without its seam, which is the bug this whole change is about.
+  it('holds a marker the record cannot take yet and writes it at the end of the turn', async () => {
+    conversationStore.putMarker.mockResolvedValueOnce(false);
+
+    phase('summarizing');
+    phase('idle');
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
+    expect(conversationStore.markers).toEqual([]);
+
+    callbacks.onResponseDone?.('cone_1');
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(2));
+
+    expect(conversationStore.markers).toEqual([
+      expect.objectContaining({ compaction: expect.objectContaining({ state: 'summarized' }) }),
+    ]);
+  });
+
+  it('stops holding a marker whose round is taken back', async () => {
+    conversationStore.putMarker.mockResolvedValueOnce(false);
+
+    phase('summarizing', { roundId: 'idle-1' });
+    phase('idle', { roundId: 'idle-1' });
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
+    phase('cancelled', { roundId: 'idle-1' });
+    await vi.waitFor(() => expect(conversationStore.deleteMarker).toHaveBeenCalled());
+
+    callbacks.onResponseDone?.('cone_1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The retraction settled it: nothing is retried, so a discarded round
+    // cannot reappear one turn later.
+    expect(conversationStore.putMarker).toHaveBeenCalledTimes(1);
+    expect(conversationStore.markers).toEqual([]);
   });
 
   it('folds a stored marker back into a rebuild from live agent state', async () => {
@@ -217,10 +279,11 @@ describe('kernel compaction-row persistence', () => {
     const plainCallbacks = Bridge.createCallbacks(plain);
 
     plainCallbacks.onCompactionStateChange?.('cone_1', 'summarizing', { trigger: 'threshold' });
+    plainCallbacks.onCompactionStateChange?.('cone_1', 'idle', { trigger: 'threshold' });
     await vi.waitFor(() => expect(saved.length).toBeGreaterThan(0));
 
     // The row still reaches the UI store — only the canonical annotation is
     // skipped, and nothing throws.
-    expect(persisted().at(-1)?.compaction).toMatchObject({ state: 'summarizing' });
+    expect(persisted().at(-1)?.compaction).toMatchObject({ state: 'summarized' });
   });
 });

--- a/packages/webapp/tests/kernel/compaction-row-persistence.test.ts
+++ b/packages/webapp/tests/kernel/compaction-row-persistence.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Durable compaction rows (#2843 follow-up).
+ *
+ * A compaction marker exists nowhere in Pi's history — it is bookkeeping
+ * ABOUT that history — so the kernel is what has to write it down. These
+ * tests pin the three writes that make a seam survive a reload: the message
+ * buffer, the `browser-coding-agent` store, and the canonical record's
+ * `markers`, plus the rebuild that folds a stored marker back in.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CompactionStateDetail } from '../../src/core/context-compaction.js';
+import type { ChatMessage } from '../../src/scoops/chat-types.js';
+import type { ConversationMarker } from '../../src/work-unit/conversation/types.js';
+
+const messageListeners: Array<(message: unknown) => void> = [];
+const sentMessages: unknown[] = [];
+
+(globalThis as unknown as { chrome: unknown }).chrome = {
+  runtime: {
+    id: 'test-extension-id',
+    lastError: undefined,
+    sendMessage: vi.fn(async (msg: unknown) => {
+      sentMessages.push(msg);
+    }),
+    onMessage: {
+      addListener: vi.fn((cb: (message: unknown) => void) => void messageListeners.push(cb)),
+      removeListener: vi.fn(),
+    },
+  },
+};
+
+const { mockSessionStore, saved } = vi.hoisted(() => {
+  const saved: Array<{ sessionId: string; messages: ChatMessage[] }> = [];
+  return {
+    saved,
+    mockSessionStore: vi.fn(function (this: Record<string, unknown>) {
+      this.init = vi.fn().mockResolvedValue(undefined);
+      this.saveMessages = vi.fn(async (sessionId: string, messages: ChatMessage[]) => {
+        saved.push({ sessionId, messages: structuredClone(messages) });
+      });
+      this.delete = vi.fn().mockResolvedValue(undefined);
+    }),
+  };
+});
+
+vi.mock('../../src/scoops/chat-session-store.js', () => ({ SessionStore: mockSessionStore }));
+
+const { Bridge } = await import('../../src/kernel/facade.js');
+
+const CONE = {
+  jid: 'cone_1',
+  name: 'Cone',
+  folder: 'cone',
+  parentJid: null,
+  requiresTrigger: false,
+  assistantLabel: 'sliccy',
+  addedAt: '2026-01-04T10:00:00.000Z',
+};
+
+/** In-memory stand-in for the canonical store's marker surface. */
+function makeConversationStore(markers: ConversationMarker[] = []) {
+  return {
+    markers,
+    load: vi.fn(async () => ({ markers })),
+    putMarker: vi.fn(async (_key: string, marker: ConversationMarker) => {
+      const at = markers.findIndex((m) => m.id === marker.id);
+      if (at >= 0) markers[at] = marker;
+      else markers.push(marker);
+      return true;
+    }),
+    deleteMarker: vi.fn(async (_key: string, id: string) => {
+      const at = markers.findIndex((m) => m.id === id);
+      if (at >= 0) markers.splice(at, 1);
+      return at >= 0;
+    }),
+  };
+}
+
+describe('kernel compaction-row persistence', () => {
+  let bridge: InstanceType<typeof Bridge>;
+  let callbacks: ReturnType<typeof Bridge.createCallbacks>;
+  let conversationStore: ReturnType<typeof makeConversationStore>;
+  let agentMessages: unknown[];
+
+  const phase = (state: string, detail: Partial<CompactionStateDetail> = {}) =>
+    callbacks.onCompactionStateChange?.(
+      'cone_1',
+      state as never,
+      {
+        trigger: 'idle',
+        ...detail,
+      } as CompactionStateDetail
+    );
+
+  /** The rows the UI store was last written with. */
+  const persisted = () => saved[saved.length - 1]?.messages ?? [];
+
+  beforeEach(async () => {
+    sentMessages.length = 0;
+    saved.length = 0;
+    vi.clearAllMocks();
+    agentMessages = [
+      { role: 'user', content: [{ type: 'text', text: 'ship it' }], timestamp: 1000 },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'shipped' }],
+        timestamp: 2000,
+        model: 'claude-opus-4-6',
+      },
+    ];
+    conversationStore = makeConversationStore();
+
+    bridge = new Bridge();
+    await bridge.bind({
+      getScoops: () => [CONE],
+      getScoopContext: () => ({ getAgentMessages: () => agentMessages }),
+      getConversationStore: () => conversationStore,
+      getQueuedMessageIds: () => [],
+    } as never);
+    callbacks = Bridge.createCallbacks(bridge);
+  });
+
+  it('records an opening round as a marker and a row', async () => {
+    phase('summarizing', { transcriptPath: '/sessions/cone/before.md' });
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalled());
+
+    expect(conversationStore.markers).toEqual([
+      expect.objectContaining({
+        kind: 'compaction',
+        compaction: {
+          trigger: 'idle',
+          state: 'summarizing',
+          transcriptPath: '/sessions/cone/before.md',
+        },
+      }),
+    ]);
+    // The same row is in the buffer the panel replays from, and in the UI
+    // store a reload reads.
+    expect(persisted().at(-1)).toMatchObject({
+      role: 'assistant',
+      content: '',
+      compaction: { state: 'summarizing' },
+    });
+  });
+
+  it('settles the round in place rather than stacking a second seam', async () => {
+    phase('summarizing');
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
+    phase('idle');
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(2));
+
+    expect(conversationStore.markers).toHaveLength(1);
+    expect(conversationStore.markers[0].compaction.state).toBe('summarized');
+    const rows = persisted().filter((m) => m.compaction);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].compaction?.state).toBe('summarized');
+  });
+
+  it('retracts a round that kept nothing, from the record AND the buffer', async () => {
+    // A real conversation under the seam: `persistScoop` refuses to write an
+    // EMPTY buffer (its truncation guard), so a transcript that is nothing
+    // but the retracted row could not show the write either way.
+    callbacks.onResponse?.('cone_1', 'shipped', false);
+    phase('summarizing', { roundId: 'idle-1' });
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(1));
+    phase('idle', { roundId: 'idle-1' });
+    await vi.waitFor(() => expect(conversationStore.putMarker).toHaveBeenCalledTimes(2));
+    phase('cancelled', { roundId: 'idle-1' });
+    await vi.waitFor(() => expect(conversationStore.deleteMarker).toHaveBeenCalled());
+
+    expect(conversationStore.markers).toEqual([]);
+    expect(persisted().filter((m) => m.compaction)).toEqual([]);
+  });
+
+  it('writes nothing for a phase that is not a row', async () => {
+    phase('extracting-memory');
+    phase('idle');
+    await vi.waitFor(() => expect(sentMessages.length).toBeGreaterThan(0));
+
+    expect(conversationStore.putMarker).not.toHaveBeenCalled();
+    expect(conversationStore.deleteMarker).not.toHaveBeenCalled();
+  });
+
+  it('folds a stored marker back into a rebuild from live agent state', async () => {
+    conversationStore.markers.push({
+      id: 'compaction-cone_1-stored',
+      kind: 'compaction',
+      timestamp: 1500,
+      compaction: { trigger: 'threshold', state: 'summarized' },
+    });
+
+    const rebuilt = (await (
+      bridge as unknown as {
+        buildBufferFromAgentMessages: (scoop: unknown) => Promise<ChatMessage[] | null>;
+      }
+    ).buildBufferFromAgentMessages(CONE)) as ChatMessage[];
+
+    // On the seam: after the message that preceded the round, before the one
+    // that followed it. Without this, every boot re-seeds the buffer from Pi's
+    // history — which never held the row — and persists the transcript minus
+    // its seams over the UI store.
+    expect(rebuilt.map((m) => (m.compaction ? 'seam' : m.role))).toEqual([
+      'user',
+      'seam',
+      'assistant',
+    ]);
+  });
+
+  it('survives a float with no canonical store at all', async () => {
+    const plain = new Bridge();
+    await plain.bind({
+      getScoops: () => [CONE],
+      getScoopContext: () => ({ getAgentMessages: () => agentMessages }),
+      getQueuedMessageIds: () => [],
+    } as never);
+    const plainCallbacks = Bridge.createCallbacks(plain);
+
+    plainCallbacks.onCompactionStateChange?.('cone_1', 'summarizing', { trigger: 'threshold' });
+    await vi.waitFor(() => expect(saved.length).toBeGreaterThan(0));
+
+    // The row still reaches the UI store — only the canonical annotation is
+    // skipped, and nothing throws.
+    expect(persisted().at(-1)?.compaction).toMatchObject({ state: 'summarizing' });
+  });
+});

--- a/packages/webapp/tests/scoops/compaction-rows.test.ts
+++ b/packages/webapp/tests/scoops/compaction-rows.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `CompactionRowTracker` — the phase→row reducer both the panel and the
+ * kernel drive (#2843).
+ *
+ * The round lifecycles (settle, retract, late retraction, round-id scoping)
+ * are pinned end-to-end through the panel in
+ * `tests/ui/offscreen-client.test.ts`; this file covers what only the shared
+ * reducer can answer: that two units keep their own rows, and that a unit can
+ * be forgotten.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CompactionRowTracker } from '../../src/scoops/compaction-rows.js';
+
+const IDLE = { trigger: 'idle' } as const;
+
+function tracker(): CompactionRowTracker {
+  let n = 0;
+  return new CompactionRowTracker((unitId) => `${unitId}-row-${++n}`);
+}
+
+describe('CompactionRowTracker', () => {
+  it('gives each unit its own round', () => {
+    const rows = tracker();
+    const cone = rows.apply('cone_1', 'summarizing', IDLE);
+    const scoop = rows.apply('scoop_1', 'summarizing', IDLE);
+    expect(cone?.messageId).not.toBe(scoop?.messageId);
+
+    // Settling one leaves the other's round open.
+    expect(rows.apply('cone_1', 'idle', IDLE)).toMatchObject({
+      kind: 'settle',
+      messageId: cone?.messageId,
+    });
+    expect(rows.apply('scoop_1', 'idle', IDLE)).toMatchObject({
+      kind: 'settle',
+      messageId: scoop?.messageId,
+    });
+  });
+
+  it('forgets a unit, so its open round can no longer be settled', () => {
+    const rows = tracker();
+    rows.apply('cone_1', 'summarizing', IDLE);
+    rows.forget('cone_1');
+    // No open row: a terminal phase for a round this tracker no longer knows
+    // must not conjure one.
+    expect(rows.apply('cone_1', 'idle', IDLE)).toBeNull();
+  });
+
+  it('carries the transcript path onto the row when the snapshot landed', () => {
+    const rows = tracker();
+    const action = rows.apply('cone_1', 'summarizing', {
+      trigger: 'threshold',
+      transcriptPath: '/sessions/cone/before.md',
+    });
+    expect(action).toMatchObject({
+      kind: 'open',
+      marker: {
+        trigger: 'threshold',
+        state: 'summarizing',
+        transcriptPath: '/sessions/cone/before.md',
+      },
+    });
+  });
+});

--- a/packages/webapp/tests/scoops/compaction-rows.test.ts
+++ b/packages/webapp/tests/scoops/compaction-rows.test.ts
@@ -5,8 +5,9 @@
  * The round lifecycles (settle, retract, late retraction, round-id scoping)
  * are pinned end-to-end through the panel in
  * `tests/ui/offscreen-client.test.ts`; this file covers what only the shared
- * reducer can answer: that two units keep their own rows, and that a unit can
- * be forgotten.
+ * reducer can answer: that two units keep their own rows, that a unit can be
+ * forgotten, and how a row id handed in from outside (the kernel's, off the
+ * wire) beats minting a second one for the same round.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -44,6 +45,40 @@ describe('CompactionRowTracker', () => {
     // No open row: a terminal phase for a round this tracker no longer knows
     // must not conjure one.
     expect(rows.apply('cone_1', 'idle', IDLE)).toBeNull();
+  });
+
+  describe('an id supplied from elsewhere', () => {
+    it('opens the round under it instead of minting a second id', () => {
+      const rows = tracker();
+      const action = rows.apply('cone_1', 'summarizing', IDLE, 'kernel-row-7');
+      expect(action).toMatchObject({ kind: 'open', messageId: 'kernel-row-7' });
+      // And the round it settles is that same row.
+      expect(rows.apply('cone_1', 'idle', IDLE, 'kernel-row-7')).toMatchObject({
+        kind: 'settle',
+        messageId: 'kernel-row-7',
+      });
+    });
+
+    // The panel mounted mid-round: it never saw the opening phase, so without
+    // an id from the kernel it would ignore the terminal one and never show
+    // the seam until the next replay.
+    it('settles a round it never saw open', () => {
+      const rows = tracker();
+      expect(rows.apply('cone_1', 'idle', IDLE, 'kernel-row-7')).toMatchObject({
+        kind: 'settle',
+        messageId: 'kernel-row-7',
+      });
+    });
+
+    it('keeps the row it is already tracking when the two disagree', () => {
+      const rows = tracker();
+      const opened = rows.apply('cone_1', 'summarizing', IDLE);
+      // Its own row is the one on screen; a late-arriving other id must not
+      // strand it half-rendered.
+      expect(rows.apply('cone_1', 'idle', IDLE, 'kernel-row-9')).toMatchObject({
+        messageId: opened?.messageId,
+      });
+    });
   });
 
   it('carries the transcript path onto the row when the snapshot landed', () => {

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -1466,6 +1466,38 @@ describe('OffscreenClient compaction notices (#1985)', () => {
     expect(ids[0]).not.toBe(ids[2]);
   });
 
+  // The kernel mints the row id, persists the marker under it and replays it
+  // in the buffer. The panel renders THAT row, so a settle after a replay
+  // updates the seam instead of appending a second one (#2843).
+  it('renders the row under the id the kernel sent', () => {
+    client.setSelectedScoopJid('cone_123');
+    const events = collect();
+
+    phase('summarizing', { rowId: 'compaction-cone_123-kernel' });
+    phase('idle', { rowId: 'compaction-cone_123-kernel' });
+
+    expect(events.map((e) => e.messageId)).toEqual([
+      'compaction-cone_123-kernel',
+      'compaction-cone_123-kernel',
+    ]);
+  });
+
+  // This panel mounted mid-round, so it never saw the opening phase. The
+  // kernel did, and names the row: the seam appears now rather than waiting
+  // for the next replay.
+  it('settles a named row for a round whose opening phase it missed', () => {
+    client.setSelectedScoopJid('cone_123');
+    const events = collect();
+
+    phase('idle', { rowId: 'compaction-cone_123-kernel' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      messageId: 'compaction-cone_123-kernel',
+      marker: { state: 'summarized' },
+    });
+  });
+
   it('does not disturb an in-flight assistant stream', () => {
     client.setSelectedScoopJid('cone_123');
     const events = collect();

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -717,6 +717,15 @@ describe('budget-mode cost surfaces', () => {
   });
 
   describe('cost group', () => {
+    /**
+     * `buildSections` stamps itself from `Date.now()` — it has no clock seam
+     * the way `buildVitals` / `buildAlerts` do — so a window under it has to
+     * reset relative to the REAL clock. Pinned to `NOW`, the badge turned into
+     * "resetting now" the day after this suite was written.
+     */
+    const liveWindow = (over: Partial<SessionBudgetWindow> = {}) =>
+      budget({ resetsAt: new Date(Date.now() + 18 * 60 * 60 * 1000).toISOString(), ...over });
+
     const costSection = async (b?: SessionBudgetWindow) => {
       const sections = await fetchSections(
         makeDeps({ getSessionStats: async () => stats(b ? { budget: b } : {}) })
@@ -727,7 +736,7 @@ describe('budget-mode cost surfaces', () => {
     };
 
     it('is named by the window, with the dollars behind it', async () => {
-      const cost = await costSection(budget());
+      const cost = await costSection(liveWindow());
       expect(cost.meta).toBe('9.5% of weekly budget · $29.06 across 1 models');
       expect(cost.status).toBe('active');
       expect(cost.rows[0]).toMatchObject({ name: 'Weekly budget', meta: '9.5% used' });
@@ -737,14 +746,14 @@ describe('budget-mode cost surfaces', () => {
     });
 
     it('turns the group red when the provider is refusing calls', async () => {
-      const cost = await costSection(budget({ percent: 96, status: 'rate-limited' }));
+      const cost = await costSection(liveWindow({ percent: 96, status: 'rate-limited' }));
       expect(cost.status).toBe('error');
       expect(cost.meta).toContain('rate-limited');
       expect(cost.rows[0].meta).toBe('rate-limited · 96% used');
     });
 
     it('warns from the warn threshold', async () => {
-      const cost = await costSection(budget({ percent: 92 }));
+      const cost = await costSection(liveWindow({ percent: 92 }));
       expect(cost.status).toBe('warn');
     });
 

--- a/packages/webapp/tests/work-unit/conversation/derive.test.ts
+++ b/packages/webapp/tests/work-unit/conversation/derive.test.ts
@@ -158,6 +158,25 @@ describe('interleaveMarkers', () => {
     expect(out.map((m) => m.id)).toEqual(['m10']);
   });
 
+  // A tab that reloaded mid-round would otherwise restore a seam that nothing
+  // alive can settle: the compaction phase stream does not replay, so the row
+  // would breathe "compacting history…" for the rest of the conversation.
+  it('drops an in-flight marker — a reload has nothing left to settle it', () => {
+    const out = interleaveMarkers(
+      [chat(10)],
+      [marker({ timestamp: 5, compaction: { trigger: 'idle', state: 'summarizing' } })]
+    );
+    expect(out.map((m) => m.id)).toEqual(['m10']);
+  });
+
+  it('restores a degraded round: fallback is a finished round too', () => {
+    const out = interleaveMarkers(
+      [chat(10)],
+      [marker({ timestamp: 5, compaction: { trigger: 'overflow', state: 'fallback' } })]
+    );
+    expect(out.map((m) => m.id)).toEqual(['compaction-1', 'm10']);
+  });
+
   it('places a marker against an ISO-string timestamp from an old profile', () => {
     const iso = {
       id: 'old',

--- a/packages/webapp/tests/work-unit/conversation/derive.test.ts
+++ b/packages/webapp/tests/work-unit/conversation/derive.test.ts
@@ -10,8 +10,10 @@
 
 import { describe, expect, it } from 'vitest';
 import { agentMessagesToChatMessages } from '../../../src/scoops/agent-message-to-chat.js';
+import type { ChatMessage } from '../../../src/scoops/chat-types.js';
 import {
   conversationLength,
+  interleaveMarkers,
   toAgentMessages,
   toChatMessages,
   toChildResultSummary,
@@ -22,6 +24,7 @@ import {
   entriesFromChatMessages,
 } from '../../../src/work-unit/conversation/entries.js';
 import type {
+  ConversationMarker,
   ConversationOrigin,
   WorkUnitConversationRecord,
 } from '../../../src/work-unit/conversation/types.js';
@@ -43,6 +46,16 @@ function record(
     createdAt: 1,
     updatedAt: 2,
     legacyKeys: { agentSessionId: 'cone_1', chatSessionId: 'session-cone' },
+  };
+}
+
+function marker(over: Partial<ConversationMarker> = {}): ConversationMarker {
+  return {
+    id: 'compaction-1',
+    kind: 'compaction',
+    timestamp: 1,
+    compaction: { trigger: 'idle', state: 'summarized' },
+    ...over,
   };
 }
 
@@ -96,6 +109,86 @@ describe('toChatMessages', () => {
 
   it('returns nothing for an empty record', async () => {
     expect(await toChatMessages(record([]))).toEqual([]);
+  });
+
+  it('folds a compaction marker back into the projection', async () => {
+    const messages = legacyAgentMessages();
+    const stored = record(entriesFromAgentMessages(messages));
+    const derived = await toChatMessages(
+      { ...stored, markers: [marker({ timestamp: 1 })] },
+      { idSeed: seededIds() }
+    );
+    const plain = await toChatMessages(stored, { idSeed: seededIds() });
+    expect(derived).toHaveLength(plain.length + 1);
+    expect(derived[0].compaction).toEqual({ trigger: 'idle', state: 'summarized' });
+  });
+});
+
+describe('interleaveMarkers', () => {
+  const chat = (timestamp: number, id = `m${timestamp}`): ChatMessage => ({
+    id,
+    role: 'assistant',
+    content: 'hi',
+    timestamp,
+  });
+
+  it('places a marker on the seam: after what preceded it, before what followed', () => {
+    const out = interleaveMarkers([chat(10), chat(30)], [marker({ timestamp: 20 })]);
+    expect(out.map((m) => m.id)).toEqual(['m10', 'compaction-1', 'm30']);
+  });
+
+  it('appends a marker later than every message', () => {
+    const out = interleaveMarkers([chat(10)], [marker({ timestamp: 99 })]);
+    expect(out.map((m) => m.id)).toEqual(['m10', 'compaction-1']);
+  });
+
+  it('orders several rounds by timestamp regardless of stored order', () => {
+    const out = interleaveMarkers(
+      [chat(50)],
+      [marker({ id: 'late', timestamp: 40 }), marker({ id: 'early', timestamp: 20 })]
+    );
+    expect(out.map((m) => m.id)).toEqual(['early', 'late', 'm50']);
+  });
+
+  it('drops a discarded marker — a retracted round is not announced', () => {
+    const out = interleaveMarkers(
+      [chat(10)],
+      [marker({ timestamp: 5, compaction: { trigger: 'idle', state: 'discarded' } })]
+    );
+    expect(out.map((m) => m.id)).toEqual(['m10']);
+  });
+
+  it('places a marker against an ISO-string timestamp from an old profile', () => {
+    const iso = {
+      id: 'old',
+      role: 'assistant',
+      content: 'hi',
+      timestamp: '2026-01-04T10:00:01.000Z',
+    } as unknown as ChatMessage;
+    const before = Date.parse('2026-01-04T09:00:00.000Z');
+    const after = Date.parse('2026-01-04T11:00:00.000Z');
+    expect(interleaveMarkers([iso], [marker({ timestamp: before })]).map((m) => m.id)).toEqual([
+      'compaction-1',
+      'old',
+    ]);
+    expect(interleaveMarkers([iso], [marker({ timestamp: after })]).map((m) => m.id)).toEqual([
+      'old',
+      'compaction-1',
+    ]);
+  });
+
+  it('puts the seam last when a message carries no usable stamp', () => {
+    const unstamped = { id: 'x', role: 'assistant', content: 'hi' } as unknown as ChatMessage;
+    expect(interleaveMarkers([unstamped], [marker({ timestamp: 5 })]).map((m) => m.id)).toEqual([
+      'x',
+      'compaction-1',
+    ]);
+  });
+
+  it('returns the input untouched when there is nothing to fold in', () => {
+    const messages = [chat(10)];
+    expect(interleaveMarkers(messages, undefined)).toBe(messages);
+    expect(interleaveMarkers(messages, [])).toBe(messages);
   });
 });
 

--- a/packages/webapp/tests/work-unit/conversation/store.test.ts
+++ b/packages/webapp/tests/work-unit/conversation/store.test.ts
@@ -291,6 +291,48 @@ describe('WorkUnitConversationStore', () => {
       readSpy.mockRestore();
       expect((await store.load(identity.key))?.markers).toBeUndefined();
     });
+
+    // The real sequence of an adopted idle compaction: the round settles its
+    // marker while its caller persists the freshly compacted history. Both
+    // read the record and then save a whole copy, so without a per-key queue
+    // the later save wins outright — dropping the marker, or reinstating the
+    // pre-compaction entries it just replaced.
+    it('does not lose either write when a marker and a history sync overlap', async () => {
+      await store.syncAgentMessages(identity, legacyAgentMessages(), { now: 1000 });
+      const compacted = [
+        { role: 'user', content: [{ type: 'text', text: 'summary of earlier work' }] },
+      ] as unknown as AgentMessage[];
+
+      // Started in the same tick, deliberately un-awaited between.
+      const written = store.putMarker(
+        identity.key,
+        marker({ compaction: { trigger: 'idle', state: 'summarized' } })
+      );
+      const synced = store.syncAgentMessages(identity, compacted, { now: 2000 });
+      expect(await Promise.all([written, synced])).toEqual([true, expect.anything()]);
+
+      const record = await store.load(identity.key);
+      expect(record?.entries).toHaveLength(1);
+      expect(record?.markers).toHaveLength(1);
+    });
+
+    it('keeps every marker when a burst of rounds settles at once', async () => {
+      await store.syncAgentMessages(identity, legacyAgentMessages());
+
+      await Promise.all(
+        [1, 2, 3, 4, 5].map((i) =>
+          store.putMarker(identity.key, marker({ id: `m${i}`, timestamp: 1000 + i }))
+        )
+      );
+
+      expect((await store.load(identity.key))?.markers?.map((m) => m.id)).toEqual([
+        'm1',
+        'm2',
+        'm3',
+        'm4',
+        'm5',
+      ]);
+    });
   });
 
   it('rekey is a no-op when keys match or the source is absent', async () => {

--- a/packages/webapp/tests/work-unit/conversation/store.test.ts
+++ b/packages/webapp/tests/work-unit/conversation/store.test.ts
@@ -11,6 +11,7 @@ import 'fake-indexeddb/auto';
 import type { AgentMessage } from '../../../src/core/index.js';
 import type { ConversationIdentity } from '../../../src/work-unit/conversation/store.js';
 import { WorkUnitConversationStore } from '../../../src/work-unit/conversation/store.js';
+import type { ConversationMarker } from '../../../src/work-unit/conversation/types.js';
 import { legacyAgentMessages } from './fixtures.js';
 
 let dbCounter = 0;
@@ -211,6 +212,85 @@ describe('WorkUnitConversationStore', () => {
     expect(moved?.workspaceId).toBe(to.workspaceId);
     expect(moved?.key).toBe(to.key);
     expect(moved?.entries).toHaveLength(5);
+  });
+
+  describe('markers', () => {
+    const marker = (over: Partial<ConversationMarker> = {}): ConversationMarker => ({
+      id: 'compaction-cone_1-abc',
+      kind: 'compaction',
+      timestamp: 5000,
+      compaction: { trigger: 'idle', state: 'summarizing' },
+      ...over,
+    });
+
+    it('settles a round in place instead of stacking rows', async () => {
+      await store.syncAgentMessages(identity, legacyAgentMessages());
+      expect(await store.putMarker(identity.key, marker())).toBe(true);
+      expect(
+        await store.putMarker(
+          identity.key,
+          marker({ compaction: { trigger: 'idle', state: 'summarized' } })
+        )
+      ).toBe(true);
+      const markers = (await store.load(identity.key))?.markers;
+      expect(markers).toHaveLength(1);
+      expect(markers?.[0].compaction.state).toBe('summarized');
+    });
+
+    it('survives the compaction that produced it', async () => {
+      // The whole point: `syncAgentMessages` replaces `entries` wholesale on
+      // a compaction, and the marker announcing it must not go with them.
+      await store.syncAgentMessages(identity, legacyAgentMessages());
+      await store.putMarker(identity.key, marker());
+      const compacted = [
+        { role: 'user', content: [{ type: 'text', text: 'summary of earlier work' }] },
+      ] as unknown as AgentMessage[];
+      const after = await store.syncAgentMessages(identity, compacted);
+      expect(after?.entries).toHaveLength(1);
+      expect(after?.markers).toHaveLength(1);
+    });
+
+    it('retracts a round that kept nothing', async () => {
+      await store.syncAgentMessages(identity, legacyAgentMessages());
+      await store.putMarker(identity.key, marker());
+      expect(await store.deleteMarker(identity.key, marker().id)).toBe(true);
+      expect((await store.load(identity.key))?.markers).toEqual([]);
+      // Already gone: nothing to write, and not an error either.
+      expect(await store.deleteMarker(identity.key, marker().id)).toBe(false);
+    });
+
+    it('keeps markers in timestamp order and caps the list', async () => {
+      await store.syncAgentMessages(identity, legacyAgentMessages());
+      for (let i = 0; i < 70; i++) {
+        await store.putMarker(identity.key, marker({ id: `m${i}`, timestamp: 1000 + i }));
+      }
+      const markers = (await store.load(identity.key))?.markers ?? [];
+      expect(markers).toHaveLength(64);
+      // Oldest went first, and what is left is still ascending.
+      expect(markers[0].id).toBe('m6');
+      expect(markers.map((m) => m.timestamp)).toEqual([...markers.map((m) => m.timestamp)].sort());
+    });
+
+    it('refuses to annotate a conversation that is not stored', async () => {
+      // An annotation with no conversation under it would derive to a
+      // transcript that is nothing but seams.
+      expect(await store.putMarker(identity.key, marker())).toBe(false);
+      expect(await store.load(identity.key)).toBeNull();
+    });
+
+    it('never writes over a newer schema or a failed read', async () => {
+      const written = await store.syncAgentMessages(identity, legacyAgentMessages());
+      await store.save({ ...written!, version: 99 });
+      expect(await store.putMarker(identity.key, marker())).toBe(false);
+
+      await store.save({ ...written!, version: 1 });
+      const readSpy = vi
+        .spyOn(store, 'read')
+        .mockResolvedValue({ status: 'error', reason: 'IndexedDB unavailable' });
+      expect(await store.putMarker(identity.key, marker())).toBe(false);
+      readSpy.mockRestore();
+      expect((await store.load(identity.key))?.markers).toBeUndefined();
+    });
   });
 
   it('rekey is a no-op when keys match or the source is absent', async () => {


### PR DESCRIPTION
## Summary

A compact-on-idle round drew a `<slicc-compaction-marker>` in the thread; reloading the tab lost it. The seam now survives a reload, because the round is recorded on the canonical conversation record as a `marker` rather than living only in the page's chat controller.

## Why

Reported from a live cone: the compaction indicator rendered, the tab was reloaded to pick up a new build, and the indicator was gone.

**Repro**

1. Let a cone compact (idle or threshold) — a `<slicc-compaction-marker>` appears in the thread.
2. Reload the leader tab.

Expected: the seam is still in the transcript.
Actual: no marker at all, and nothing in `browser-coding-agent` IDB for any session.

Diagnosed against the running instance on CDP 9222: zero `slicc-compaction-marker` elements after the reload and zero rows carrying `compaction` across all six persisted sessions — so no renderer dropped it; it was never written anywhere. Three layers were missing it at once:

1. `WcChatController.#handleCompactionNotice` appends the row to its in-memory array and the DOM, and nothing else.
2. The only writer of chat rows to IDB is the kernel bridge, from `messageBuffers` — which never held a compaction row — and `toBufferedChatMessages` enumerates fields explicitly, omitting `compaction`.
3. Even with the row in IDB, boot re-seeds the buffer from Pi's history and overwrites the store. No `ConversationEntry` can carry the row either: compaction REPLACES Pi's history wholesale, so an entry announcing it would be erased by the event it announces — and the model must never be shown a row saying its own context was summarized.

## Approach / Implementation notes

- **`record.markers`** (`ConversationMarker`, `kind: 'compaction'`) is a new field on the canonical record, deliberately OUTSIDE the entry reconciliation, so a compaction's wholesale entry replace leaves it standing. `putMarker` / `deleteMarker` upsert by row id under the store's existing never-overwrite guards (newer schema, failed read) plus an ABSENT record, and cap the list at 64 (oldest first).
- **Anchored by `timestamp` alone.** `interleaveMarkers` folds markers into `toChatMessages`; no entry survives a rewrite to anchor to. A marker is stamped when its round settles, so it sorts after the summary message compaction just wrote — the seam. `discarded` markers are dropped, and ISO-string timestamps from the oldest profiles are parsed rather than compared as `number <= string` (which silently answers `false`).
- **One reducer, two consumers.** The phase→row decision moved out of `offscreen-client.ts` into `scoops/compaction-rows.ts` (`CompactionRowTracker`), driven by the panel (renders the row) and the kernel (persists it). A second reading of the same phase stream would mean a transcript whose seams change when you reload it. Round lifecycles — settle-in-place, retraction, the late idle-timer retraction scoped by `roundId` — are unchanged.
- **Rejected alternative:** a `'compaction'` `ConversationEntryKind`. It would have needed the prefix/rewrite reconciliation in `store.ts` to preserve non-Pi entries across a replace, and it puts bookkeeping in the list Pi's history derives from.
- **Data shape:** `markers` is optional; every record written before this reads as "no annotations" and derives exactly as it does today. No migration, no schema-version bump.

## Cross-cutting impact

- **Floats exercised**: standalone/CLI and extension share `Bridge` + `OffscreenClient`, so both get the persistence. `compaction` was added to `ScoopMessagesReplacedMsg['messages']` so a REPLAY carries the seam — that is the path a remounted panel and a **tray follower** take (the iOS `CompactionMarkerRow` already renders from the same `ChatCompactionMarker`, so it inherits it). No new wire message, no protocol-version change.
- **Other callers of the changed contract**: `toChatMessages` is also read by `buildBufferFromCanonicalRecord`; `buildBufferFromAgentMessages` now interleaves the record's markers, which is what stops the boot seed from persisting the transcript minus its seams. `toAgentMessages` and `toTranscriptText` are untouched by design — the model and the archives never see a marker.
- **Persisted state side-effects**: `slicc-work-units` records gain `markers`; `browser-coding-agent` sessions gain rows carrying `compaction`. A retraction removes both. The buffer row is spliced in place rather than swapped for a copy, because `getBuffer` hands the array out by reference.
- **Rendering**: unchanged. The row is still a `ChatMessage` carrying `compaction`, and `messageEls` already anticipated a persisted one (it re-checks `discarded` as a belt to the controller's braces).

## Test plan

- [x] `npm run verify` — 8/8 checks
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 21014 passed, 0 failed
- [x] `npm run test:coverage` — floors met
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK, both apps under budget
- [x] **New behavior covered by unit tests**
  - `tests/work-unit/conversation/store.test.ts` — settle-in-place, retraction, ordering + cap, refusal to annotate an absent record, never-overwrite guards, and the one that matters: **a marker survives the compaction that produced it**
  - `tests/work-unit/conversation/derive.test.ts` — seam placement, multi-round ordering, `discarded` drop, ISO-string and unstamped messages
  - `tests/kernel/compaction-row-persistence.test.ts` (new) — the marker + buffer + UI-store writes, retraction from record and buffer, the rebuild that folds a stored marker in, and a float with no canonical store at all
  - `tests/scoops/compaction-rows.test.ts` (new) — per-unit isolation and `forget`, on top of the round lifecycles already pinned through the panel in `offscreen-client.test.ts`
- [x] **e2e reload assertion, verified to have teeth**: the success scenario in `tests/e2e/compaction-robustness.test.ts` now reloads twice and asserts the seam. Against the previous behavior it fails with `0 elements` — the reported symptom. Full compaction e2e suite: 5 passed (`SLICC_E2E_CDP_PORT=9322 SLICC_E2E_WRANGLER_PORT=8887 SLICC_E2E_BRIDGE_PORT=5810 SLICC_E2E_FAKE_LLM_PORT=5881 npm run test:e2e -- -g compaction`, ports shifted off the live instance).
- [ ] Manual smoke: not run beyond the read-only CDP inspection that produced the diagnosis; the e2e double-reload covers the reported flow.
- [ ] UI screencast: N/A — no visual change. The marker element, its wording and its styling are untouched; only whether it is still there after a reload.

**Pre-existing failure fixed here, unrelated to the seam:** `wc-monitor.test.ts > cost group > is named by the window` fails on `main` today (`expected 'resetting now' to match /^resets in/`). `buildSections` stamps itself from `Date.now()` with no `now` seam, unlike `buildVitals` / `buildAlerts`, and the fixture reset 18h after a hardcoded `2026-09-08`, so it went red on the calendar. Fixed in its own commit so CI here is green.

## Documentation

- [x] Relevant `CLAUDE.md` — `packages/webapp/CLAUDE.md`: markers are `record.markers`, never a `ConversationEntry`
- [x] `docs/` — `docs/work-unit.md`: the marker rule, who writes it, and why the reducer is shared
- [ ] `README.md` — no user-facing behavior change beyond the bug being gone

## Risk & rollback

- Blast radius: one transcript row on every float. Worst case is a duplicated or missing seam; conversation content is never involved — markers are a separate field and `toAgentMessages` cannot see them.
- No feature flag. Reverting the PR is clean: a leftover `markers` field on a record is ignored by the previous reader (unknown fields are preserved by `...existing` and read by nobody), and no entry, key or schema version changed.
- What CI cannot catch: the seam on a **real tray follower** (iOS `CompactionMarkerRow` renders the same marker over the replay path, exercised only by a paired leader/follower), and the seam after a session freeze/thaw.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel change
- [x] Cross-float contract checked: replay shape (`ScoopMessagesReplacedMsg`), the kernel buffer, and the follower's renderer

## Not in scope

Error cards (`ChatMessage.error`) vanish on reload the same way — same page-only path, and `error` is likewise absent from the buffered shape. `lickCount` / `lickParts` / `queued` are render-time state and arguably should stay ephemeral. Left for a follow-up rather than widening this change.
