### PR TITLE
docs(skills): warn that an upgrade can silently drop in-flight scoop work

### DIFF
--- a/packages/vfs-root/workspace/skills/upgrade/SKILL.md
+++ b/packages/vfs-root/workspace/skills/upgrade/SKILL.md
@@ -40,6 +40,8 @@ The runtime renders the upgrade lick as a binary action card automatically — y
 
 The card flips to ✓ on confirm / muted ✗ on dismiss. Never auto-run the merge — the user must choose. Reviewing the changelog is **not** a card action; it is a separate step you can run first to help the user decide.
 
+**Before `lick_confirm` or `lick_dismiss`, check `list_scoops`.** A scoop that is `processing` may lose its in-flight work when the runtime moves to the new version. There is **no notification** — the scoop can look `ready` / finished, indistinguishable from a clean completion. Wait until every scoop is idle, or expect to re-feed any that were still working. Idle scoops survive.
+
 ## Which version am I running?
 
 `uname -r` prints the running version. `upgrade status` adds the last-booted one, whether a merge is pending, and the exact `upgrade apply` line to run when it is — that is where `--from`/`--to` come from without a card on screen. Realm scripts read `globalThis.SLICC_VERSION`.
@@ -99,6 +101,7 @@ Notes worth knowing:
 
 ## Do not
 
+- Do not call `lick_confirm` or `lick_dismiss` while `list_scoops` shows a scoop `processing`. In-flight work can drop to `ready` with no notification; wait until scoops are idle, or expect to re-feed them.
 - Do not run `upgrade apply` before the user confirms. Confirmation runs it automatically; dismissal runs nothing.
 - Do not delete files that no longer exist in the new release — many users name-collide their own scripts with bundled ones; deletion is too dangerous to automate.
 - Do not modify files outside `/workspace/skills/`, `/shared/sprinkles/`, `/shared/sounds/`, `/shared/MEMORY.md`, and `/etc/` without the user explicitly extending the scope.

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import 'fake-indexeddb/auto';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
@@ -639,6 +639,13 @@ describe('budget-mode cost surfaces', () => {
   const NOW = Date.parse('2026-09-08T12:00:00.000Z');
   const RESETS_IN_18H = new Date(NOW + 18 * 60 * 60 * 1000).toISOString();
 
+  // fetchMonitorData reads Date.now(); RESETS_IN_18H is a wall-clock instant
+  // (2026-09-09T06:00Z). After that, formatBudgetResets prints "resetting now".
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
   const budget = (over: Partial<SessionBudgetWindow> = {}): SessionBudgetWindow => ({
     percent: 9.5,
     status: 'ok',
@@ -731,7 +738,7 @@ describe('budget-mode cost surfaces', () => {
       expect(cost.meta).toBe('9.5% of weekly budget · $29.06 across 1 models');
       expect(cost.status).toBe('active');
       expect(cost.rows[0]).toMatchObject({ name: 'Weekly budget', meta: '9.5% used' });
-      expect(cost.rows[0].badges?.[0]).toMatch(/^resets in/);
+      expect(cost.rows[0].badges?.[0]).toBe('resets in 18h');
       // Per-model dollars keep their rows, below the window.
       expect(cost.rows[1]).toMatchObject({ name: 'claude-opus-5', meta: '$20.3400' });
     });


### PR DESCRIPTION
Closes #2951.

## Summary

The `upgrade` skill now warns operators to check `list_scoops` before `lick_confirm` or `lick_dismiss`. A scoop that is `processing` may lose in-flight work when the runtime moves to the new version, with **no notification** — it can look `ready` / finished. Wait until scoops are idle, or expect to re-feed them. Idle scoops were measured to survive.

No runtime, `lick_confirm`, or scoop-lifecycle changes.

## Why

An operator following the skill had no reason to check whether a scoop was mid-task. A `processing` scoop dropping to `ready` looks identical to a clean completion, so the work is silently lost. Issue #2951 asked for this docs warning regardless of the still-unconfirmed trigger (boot vs confirm vs any reload).

## Approach / Implementation notes

- One paragraph in **What to do when you receive an upgrade lick** and one **Do not** bullet.
- Existing card / changelog / `upskill` flow is unchanged.
- Does **not** invent a runtime “interrupted by upgrade” event (that is the issue’s second, maintainer-owned part).
- Does **not** steal #2942, #2978, or #2950.

No one-line mention in `docs/` or agent `CLAUDE.md`: there is no local convention for skill hazards outside the skill itself.

## Cross-cutting impact

- **Floats exercised:** none. Agent-facing vfs-root skill text only; lazy seed chunk, not the eager first-load graph.
- **Shell contexts:** none.
- **Runtime:** upgrade detection, lick registry, and scoop lifecycle are untouched.

## Test plan

- [x] `npx prettier --write packages/vfs-root/workspace/skills/upgrade/SKILL.md` — unchanged
- [x] `npm run lint:skills -- --strict` — all 31 skills passed, including `upgrade`
- [x] `npm run verify` — all 8 checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [x] `npm run test` — 20998 passed, 53 skipped; 1 unrelated failure in `wc-monitor.test.ts` (`resetting now` vs `/^resets in/` on a budget-window badge). Docs-only SKILL.md change; no product tests.

## Documentation

- [x] `packages/vfs-root/workspace/skills/upgrade/SKILL.md` (agent-facing)

## Risk & rollback

- Blast radius: operator guidance only. Confirm/dismiss still do the same things.
- Rollback: revert this PR.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] Linear history (rebased onto origin/main)
- [x] Isolated worktree