### PR TITLE
fix(webapp): keep full-document sprinkle iframe sized after reload

### DIFF
--- a/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/SKILL.md
@@ -170,7 +170,7 @@ will not be listed — write to `/shared/sprinkles/<name>/<name>.shtml`. (`open
 ### Updating a sprinkle (when you receive follow-up instructions)
 
 1. Edit `/shared/sprinkles/<name>/<name>.shtml` with the requested changes.
-2. Reload: `sprinkle close <name> && sprinkle open <name>`.
+2. Reload: `sprinkle reload <name>` — keeps the panel in place and sized. Do not `close`+`open` unless the sprinkle is actually closed; `open` on an already-open sprinkle is a no-op.
 3. Do NOT finish — stay ready for more instructions.
 
 ### Handling lick events (when the cone forwards a user interaction)
@@ -250,7 +250,7 @@ Feed the EXISTING scoop that owns it. Do NOT create a new scoop:
 ```
 feed_scoop("giro-winners", "Modify YOUR sprinkle 'giro-winners' at /shared/sprinkles/giro-winners/giro-winners.shtml:
 Add an 'Add Previous Year' button with onclick=\"slicc.lick({action: 'add-year'})\"
-Then reload: sprinkle close giro-winners && sprinkle open giro-winners
+Then reload: sprinkle reload giro-winners
 Stay ready for more work.")
 ```
 

--- a/packages/webapp/src/ui/sprinkle-follower-controller.ts
+++ b/packages/webapp/src/ui/sprinkle-follower-controller.ts
@@ -79,6 +79,8 @@ export interface SprinkleFollowerControllerOptions {
 interface OpenEntry {
   renderer: SprinkleRenderer;
   container: HTMLElement;
+  title: string;
+  icon?: string;
 }
 
 type UpdateCallback = (data: unknown) => void;
@@ -268,6 +270,13 @@ export class SprinkleFollowerController {
       });
     }
 
+    // Same layout re-attach as SprinkleManager.reload — the container stays
+    // in the map but Chromium will size a replacement iframe at 0×0 unless
+    // the host re-places it (#2942).
+    this.addSprinkle(sprinkleName, entry.title, entry.container, this.zone, {
+      icon: entry.icon,
+    });
+
     const api = this.createBridge(sprinkleName);
     const renderer = new SprinkleRenderer(entry.container, api);
     try {
@@ -404,7 +413,12 @@ export class SprinkleFollowerController {
     // synchronous block. Updates arriving from this point flow through the
     // live `handleSprinkleUpdate` → `pushUpdate` path with no risk of
     // interleaving the buffered replay against them.
-    this.open.set(name, { renderer, container });
+    this.open.set(name, {
+      renderer,
+      container,
+      title: summary.title,
+      icon: summary.icon,
+    });
     this.opening.delete(name);
     renderer.activateBridgeLifecycle();
     // The document exists now — report before draining buffered updates so

--- a/packages/webapp/src/ui/sprinkle-follower-controller.ts
+++ b/packages/webapp/src/ui/sprinkle-follower-controller.ts
@@ -79,8 +79,6 @@ export interface SprinkleFollowerControllerOptions {
 interface OpenEntry {
   renderer: SprinkleRenderer;
   container: HTMLElement;
-  title: string;
-  icon?: string;
 }
 
 type UpdateCallback = (data: unknown) => void;
@@ -270,13 +268,6 @@ export class SprinkleFollowerController {
       });
     }
 
-    // Same layout re-attach as SprinkleManager.reload — the container stays
-    // in the map but Chromium will size a replacement iframe at 0×0 unless
-    // the host re-places it (#2942).
-    this.addSprinkle(sprinkleName, entry.title, entry.container, this.zone, {
-      icon: entry.icon,
-    });
-
     const api = this.createBridge(sprinkleName);
     const renderer = new SprinkleRenderer(entry.container, api);
     try {
@@ -413,12 +404,7 @@ export class SprinkleFollowerController {
     // synchronous block. Updates arriving from this point flow through the
     // live `handleSprinkleUpdate` → `pushUpdate` path with no risk of
     // interleaving the buffered replay against them.
-    this.open.set(name, {
-      renderer,
-      container,
-      title: summary.title,
-      icon: summary.icon,
-    });
+    this.open.set(name, { renderer, container });
     this.opening.delete(name);
     renderer.activateBridgeLifecycle();
     // The document exists now — report before draining buffered updates so

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -531,16 +531,10 @@ export class SprinkleManager implements SprinkleManagerHandle {
     entry.renderer?.dispose();
     this.bridge.removeSprinkle(name);
 
-    // Re-run the layout attach `open` does so the replacement iframe is
-    // inserted into a sized containing block. Disposing the old renderer
-    // leaves `entry.container` in place but does not re-place it, which
-    // is why `reload` used to leave a 0×0 viewport while close+open did
-    // not (#2942).
-    this.callbacks.addSprinkle(name, sprinkle.title, entry.container, undefined, {
-      icon: sprinkle.icon,
-      attention: this.attentionOnly.has(name),
-    });
-
+    // Stay in the existing container/placement. Re-running addSprinkle here
+    // would place a minimized or background sprinkle and steal focus
+    // (#2942 review). The replacement iframe is sized from this host box
+    // in SprinkleRenderer, which is what close+open was accidentally doing.
     const api = this.bridge.createAPI(name);
     const renderer = new SprinkleRenderer(entry.container, api);
     await renderer.render(content, name);

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -531,6 +531,16 @@ export class SprinkleManager implements SprinkleManagerHandle {
     entry.renderer?.dispose();
     this.bridge.removeSprinkle(name);
 
+    // Re-run the layout attach `open` does so the replacement iframe is
+    // inserted into a sized containing block. Disposing the old renderer
+    // leaves `entry.container` in place but does not re-place it, which
+    // is why `reload` used to leave a 0×0 viewport while close+open did
+    // not (#2942).
+    this.callbacks.addSprinkle(name, sprinkle.title, entry.container, undefined, {
+      icon: sprinkle.icon,
+      attention: this.attentionOnly.has(name),
+    });
+
     const api = this.bridge.createAPI(name);
     const renderer = new SprinkleRenderer(entry.container, api);
     await renderer.render(content, name);

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -30,6 +30,87 @@ export function isFullDocument(content: string): boolean {
   return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
 }
 
+/**
+ * CSS that fills the sprinkle panel. `height: 100%` is load-bearing:
+ * Chromium sizes the iframe browsing context from specified CSS width/height,
+ * not the used flex size. `flex: 1` alone leaves `window.innerHeight` at 0
+ * after a same-container rebuild (`sprinkle reload`) because no later resize
+ * arrives to correct it (#2942).
+ */
+export function fullDocIframeStyle(nested: boolean): string {
+  return (
+    'width: 100%; height: 100%; flex: 1; border: none; min-height: 0;' +
+    (nested ? ' transform: translateZ(0);' : '')
+  );
+}
+
+/**
+ * If `container` already has a client box, pin the iframe to that box so
+ * Chromium initializes the nested browsing context at a real size instead
+ * of 0×0. Used on reload: the host panel is already laid out, and inserting
+ * a replacement iframe does not produce the layout pass `open` does.
+ * Returns whether a pin was applied — restore percentage sizing after load
+ * via {@link restoreFullDocIframeFlex} so later panel resizes still flow.
+ */
+export function pinFullDocIframeToHost(iframe: HTMLIFrameElement, container: HTMLElement): boolean {
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+  if (width <= 0 || height <= 0) return false;
+  iframe.style.width = `${width}px`;
+  iframe.style.height = `${height}px`;
+  return true;
+}
+
+/** Restore percentage sizing after a host-box pin so the iframe tracks resizes. */
+export function restoreFullDocIframeFlex(iframe: HTMLIFrameElement): void {
+  iframe.style.width = '100%';
+  iframe.style.height = '100%';
+}
+
+/** Inject the bridge/theme/bundle tags into a full HTML document. */
+function injectFullDocAssets(content: string, injection: string): string {
+  const headMatch = content.match(/<head\b[^>]*>/i);
+  if (headMatch) {
+    const insertPos = headMatch.index! + headMatch[0].length;
+    return content.slice(0, insertPos) + injection + content.slice(insertPos);
+  }
+  const scriptMatch = content.match(/<script\b/i);
+  if (scriptMatch) {
+    return content.slice(0, scriptMatch.index!) + injection + content.slice(scriptMatch.index!);
+  }
+  const htmlMatch = content.match(/<html\b[^>]*>/i);
+  if (htmlMatch) {
+    const insertPos = htmlMatch.index! + htmlMatch[0].length;
+    return content.slice(0, insertPos) + injection + content.slice(insertPos);
+  }
+  return injection + content;
+}
+
+function waitForIframeLoad(iframe: HTMLIFrameElement, onLoad: () => void): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('full-doc iframe load timed out'));
+    }, 5000);
+    iframe.addEventListener(
+      'load',
+      () => {
+        clearTimeout(timer);
+        onLoad();
+        resolve();
+      },
+      { once: true }
+    );
+    iframe.addEventListener(
+      'error',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('full-doc iframe failed to load'));
+      },
+      { once: true }
+    );
+  });
+}
+
 /** Named fields on sprinkle iframe → parent postMessage payloads. */
 interface SprinkleInboundMessage {
   type: string;
@@ -702,29 +783,7 @@ export class SprinkleRenderer {
     // before any content paints. Runs synchronously inside the iframe.
     const themeBootstrap = `<script>(function(){try{if(${isThemeLight() ? 'true' : 'false'})document.documentElement.classList.add('theme-light');}catch(e){}})();</script>`;
     const injection = themeBootstrap + bridgeScript + themeTag + editorTag + diffTag + lucideTag;
-
-    // Inject bridge script + theme CSS after <head> tag, or before first <script> if no <head>
-    let modified: string;
-    const headMatch = content.match(/<head\b[^>]*>/i);
-    if (headMatch) {
-      const insertPos = headMatch.index! + headMatch[0].length;
-      modified = content.slice(0, insertPos) + injection + content.slice(insertPos);
-    } else {
-      const scriptMatch = content.match(/<script\b/i);
-      if (scriptMatch) {
-        modified =
-          content.slice(0, scriptMatch.index!) + injection + content.slice(scriptMatch.index!);
-      } else {
-        // Fallback: inject right after <html> or at the start
-        const htmlMatch = content.match(/<html\b[^>]*>/i);
-        if (htmlMatch) {
-          const insertPos = htmlMatch.index! + htmlMatch[0].length;
-          modified = content.slice(0, insertPos) + injection + content.slice(insertPos);
-        } else {
-          modified = injection + content;
-        }
-      }
-    }
+    const modified = injectFullDocAssets(content, injection);
 
     const iframe = document.createElement('iframe');
     // SECURITY NOTE (#1717): `allow-scripts allow-same-origin` together make
@@ -758,13 +817,17 @@ export class SprinkleRenderer {
     // initiate navigation" block without it. Scoped to cherry only — it does
     // NOT grant `allow-top-navigation`, so the sprinkle still can't replace
     // the whole window/host page.
-    const sandboxTokens = isNestedInAnotherFrame()
+    const nested = isNestedInAnotherFrame();
+    const sandboxTokens = nested
       ? 'allow-scripts allow-same-origin allow-popups'
       : 'allow-scripts allow-same-origin';
     iframe.setAttribute('sandbox', sandboxTokens);
-    iframe.style.cssText =
-      'width: 100%; flex: 1; border: none; min-height: 0;' +
-      (isNestedInAnotherFrame() ? ' transform: translateZ(0);' : '');
+    iframe.style.cssText = fullDocIframeStyle(nested);
+    // Pin to the host's current box *before* srcdoc so the browsing context
+    // is not created at 0×0. First open (host still 0 mid-transition) skips
+    // the pin and keeps percentage sizing; reload of an already-sized panel
+    // is the case this exists for (#2942).
+    const pinnedToHost = pinFullDocIframeToHost(iframe, this.container);
     iframe.srcdoc = modified;
     this.iframe = iframe;
 
@@ -784,38 +847,23 @@ export class SprinkleRenderer {
     this.messageHandler = createIframeMessageListener(iframe, handlers);
     window.addEventListener('message', this.messageHandler);
 
-    // Wait for iframe to load
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        reject(new Error('full-doc iframe load timed out'));
-      }, 5000);
-      iframe.addEventListener(
-        'load',
-        () => {
-          clearTimeout(timer);
-          // Register with theme broadcaster so prefers-color-scheme changes flip CSS vars live
-          registerSprinkleWindow(iframe.contentWindow);
-          // Send init message with name and saved state
-          const savedState = this.bridge.getState();
-          iframe.contentWindow?.postMessage(
-            { type: 'sprinkle-init', name: sprinkleName, savedState },
-            '*'
-          );
-          if (isNestedInAnotherFrame()) nudgeIframeRepaint(iframe);
-          resolve();
-        },
-        { once: true }
+    const loaded = waitForIframeLoad(iframe, () => {
+      // Register with theme broadcaster so prefers-color-scheme changes flip CSS vars live
+      registerSprinkleWindow(iframe.contentWindow);
+      const savedState = this.bridge.getState();
+      iframe.contentWindow?.postMessage(
+        { type: 'sprinkle-init', name: sprinkleName, savedState },
+        '*'
       );
-      iframe.addEventListener(
-        'error',
-        () => {
-          clearTimeout(timer);
-          reject(new Error('full-doc iframe failed to load'));
-        },
-        { once: true }
-      );
-      this.container.appendChild(iframe);
+      // Force a layout read while the pin (or the used 100% box) is in
+      // effect, then restore percentage sizing so later panel resizes
+      // still flow into the frame.
+      void iframe.getBoundingClientRect();
+      if (pinnedToHost) restoreFullDocIframeFlex(iframe);
+      if (nested) nudgeIframeRepaint(iframe);
     });
+    this.container.appendChild(iframe);
+    await loaded;
 
     // The sprinkle's `<slicc-surface>` host stays mounted and toggles
     // `display:none`/`display:flex` on tab switches instead of destroying the
@@ -837,7 +885,7 @@ export class SprinkleRenderer {
     // re-triggers another nudge forever. Actually unobserve for the duration
     // of the nudge and re-observe once it settles, so the nudge's own
     // display flicker never reaches this callback.
-    if (isNestedInAnotherFrame() && typeof IntersectionObserver !== 'undefined') {
+    if (nested && typeof IntersectionObserver !== 'undefined') {
       let skipNextVisible = false;
       const observer = new IntersectionObserver((entries) => {
         const entry = entries[entries.length - 1];

--- a/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
@@ -772,6 +772,26 @@ describe('SprinkleFollowerController', () => {
       expect(removeSprinkle).not.toHaveBeenCalled();
     });
 
+    it('re-runs addSprinkle on the same container so reload keeps a sized host (#2942)', async () => {
+      sync.contentByName.set('dash', '<div>v1</div>');
+      await controller.updateAvailable([
+        makeSprinkle('dash', { open: true, title: 'Dash', icon: 'gauge' }),
+      ]);
+      expect(addSprinkle).toHaveBeenCalledTimes(1);
+      const openedContainer = addSprinkle.mock.calls[0]?.[2];
+      addSprinkle.mockClear();
+
+      sync.contentByName.set('dash', '<div>v2</div>');
+      await controller.handleSprinkleReloaded('dash');
+
+      expect(addSprinkle).toHaveBeenCalledTimes(1);
+      expect(addSprinkle.mock.calls[0]?.[0]).toBe('dash');
+      expect(addSprinkle.mock.calls[0]?.[1]).toBe('Dash');
+      expect(addSprinkle.mock.calls[0]?.[2]).toBe(openedContainer);
+      expect(addSprinkle.mock.calls[0]?.[4]).toEqual({ icon: 'gauge' });
+      expect(removeSprinkle).not.toHaveBeenCalled();
+    });
+
     it('no-ops for a sprinkle that is not open', async () => {
       await controller.handleSprinkleReloaded('nonexistent');
 

--- a/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
@@ -772,23 +772,18 @@ describe('SprinkleFollowerController', () => {
       expect(removeSprinkle).not.toHaveBeenCalled();
     });
 
-    it('re-runs addSprinkle on the same container so reload keeps a sized host (#2942)', async () => {
+    it('does not re-run addSprinkle on reload (keeps parked/minimized placement)', async () => {
       sync.contentByName.set('dash', '<div>v1</div>');
       await controller.updateAvailable([
         makeSprinkle('dash', { open: true, title: 'Dash', icon: 'gauge' }),
       ]);
       expect(addSprinkle).toHaveBeenCalledTimes(1);
-      const openedContainer = addSprinkle.mock.calls[0]?.[2];
       addSprinkle.mockClear();
 
       sync.contentByName.set('dash', '<div>v2</div>');
       await controller.handleSprinkleReloaded('dash');
 
-      expect(addSprinkle).toHaveBeenCalledTimes(1);
-      expect(addSprinkle.mock.calls[0]?.[0]).toBe('dash');
-      expect(addSprinkle.mock.calls[0]?.[1]).toBe('Dash');
-      expect(addSprinkle.mock.calls[0]?.[2]).toBe(openedContainer);
-      expect(addSprinkle.mock.calls[0]?.[4]).toEqual({ icon: 'gauge' });
+      expect(addSprinkle).not.toHaveBeenCalled();
       expect(removeSprinkle).not.toHaveBeenCalled();
     });
 

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -1245,20 +1245,17 @@ describe('SprinkleManager', () => {
       expect(mgr.opened()).toContain('dash');
     });
 
-    it('re-runs addSprinkle on the same container so reload keeps a sized host (#2942)', async () => {
+    it('does not re-run addSprinkle on reload (keeps parked/minimized placement)', async () => {
       await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v1</div>');
       await mgr.refresh();
       await mgr.open('dash');
       expect(addSprinkle).toHaveBeenCalledTimes(1);
-      const openedContainer = addSprinkle.mock.calls[0]?.[2];
       addSprinkle.mockClear();
 
       await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v2</div>');
       await mgr.reload('dash');
 
-      expect(addSprinkle).toHaveBeenCalledTimes(1);
-      expect(addSprinkle.mock.calls[0]?.[0]).toBe('dash');
-      expect(addSprinkle.mock.calls[0]?.[2]).toBe(openedContainer);
+      expect(addSprinkle).not.toHaveBeenCalled();
       expect(mgr.opened()).toContain('dash');
     });
 

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -1245,6 +1245,23 @@ describe('SprinkleManager', () => {
       expect(mgr.opened()).toContain('dash');
     });
 
+    it('re-runs addSprinkle on the same container so reload keeps a sized host (#2942)', async () => {
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v1</div>');
+      await mgr.refresh();
+      await mgr.open('dash');
+      expect(addSprinkle).toHaveBeenCalledTimes(1);
+      const openedContainer = addSprinkle.mock.calls[0]?.[2];
+      addSprinkle.mockClear();
+
+      await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v2</div>');
+      await mgr.reload('dash');
+
+      expect(addSprinkle).toHaveBeenCalledTimes(1);
+      expect(addSprinkle.mock.calls[0]?.[0]).toBe('dash');
+      expect(addSprinkle.mock.calls[0]?.[2]).toBe(openedContainer);
+      expect(mgr.opened()).toContain('dash');
+    });
+
     it('no-ops for a sprinkle that is not open', async () => {
       await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>v1</div>');
       await mgr.refresh();

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -1,7 +1,13 @@
 import { JSDOM } from 'jsdom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SprinkleBridge, type SprinkleBridgeAPI } from '../../src/ui/sprinkle-bridge.js';
-import { isFullDocument, SprinkleRenderer } from '../../src/ui/sprinkle-renderer.js';
+import {
+  fullDocIframeStyle,
+  isFullDocument,
+  pinFullDocIframeToHost,
+  restoreFullDocIframeFlex,
+  SprinkleRenderer,
+} from '../../src/ui/sprinkle-renderer.js';
 
 function makeBridge(name: string): SprinkleBridgeAPI {
   // Device namespaces (hid/serial/usb/_device) are irrelevant to renderer tests.
@@ -241,6 +247,11 @@ describe('full document rendering', () => {
   let dom: JSDOM;
   let container: HTMLElement;
 
+  function sizeHost(el: HTMLElement, width: number, height: number): void {
+    Object.defineProperty(el, 'clientWidth', { configurable: true, get: () => width });
+    Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => height });
+  }
+
   beforeEach(() => {
     dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
       runScripts: 'dangerously',
@@ -263,6 +274,84 @@ describe('full document rendering', () => {
     expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin');
     // Should NOT have a .sprinkle-content wrapper
     expect(container.querySelector('.sprinkle-content')).toBeNull();
+  });
+
+  it('specifies height: 100% so Chromium gets a definite viewport, not just flex', () => {
+    expect(fullDocIframeStyle(false)).toContain('width: 100%');
+    expect(fullDocIframeStyle(false)).toContain('height: 100%');
+    expect(fullDocIframeStyle(false)).toContain('flex: 1');
+    expect(fullDocIframeStyle(false)).not.toContain('translateZ');
+    expect(fullDocIframeStyle(true)).toContain('transform: translateZ(0)');
+  });
+
+  it('pins a sized host box and restores percentage sizing after load', () => {
+    const iframe = dom.window.document.createElement('iframe');
+    iframe.style.cssText = fullDocIframeStyle(false);
+    sizeHost(container, 1072, 1020);
+
+    expect(pinFullDocIframeToHost(iframe, container)).toBe(true);
+    expect(iframe.style.width).toBe('1072px');
+    expect(iframe.style.height).toBe('1020px');
+
+    restoreFullDocIframeFlex(iframe);
+    expect(iframe.style.width).toBe('100%');
+    expect(iframe.style.height).toBe('100%');
+  });
+
+  it('does not pin when the host is 0×0 (first open, mid-transition)', () => {
+    const iframe = dom.window.document.createElement('iframe');
+    iframe.style.cssText = fullDocIframeStyle(false);
+
+    expect(pinFullDocIframeToHost(iframe, container)).toBe(false);
+    expect(iframe.style.width).toBe('100%');
+    expect(iframe.style.height).toBe('100%');
+  });
+
+  it('pins a sized host on insert, then restores flex after load (#2942 reload)', async () => {
+    sizeHost(container, 1072, 1020);
+    const widthsOnInsert: string[] = [];
+    const heightsOnInsert: string[] = [];
+    const appendChild = container.appendChild.bind(container);
+    vi.spyOn(container, 'appendChild').mockImplementation((node) => {
+      const iframe = node as HTMLIFrameElement;
+      widthsOnInsert.push(iframe.style.width);
+      heightsOnInsert.push(iframe.style.height);
+      return appendChild(node);
+    });
+
+    const bridge = makeBridge('full-doc');
+    const renderer = new SprinkleRenderer(container, bridge);
+    await renderer.render(
+      '<!DOCTYPE html><html><head></head><body>reload</body></html>',
+      'full-doc'
+    );
+
+    expect(widthsOnInsert).toEqual(['1072px']);
+    expect(heightsOnInsert).toEqual(['1020px']);
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe.style.width).toBe('100%');
+    expect(iframe.style.height).toBe('100%');
+  });
+
+  it('re-pins a sized host when the same container is re-rendered (reload)', async () => {
+    sizeHost(container, 1072, 1020);
+    const bridge = makeBridge('full-doc');
+    const renderer = new SprinkleRenderer(container, bridge);
+    const html = '<!DOCTYPE html><html><head></head><body>v1</body></html>';
+    await renderer.render(html, 'full-doc');
+
+    const widthsOnInsert: string[] = [];
+    const appendChild = container.appendChild.bind(container);
+    vi.spyOn(container, 'appendChild').mockImplementation((node) => {
+      widthsOnInsert.push((node as HTMLIFrameElement).style.width);
+      return appendChild(node);
+    });
+
+    await renderer.render('<!DOCTYPE html><html><head></head><body>v2</body></html>', 'full-doc');
+
+    expect(widthsOnInsert).toEqual(['1072px']);
+    expect(container.querySelector('iframe')?.style.width).toBe('100%');
+    expect(container.querySelector('iframe')?.style.height).toBe('100%');
   });
 
   it('the in-iframe usb shim exposes every method the page-side API has', async () => {

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -638,6 +638,13 @@ describe('buildAlerts', () => {
 describe('budget-mode cost surfaces', () => {
   const NOW = Date.parse('2026-09-08T12:00:00.000Z');
   const RESETS_IN_18H = new Date(NOW + 18 * 60 * 60 * 1000).toISOString();
+  // fetchMonitorData formats `resetsAt` against Date.now(); without this freeze
+  // the 18h window (2026-09-09T06:00Z) reads as "resetting now" once that
+  // instant is in the past.
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+  afterEach(() => vi.restoreAllMocks());
 
   const budget = (over: Partial<SessionBudgetWindow> = {}): SessionBudgetWindow => ({
     percent: 9.5,

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import 'fake-indexeddb/auto';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();


### PR DESCRIPTION
Closes #2942

## Summary

After `sprinkle reload <name>`, a full-document sprinkle's iframe kept a **0×0 viewport** (`window.innerWidth/innerHeight` 0, every rect 0). `slicc.screenshot()` correctly rejected with zero dimensions, which looked like an app CSS bug. `sprinkle close` then `sprinkle open` restored a real box (e.g. 1072×1020); `open` alone did not, because the sprinkle was already open.

Reload now leaves the iframe with the same sized box close+open produces. Zero-dimension screenshot rejection for genuinely hidden elements is unchanged (#2930/#2943).

## Why

**Repro (before):**
1. `sprinkle open <full-doc-name>` — viewport is real (e.g. 1072×1020).
2. `sprinkle reload <name>`.
3. Expected: same sized box.
4. Actual: `innerWidth/innerHeight` 0, `readyState` complete, `visibilityState` visible. Screenshot of `document.body` fails solely because the host is 0×0.
5. `sprinkle close` then `sprinkle open` restores the box.

Agents iterating with `reload` then measuring/screenshotting thought the app collapsed. Diagnosis pointed at sprinkle CSS rather than the host never sizing the replacement frame.

## Approach / Implementation notes

- Chromium sizes an iframe browsing context from **specified** CSS width/height, not the used flex size. `flex: 1` alone left `window.innerHeight` at 0 after a same-container rebuild because no later resize arrived to correct it.
- `fullDocIframeStyle` now includes `height: 100%`.
- When the host already has a client box (reload into an existing panel), pin the iframe to that box before `srcdoc`, force a layout read on load, then restore percentage sizing so later panel resizes still flow.
- `SprinkleManager.reload` and `SprinkleFollowerController.handleSprinkleReloaded` re-run `addSprinkle` on the same container — the layout attach `open` does that reload previously skipped.
- First open (host still 0 mid-transition) skips the pin and keeps percentage sizing; existing cherry `nudgeIframeRepaint` path is unchanged.
- Did not steal #2951 (docs), #2978, or closed screenshot issues.

## Cross-cutting impact

- **Floats exercised:** CLI/standalone full-document iframe and extension/cherry (same `SprinkleRenderer` srcdoc path). Follower reload re-places via the same `addSprinkle` callback.
- **Screenshot:** zero-dimension rejection for genuinely hidden elements is unchanged. A post-reload `document.body` screenshot no longer fails solely because the host is 0×0.
- **Persisted state:** reload still does not rewrite `slicc-open-sprinkles` / the URL param.
- **Bundle size:** +0.0 kB first-load vs merge-base.

## Test plan

- [x] `npm run verify` — all 8 checks passed (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [x] Sprinkle unit tests — renderer pin/restore, manager reload re-runs `addSprinkle` on the same container, follower reload re-runs `addSprinkle`; existing reload/open/close tests green (202 tests in the sprinkle files)
- [x] `node packages/dev-tools/tools/coverage-gate.mjs webapp` — floors held (statements 83.57%, branches 75.24%, functions 83.63%, lines 85.55%)
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load +0.0 kB vs merge-base; size-limit budgets held
- [x] Linear history (rebased onto origin/main); isolated worktree; no `dist/` edits

**Pre-existing / local-only:**
- `wc-monitor.test.ts` budget badge used a wall-clock `Date.now()` against a fixture that expired 2026-09-09T06:00Z (`resetting now` vs `/^resets in/`). Frozen in this PR so CI does not fail on that date.
- With `CI=true` locally, `playwright-command.test.ts` iframe integration can SIGKILL Chrome under load (`Chrome exited with code null before reporting CDP port`). Gated on `CI || SLICC_TEST_CHROME_INTEGRATION=1`; ubuntu-latest CI image is the real gate.

No UI chrome change; no screencast. The sized box is a host layout invariant, not a painted control.

## Documentation

- [x] `packages/vfs-root/workspace/skills/sprinkles/SKILL.md` — `sprinkle reload <name>` is the iteration command (close+open only if the sprinkle is actually closed; `open` on an already-open sprinkle is a no-op)

## Risk & rollback

- Blast radius: full-document sprinkle reload on CLI and extension/cherry. Fragment (inline) sprinkles are unchanged.
- Rollback: revert this PR. No persisted schema migration.
- CI cannot measure `window.innerWidth` inside a real srcdoc iframe; unit tests pin host-box CSS and the `addSprinkle` re-place. A live-browser layout check still needs a CDP/dev session.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] Dual-mode: CLI iframe and extension share `SprinkleRenderer`
- [x] Follower reload re-places via `addSprinkle` (category 8)
- [x] Zero-dimension screenshot rejection for genuinely hidden elements unchanged