### PR TITLE
fix(webapp): dot only cones on the tab strip, never scoops

### DIFF
--- a/docs/webcomponents-details.md
+++ b/docs/webcomponents-details.md
@@ -366,7 +366,10 @@ a host has to know:
   trigger with one dot in `--ink` (it stands for several agents, so it carries no
   single hue). The count also reaches the screen reader through both aria labels.
 
-The webapp derives the count in `work-unit/client/unread.ts` — see
+The component dots whatever segment carries a count; deciding WHICH agents can
+have one is the host's call. The webapp derives the count in
+`work-unit/client/unread.ts` and hands it to cones only — a scoop's turns are its
+cone's work, not news the user is expected to read — see
 [`work-unit-client.md`](work-unit-client.md).
 
 ## Tablist arrows vs a host keyboard

--- a/docs/work-unit-client.md
+++ b/docs/work-unit-client.md
@@ -271,8 +271,16 @@ protocol does not settle approvals, it only agrees on who owns whom.
 
 Multiple cones made the strip a place you leave things running, so a tab has to
 be able to say it has news. `UnreadLedger.sync(units, selectedId)` folds a roster
-plus the selection into per-unit counts, which `toTabDescriptors` puts on the
+plus the selection into per-cone counts, which `toTabDescriptors` puts on the
 descriptor as `unread`.
+
+**Cones only.** A scoop finishing a turn is the cone's own work progressing, not
+a message addressed to the user — and since users never talk to a scoop
+(`isReadOnlyUnit`), there is no reply waiting behind such a dot. One ask can fan
+out to a dozen scoops running several turns each, which dotted most of the strip
+for something nobody asked to read. The ledger skips a non-root unit before it
+records any baseline for it, and `toTabDescriptors` refuses to paint one even for
+a caller that hands over its own map.
 
 **The signal is the roster, not a message stream** — which is what lets both
 sides share it. A leader could count `turn_end` per unit, but a follower

--- a/packages/webapp/src/work-unit/client/presentation.ts
+++ b/packages/webapp/src/work-unit/client/presentation.ts
@@ -35,8 +35,9 @@ export interface WorkUnitTabDescriptor {
   awaiting?: boolean;
   /**
    * Messages produced since the user last looked at this unit, from
-   * {@link import('./unread.js').UnreadLedger}. Omitted at zero, and always
-   * omitted for the selected unit.
+   * {@link import('./unread.js').UnreadLedger}. Omitted at zero, for the
+   * selected unit, and for a scoop — a scoop's turns are its cone's work, not
+   * news the user is expected to read.
    */
   unread?: number;
 }
@@ -216,9 +217,11 @@ export function toTabDescriptors(
       // pin on an idle tab.
       ...(unit.state === 'working' && unit.phase ? { phase: unit.phase } : {}),
       ...(unit.state === 'idle' && unit.awaiting ? { awaiting: true as const } : {}),
-      // The selected unit is read by definition; the ledger already clears it,
-      // and this keeps that true even for a caller that hands over its own map.
-      ...(unit.id !== selectedId && (unread?.get(unit.id) ?? 0) > 0
+      // Only a cone, and never the selected one: the selected unit is read by
+      // definition and a scoop is not news at all. The ledger already applies
+      // both rules; re-applying them here keeps them true for a caller that
+      // hands over its own map.
+      ...(isRoot && unit.id !== selectedId && (unread?.get(unit.id) ?? 0) > 0
         ? { unread: unread?.get(unit.id) }
         : {}),
     };

--- a/packages/webapp/src/work-unit/client/unread.ts
+++ b/packages/webapp/src/work-unit/client/unread.ts
@@ -22,12 +22,19 @@
  * Selection is the read receipt: the selected unit is always at zero, so the
  * count clears the moment the user looks. Nothing here persists — unread is
  * per-page-session by design, the way an unseen streamed reply is.
+ *
+ * **Only cones are counted.** A scoop's turns are the cone's own work, not news
+ * addressed to the user: a single ask can fan out to a dozen scoops that each
+ * finish several turns, which dotted most of the strip for something nobody
+ * asked to read — and users never talk to a scoop, so there is no reply waiting
+ * behind that dot. The cone that owns the work still reports when its turn ends.
  */
 
+import { isRootSummary } from './presentation.js';
 import type { WorkUnitId, WorkUnitPresentationState, WorkUnitSummary } from './types.js';
 
-/** What the ledger needs of a unit: who it is, what it is doing, what it finished. */
-type LedgerUnit = Pick<WorkUnitSummary, 'id' | 'state' | 'turns'>;
+/** What the ledger needs of a unit: who it is, what it is, what it finished. */
+type LedgerUnit = Pick<WorkUnitSummary, 'id' | 'role' | 'state' | 'turns'>;
 
 export class UnreadLedger {
   readonly #counts = new Map<WorkUnitId, number>();
@@ -35,8 +42,8 @@ export class UnreadLedger {
   readonly #lastTurns = new Map<WorkUnitId, number>();
 
   /**
-   * Fold a roster and the current selection into unread counts, and return
-   * them for the strip.
+   * Fold a roster and the current selection into unread counts for its CONES,
+   * and return them for the strip.
    *
    * Called from the strip publisher, so it runs on every roster push, every
    * status change and every selection change — the three events that can move
@@ -47,6 +54,9 @@ export class UnreadLedger {
   sync(units: readonly LedgerUnit[], selectedId?: WorkUnitId | null): ReadonlyMap<string, number> {
     const present = new Set<WorkUnitId>();
     for (const unit of units) {
+      // A scoop is never news (see the header): skipping it before the baseline
+      // is recorded also keeps its transitions out of the maps entirely.
+      if (!isRootSummary(unit)) continue;
       present.add(unit.id);
       const finished = this.#turnsFinished(unit);
       if (finished > 0 && unit.id !== selectedId) {
@@ -56,9 +66,9 @@ export class UnreadLedger {
     // Selection is the read receipt, applied after the increments: a turn that
     // ends on the unit the user is watching is already read.
     if (selectedId) this.#counts.delete(selectedId);
-    // A unit the roster dropped is gone for good (a dropped cone, a scoop that
-    // finished); keeping its count would leak the map across a long session and
-    // resurrect a stale dot if the id ever came back.
+    // A cone the roster dropped is gone for good; keeping its count would leak
+    // the map across a long session and resurrect a stale dot if the id ever
+    // came back.
     for (const id of [...this.#counts.keys()]) if (!present.has(id)) this.#counts.delete(id);
     for (const id of [...this.#lastState.keys()]) if (!present.has(id)) this.#lastState.delete(id);
     for (const id of [...this.#lastTurns.keys()]) if (!present.has(id)) this.#lastTurns.delete(id);

--- a/packages/webapp/tests/ui/wc/wc-live.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live.test.ts
@@ -339,26 +339,37 @@ describe('createWcLiveCallbacks', () => {
     wiring.refs.switcher.remove();
   });
 
-  it('dots a tab whose turn ended while the user was on another one', () => {
+  it('dots a cone whose turn ended while the user was on another one', () => {
+    const away = scoop({
+      jid: 'cone-2',
+      name: 'sliccy',
+      folder: 'cone-2',
+      parentJid: null,
+      assistantLabel: 'sliccy',
+    });
     const worker = scoop({ jid: 'scoop-worker', name: 'worker' });
-    const wiring = makeWiring({ selected: cone, scoops: [cone, worker] });
+    const wiring = makeWiring({ selected: cone, scoops: [cone, away, worker] });
     const callbacks = createWcLiveCallbacks(wiring);
     const unreadOf = (jid: string): number | undefined =>
       wiring.refs.switcher.scoops.find((chip) => chip.key === jid)?.unread;
 
+    callbacks.onStatusChange(away.jid, 'processing' as never);
+    expect(unreadOf(away.jid)).toBeUndefined();
+    callbacks.onStatusChange(away.jid, 'ready' as never);
+    expect(unreadOf(away.jid)).toBe(1);
+    // A scoop's turn is the work its cone was asked for, not news of its own.
     callbacks.onStatusChange(worker.jid, 'processing' as never);
-    expect(unreadOf(worker.jid)).toBeUndefined();
     callbacks.onStatusChange(worker.jid, 'ready' as never);
-    expect(unreadOf(worker.jid)).toBe(1);
+    expect(unreadOf(worker.jid)).toBeUndefined();
     // The selected tab is read by definition, even across its own turn.
     callbacks.onStatusChange(cone.jid, 'processing' as never);
     callbacks.onStatusChange(cone.jid, 'ready' as never);
     expect(unreadOf(cone.jid)).toBeUndefined();
 
-    // Selecting the scoop is the read receipt; the next repaint clears the dot.
-    wiring.selectScoop(asUnit(worker));
+    // Selecting the cone is the read receipt; the next repaint clears the dot.
+    wiring.selectScoop(asUnit(away));
     wiring.refreshScoops?.();
-    expect(unreadOf(worker.jid)).toBeUndefined();
+    expect(unreadOf(away.jid)).toBeUndefined();
   });
 
   it('counts a completed turn where a follower can still see it', () => {

--- a/packages/webapp/tests/ui/wc/wc-tray-unread.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray-unread.test.ts
@@ -54,34 +54,50 @@ function mountFollower(): {
 }
 
 const CONE = { jid: 'cone-a', name: 'cone', isCone: true, parentId: null };
+/** A second cone plus one of its scoops, both moving through `state`. */
 const roster = (state: 'working' | 'idle', turns?: number) => [
   CONE,
+  {
+    jid: 'cone-b',
+    name: 'cone',
+    isCone: true,
+    parentId: null,
+    state,
+    ...(turns === undefined ? {} : { turns }),
+  },
   {
     jid: 'scoop-a',
     name: 'helper',
     isCone: false,
-    parentId: 'cone-a',
+    parentId: 'cone-b',
     state,
     ...(turns === undefined ? {} : { turns }),
   },
 ];
 
 describe('follower strip unread', () => {
-  it('dots a followed scoop whose turn ended off-screen, and clears it on selection', () => {
+  it('dots a followed cone whose turn ended off-screen, and clears it on selection', () => {
     const { switcher, onScoopsList } = mountFollower();
     const unreadOf = (key: string): number | undefined =>
       switcher.scoops.find((chip) => chip.key === key)?.unread;
 
     onScoopsList(roster('working'), 'cone-a');
-    expect(unreadOf('scoop-a')).toBeUndefined();
+    expect(unreadOf('cone-b')).toBeUndefined();
     onScoopsList(roster('idle'), 'cone-a');
-    expect(unreadOf('scoop-a')).toBe(1);
+    expect(unreadOf('cone-b')).toBe(1);
     // Opening the tab is the read receipt here as well — the follower's own
     // click, which republishes the strip for the new selection.
     switcher.dispatchEvent(
-      new CustomEvent('slicc-scoop-select', { detail: { key: 'scoop-a' }, bubbles: true })
+      new CustomEvent('slicc-scoop-select', { detail: { key: 'cone-b' }, bubbles: true })
     );
-    expect(unreadOf('scoop-a')).toBeUndefined();
+    expect(unreadOf('cone-b')).toBeUndefined();
+  });
+
+  it("never dots a scoop, whose turns are its cone's work", () => {
+    const { switcher, onScoopsList } = mountFollower();
+    onScoopsList(roster('working'), 'cone-a');
+    onScoopsList(roster('idle'), 'cone-a');
+    expect(switcher.scoops.find((chip) => chip.key === 'scoop-a')?.unread).toBeUndefined();
   });
 
   it('dots a turn the coalescing window swallowed, seen only as a bumped counter', () => {
@@ -90,11 +106,11 @@ describe('follower strip unread', () => {
       switcher.scoops.find((chip) => chip.key === key)?.unread;
 
     onScoopsList(roster('idle', 3), 'cone-a');
-    expect(unreadOf('scoop-a')).toBeUndefined();
+    expect(unreadOf('cone-b')).toBeUndefined();
     // The leader ran a whole turn between these two frames. State says `idle`
     // both times; the counter is the only thing that says a turn ended.
     onScoopsList(roster('idle', 4), 'cone-a');
-    expect(unreadOf('scoop-a')).toBe(1);
+    expect(unreadOf('cone-b')).toBe(1);
   });
 
   it('opens a first roster with nothing unread', () => {

--- a/packages/webapp/tests/work-unit/client/unread.test.ts
+++ b/packages/webapp/tests/work-unit/client/unread.test.ts
@@ -6,62 +6,77 @@ import type {
 } from '../../../src/work-unit/client/types.js';
 import { UnreadLedger } from '../../../src/work-unit/client/unread.js';
 
-function unit(
-  id: string,
-  state: WorkUnitPresentationState,
-  turns?: number
-): Pick<WorkUnitSummary, 'id' | 'state' | 'turns'> {
-  return { id, state, ...(turns === undefined ? {} : { turns }) };
+type LedgerUnit = Pick<WorkUnitSummary, 'id' | 'role' | 'state' | 'turns'>;
+
+/** A cone — the only kind of unit the ledger counts. */
+function cone(id: string, state: WorkUnitPresentationState, turns?: number): LedgerUnit {
+  return { id, role: 'primary', state, ...(turns === undefined ? {} : { turns }) };
+}
+
+/** A scoop, which is never news however busy it is. */
+function scoop(id: string, state: WorkUnitPresentationState, turns?: number): LedgerUnit {
+  return { id, role: 'child', state, ...(turns === undefined ? {} : { turns }) };
 }
 
 describe('UnreadLedger', () => {
-  it('counts a turn ending on a unit the user is not watching', () => {
+  it('counts a turn ending on a cone the user is not watching', () => {
     const ledger = new UnreadLedger();
-    ledger.sync([unit('cone', 'idle'), unit('scoop', 'working')], 'cone');
-    expect(ledger.sync([unit('cone', 'idle'), unit('scoop', 'idle')], 'cone').get('scoop')).toBe(1);
-    ledger.sync([unit('cone', 'idle'), unit('scoop', 'working')], 'cone');
-    expect(ledger.sync([unit('cone', 'idle'), unit('scoop', 'idle')], 'cone').get('scoop')).toBe(2);
+    ledger.sync([cone('here', 'idle'), cone('there', 'working')], 'here');
+    expect(ledger.sync([cone('here', 'idle'), cone('there', 'idle')], 'here').get('there')).toBe(1);
+    ledger.sync([cone('here', 'idle'), cone('there', 'working')], 'here');
+    expect(ledger.sync([cone('here', 'idle'), cone('there', 'idle')], 'here').get('there')).toBe(2);
   });
 
   it('counts a turn that ends in failure', () => {
     const ledger = new UnreadLedger();
-    ledger.sync([unit('scoop', 'working')], 'cone');
-    expect(ledger.sync([unit('scoop', 'broken')], 'cone').get('scoop')).toBe(1);
+    ledger.sync([cone('there', 'working')], 'here');
+    expect(ledger.sync([cone('there', 'broken')], 'here').get('there')).toBe(1);
   });
 
-  it('never counts the selected unit, and clears it on selection', () => {
+  it('never counts a scoop, however many turns it finishes', () => {
     const ledger = new UnreadLedger();
-    ledger.sync([unit('cone', 'idle'), unit('scoop', 'working')], 'cone');
-    expect(ledger.sync([unit('cone', 'idle'), unit('scoop', 'idle')], 'scoop').has('scoop')).toBe(
+    // A scoop's turns are the work its cone was asked for, and a user never
+    // talks to a scoop — so there is no unread reply behind such a dot.
+    ledger.sync([cone('here', 'idle'), scoop('helper', 'working', 1)], 'here');
+    expect(ledger.sync([cone('here', 'idle'), scoop('helper', 'idle', 2)], 'here').size).toBe(0);
+    // Not even while the user is watching a different cone entirely.
+    ledger.sync([cone('there', 'idle'), scoop('helper', 'working')], 'there');
+    expect(ledger.sync([cone('there', 'idle'), scoop('helper', 'idle')], 'there').size).toBe(0);
+  });
+
+  it('never counts the selected cone, and clears it on selection', () => {
+    const ledger = new UnreadLedger();
+    ledger.sync([cone('here', 'idle'), cone('there', 'working')], 'here');
+    expect(ledger.sync([cone('here', 'idle'), cone('there', 'idle')], 'there').has('there')).toBe(
       false
     );
     // And a count already held is a read receipt the moment the tab is opened.
-    ledger.sync([unit('scoop', 'working')], 'cone');
-    expect(ledger.sync([unit('scoop', 'idle')], 'cone').get('scoop')).toBe(1);
-    expect(ledger.sync([unit('scoop', 'idle')], 'scoop').has('scoop')).toBe(false);
+    ledger.sync([cone('there', 'working')], 'here');
+    expect(ledger.sync([cone('there', 'idle')], 'here').get('there')).toBe(1);
+    expect(ledger.sync([cone('there', 'idle')], 'there').has('there')).toBe(false);
   });
 
   it('is idempotent for an unchanged roster — it counts transitions, not states', () => {
     const ledger = new UnreadLedger();
-    ledger.sync([unit('scoop', 'working')], 'cone');
-    ledger.sync([unit('scoop', 'idle')], 'cone');
-    ledger.sync([unit('scoop', 'idle')], 'cone');
-    expect(ledger.sync([unit('scoop', 'idle')], 'cone').get('scoop')).toBe(1);
+    ledger.sync([cone('there', 'working')], 'here');
+    ledger.sync([cone('there', 'idle')], 'here');
+    ledger.sync([cone('there', 'idle')], 'here');
+    expect(ledger.sync([cone('there', 'idle')], 'here').get('there')).toBe(1);
   });
 
   it('does not open a first roster with everything unread', () => {
     const ledger = new UnreadLedger();
-    const counts = ledger.sync([unit('cone', 'idle'), unit('old', 'broken')], 'cone');
+    const counts = ledger.sync([cone('here', 'idle'), cone('old', 'broken')], 'here');
     expect(counts.size).toBe(0);
   });
 
-  it('forgets a unit the roster dropped instead of resurrecting its dot', () => {
+  it('forgets a cone the roster dropped instead of resurrecting its dot', () => {
     const ledger = new UnreadLedger();
-    ledger.sync([unit('cone', 'idle'), unit('scoop', 'working')], 'cone');
-    expect(ledger.sync([unit('cone', 'idle'), unit('scoop', 'idle')], 'cone').get('scoop')).toBe(1);
-    expect(ledger.sync([unit('cone', 'idle')], 'cone').has('scoop')).toBe(false);
+    ledger.sync([cone('here', 'idle'), cone('there', 'working')], 'here');
+    expect(ledger.sync([cone('here', 'idle'), cone('there', 'idle')], 'here').get('there')).toBe(1);
+    expect(ledger.sync([cone('here', 'idle')], 'here').has('there')).toBe(false);
     // A recycled id starts clean: no held count, and no remembered `working`.
-    expect(ledger.sync([unit('cone', 'idle'), unit('scoop', 'idle')], 'cone').has('scoop')).toBe(
+    expect(ledger.sync([cone('here', 'idle'), cone('there', 'idle')], 'here').has('there')).toBe(
       false
     );
   });
@@ -69,60 +84,60 @@ describe('UnreadLedger', () => {
   describe('the completion counter', () => {
     it('counts a turn a coalesced roster push never showed as working', () => {
       const ledger = new UnreadLedger();
-      // The follower has seen this unit idle; the leader then runs a whole turn
+      // The follower has seen this cone idle; the leader then runs a whole turn
       // inside its 50ms coalescing window, so the only frame that lands is the
       // final `idle` — sampled state says nothing happened, `turns` says one
       // turn did.
-      ledger.sync([unit('cone', 'idle'), unit('scoop', 'idle', 3)], 'cone');
-      const counts = ledger.sync([unit('cone', 'idle'), unit('scoop', 'idle', 4)], 'cone');
-      expect(counts.get('scoop')).toBe(1);
+      ledger.sync([cone('here', 'idle'), cone('there', 'idle', 3)], 'here');
+      const counts = ledger.sync([cone('here', 'idle'), cone('there', 'idle', 4)], 'here');
+      expect(counts.get('there')).toBe(1);
     });
 
     it('counts every turn a burst of them collapsed into one frame', () => {
       const ledger = new UnreadLedger();
-      ledger.sync([unit('scoop', 'idle', 1)], 'cone');
-      expect(ledger.sync([unit('scoop', 'working', 4)], 'cone').get('scoop')).toBe(3);
+      ledger.sync([cone('there', 'idle', 1)], 'here');
+      expect(ledger.sync([cone('there', 'working', 4)], 'here').get('there')).toBe(3);
     });
 
-    it('counts the first turn of a unit it has been watching', () => {
+    it('counts the first turn of a cone it has been watching', () => {
       const ledger = new UnreadLedger();
       // No counter yet: a leader only sends one once the unit has finished a
       // turn, so its arrival at 1 IS that turn and must not be swallowed as a
       // baseline.
-      ledger.sync([unit('scoop', 'working')], 'cone');
-      expect(ledger.sync([unit('scoop', 'idle', 1)], 'cone').get('scoop')).toBe(1);
+      ledger.sync([cone('there', 'working')], 'here');
+      expect(ledger.sync([cone('there', 'idle', 1)], 'here').get('there')).toBe(1);
     });
 
-    it('baselines a unit it is seeing for the first time', () => {
+    it('baselines a cone it is seeing for the first time', () => {
       const ledger = new UnreadLedger();
-      expect(ledger.sync([unit('scoop', 'idle', 7)], 'cone').size).toBe(0);
-      expect(ledger.sync([unit('scoop', 'idle', 8)], 'cone').get('scoop')).toBe(1);
+      expect(ledger.sync([cone('there', 'idle', 7)], 'here').size).toBe(0);
+      expect(ledger.sync([cone('there', 'idle', 8)], 'here').get('there')).toBe(1);
     });
 
     it('re-baselines instead of underflowing when a leader reloads', () => {
       const ledger = new UnreadLedger();
-      ledger.sync([unit('scoop', 'idle', 9)], 'cone');
+      ledger.sync([cone('there', 'idle', 9)], 'here');
       // A fresh leader counts from zero again; that is not negative news.
-      expect(ledger.sync([unit('scoop', 'idle', 0)], 'cone').size).toBe(0);
-      expect(ledger.sync([unit('scoop', 'idle', 1)], 'cone').get('scoop')).toBe(1);
+      expect(ledger.sync([cone('there', 'idle', 0)], 'here').size).toBe(0);
+      expect(ledger.sync([cone('there', 'idle', 1)], 'here').get('there')).toBe(1);
     });
 
     it('takes precedence over the state it also sees', () => {
       const ledger = new UnreadLedger();
-      ledger.sync([unit('scoop', 'working', 2)], 'cone');
+      ledger.sync([cone('there', 'working', 2)], 'here');
       // The transition happened AND the counter stood still (the turn was
       // aborted, not completed) — the counter is the one that knows.
-      expect(ledger.sync([unit('scoop', 'idle', 2)], 'cone').size).toBe(0);
+      expect(ledger.sync([cone('there', 'idle', 2)], 'here').size).toBe(0);
     });
 
     it('keeps watching state for a leader that sends no counter', () => {
       const ledger = new UnreadLedger();
-      ledger.sync([unit('scoop', 'working')], 'cone');
-      expect(ledger.sync([unit('scoop', 'idle')], 'cone').get('scoop')).toBe(1);
+      ledger.sync([cone('there', 'working')], 'here');
+      expect(ledger.sync([cone('there', 'idle')], 'here').get('there')).toBe(1);
     });
   });
 
-  it('hands its counts to the strip, minus the selected tab', () => {
+  it('hands its counts to the strip, minus the selected tab and every scoop', () => {
     const summaries: WorkUnitSummary[] = [
       {
         id: 'cone',
@@ -133,6 +148,16 @@ describe('UnreadLedger', () => {
         assistantLabel: 'Sliccy',
         state: 'idle',
         fill: 10,
+      },
+      {
+        id: 'other',
+        parentId: null,
+        role: 'primary',
+        name: 'sliccy',
+        folder: 'other',
+        assistantLabel: 'Sliccy',
+        state: 'idle',
+        fill: 15,
       },
       {
         id: 'scoop',
@@ -147,12 +172,17 @@ describe('UnreadLedger', () => {
     ];
     const unread = new Map([
       ['cone', 4],
+      ['other', 3],
       ['scoop', 2],
     ]);
     const tabs = toTabDescriptors(summaries, 'cone', () => '#000', unread);
     expect(tabs.find((tab) => tab.key === 'cone')?.unread).toBeUndefined();
-    expect(tabs.find((tab) => tab.key === 'scoop')?.unread).toBe(2);
+    expect(tabs.find((tab) => tab.key === 'other')?.unread).toBe(3);
+    // A caller handing over its own map does not get to dot a scoop either.
+    expect(tabs.find((tab) => tab.key === 'scoop')?.unread).toBeUndefined();
     // A caller that tracks nothing dots nothing.
-    expect(toTabDescriptors(summaries, 'cone', () => '#000')[1]?.unread).toBeUndefined();
+    expect(
+      toTabDescriptors(summaries, 'cone', () => '#000').every((tab) => tab.unread === undefined)
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What

The tab strip dotted every agent that finished a turn off-screen — cones **and** scoops. Only the cone dot is wanted, so unread is now a cone-only signal.

A scoop finishing a turn is the cone's own work progressing, not a message addressed to the user, and since users never talk to a scoop (`isReadOnlyUnit`) no reply waits behind such a dot. One ask fanning out to a dozen scoops running several turns each dotted most of the strip for something nobody asked to read.

## How

- `UnreadLedger.sync` skips a non-root unit *before* recording any baseline for it, so a scoop's transitions and `turns` never enter the ledger's maps at all.
- `toTabDescriptors` refuses to put `unread` on a scoop descriptor, the same way it already refuses it for the selected unit — so a caller handing over its own map cannot paint one either.
- Both floats keep their behaviour for cones, including the coalesced-turn counter path (#2948): a cone whose turn ended while you were on another tab still reports it, on leader and follower.

`<slicc-agent-tabs>` / `<slicc-scoop-overflow>` are unchanged: they still dot whatever segment carries a count, and deciding which agents can have one stays the host's call.

## Tests

- `work-unit/client/unread.test.ts` rewritten around cones, plus a case asserting a busy scoop with a climbing `turns` counter is never counted.
- `wc-live.test.ts` (leader) and `wc-tray-unread.test.ts` (follower) now dot a second cone and assert the scoop in the same roster stays clean.

## Docs

`docs/work-unit-client.md` gains the "Cones only" rule; `docs/webcomponents-details.md` records that the component is generic and the webapp feeds cones only.

## Verification

`npm run verify`, `check-touched-exemptions.mjs`, `typecheck`, `test`, `test:coverage`, both builds and `bundle-size` all pass.
