### PR TITLE
fix(webapp): send a curl request body as the bytes on disk

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -2341,12 +2341,21 @@ onto one byte per character under `application/octet-stream` (`→` → `92`). S
 `readFile` parks the exact bytes it decoded under the string it returned
 (`shell/request-body-provenance.ts` — the request-side sibling of
 `binary-cache.ts`, bounded at 8 MiB total with a 10 s TTL), and
-`resolveExactRequestBody` swaps them back in at the fetch boundary. A hit is
-proof rather than a guess, because the key is the string itself; a miss (a body
-assembled from several `-d` parts, a `-F` multipart, a read past the budget)
-falls back to the Content-Type convention above. Provenance is per-realm, so
-the worker→page hop resolves the body BEFORE the panel-RPC call, in the realm
-that holds the bytes.
+`resolveExactRequestBody` swaps them back in at the fetch boundary. A miss (a
+body assembled from several `-d` parts, a `-F` multipart, a read past the
+budget) falls back to the Content-Type convention above.
+
+The string alone is **not** proof that a body came from the read that parked it
+— an inline `curl -d 'é'` is the same string as a latin1 read of the byte `E9`
+— so two guards scope a lookup. `AlmostBashShellHeadless.runCommand` resets the
+table before each command line, and a `curl` reads its `@file` and issues its
+request inside one command, so an earlier read (or another shell's) can never
+answer for a later body. And when two reads of DIFFERENT bytes decode to the
+same string, that string stops resolving for the rest of the command rather
+than letting either claim it. What is left is a body prepared after the command
+that read it (`curl -d @f &`), which falls back to the Content-Type convention.
+Provenance is per-realm, so the worker→page hop resolves the body BEFORE the
+panel-RPC call, in the realm that holds the bytes.
 
 The defaults above hold on **both** paths. The realm's `serializeRequestInit`
 has to decide them itself rather than leaning on the host adapter: text still

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -2313,7 +2313,10 @@ Network requests are proxied to handle CORS and cross-origin restrictions.
 `SecureFetch` historically carried a `body: string`. just-bash `curl` and git
 still thread binary through the **latin1 convention** (one character per byte);
 `prepareRequestBody` decodes that back to raw bytes whenever the Content-Type
-is not text-shaped. The `.jsh` `fetch` global and the kernel realm's `fetch`
+is not text-shaped. A code unit above `0xFF` cannot have come from that
+convention, so `getFetchBodyBytes` UTF-8-encodes such a string instead of
+masking it — masking turned `→` (U+2192) into a lone `0x92`. The `.jsh`
+`fetch` global and the kernel realm's `fetch`
 RPC do **not** use latin1 for binary — they send a `Uint8Array` so native
 `fetch` cannot UTF-8-expand bytes ≥0x80 (a JPEG SOI `FF D8` must not become
 `C3 BF C3 98`). Both accept:
@@ -2326,6 +2329,24 @@ RPC do **not** use latin1 for binary — they send a `Uint8Array` so native
 | `Blob` / `File`                            | raw bytes     | the blob's own `type`, else `application/octet-stream` |
 | `FormData`                                 | raw multipart | `multipart/form-data; boundary=<token>`                |
 | `ReadableStream`                           | —             | rejected; collect it into a `Uint8Array` first         |
+
+**Byte provenance beats the Content-Type guess.** `curl -d @file` /
+`--data-binary @file` / `-T file` can only hand that string-typed contract a
+DECODED file, and the Content-Type says nothing about which decoding
+`VfsAdapter.readFile` used (UTF-8 when the bytes decode cleanly, latin1 when
+they do not). Crossing the two guesses corrupted the body silently: a payload
+that was not valid UTF-8 went out double-encoded under `application/json`
+(`E2 86 92` → `C3 A2 C2 86 C2 92`, i.e. `→` → `â†’`), and valid UTF-8 collapsed
+onto one byte per character under `application/octet-stream` (`→` → `92`). So
+`readFile` parks the exact bytes it decoded under the string it returned
+(`shell/request-body-provenance.ts` — the request-side sibling of
+`binary-cache.ts`, bounded at 8 MiB total with a 10 s TTL), and
+`resolveExactRequestBody` swaps them back in at the fetch boundary. A hit is
+proof rather than a guess, because the key is the string itself; a miss (a body
+assembled from several `-d` parts, a `-F` multipart, a read past the budget)
+falls back to the Content-Type convention above. Provenance is per-realm, so
+the worker→page hop resolves the body BEFORE the panel-RPC call, in the realm
+that holds the bytes.
 
 The defaults above hold on **both** paths. The realm's `serializeRequestInit`
 has to decide them itself rather than leaning on the host adapter: text still

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -75,6 +75,7 @@ import {
   wrapTimeoutForProgress,
 } from './progress/index.js';
 import { createProxiedFetch } from './proxied-fetch.js';
+import { clearReadByteProvenance } from './request-body-provenance.js';
 import { ScriptCatalog } from './script-catalog.js';
 import { enforceCommandSudo } from './sudo/command-guard.js';
 import { runMountDirectoryApproval } from './supplemental-commands/mount-directory-approval.js';
@@ -975,6 +976,12 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
   ): Promise<BashExecResult> {
     const commandName = command.trim().split(/\s+/)[0] || 'unknown';
     emitShellCommand(commandName);
+
+    // A file read answers for a request body only inside the command that read
+    // it (`curl -d @file` reads and fetches in one command). Dropping the
+    // previous command's reads here is what keeps the string key from matching
+    // an unrelated later body — see `request-body-provenance.ts`.
+    clearReadByteProvenance();
 
     // Wait for the constructor's `.jsh` registration before the first command.
     //

--- a/packages/webapp/src/shell/fetch-body.ts
+++ b/packages/webapp/src/shell/fetch-body.ts
@@ -13,12 +13,24 @@ export function parseFetchJson<T>(body: FetchBody): T {
   return JSON.parse(decodeFetchBody(body)) as T;
 }
 
+/**
+ * The bytes a `FetchBody` stands for. A string is read under the latin1
+ * convention (one char per byte) that just-bash `curl` and git use to thread
+ * binary through a string body.
+ *
+ * A code unit above 0xFF cannot come from that convention — it is Unicode text
+ * that was never a byte string — so such a string is encoded as UTF-8 instead.
+ * Masking it (`charCodeAt(i) & 0xff`) silently dropped the high bits and turned
+ * `→` (U+2192) into a lone `0x92`.
+ */
 export function getFetchBodyBytes(body: FetchBody): Uint8Array {
   if (typeof body !== 'string') return body;
-
+  for (let i = 0; i < body.length; i++) {
+    if (body.charCodeAt(i) > 0xff) return new TextEncoder().encode(body);
+  }
   const bytes = new Uint8Array(body.length);
   for (let i = 0; i < body.length; i++) {
-    bytes[i] = body.charCodeAt(i) & 0xff;
+    bytes[i] = body.charCodeAt(i);
   }
   return bytes;
 }

--- a/packages/webapp/src/shell/proxied-fetch.ts
+++ b/packages/webapp/src/shell/proxied-fetch.ts
@@ -33,6 +33,7 @@ import {
   encodeForbiddenRequestHeaders as _encodeForbiddenRequestHeaders,
   headersToRecord as _headersToRecord,
 } from './proxy-headers.js';
+import { lookupReadBytes } from './request-body-provenance.js';
 
 /**
  * Ceiling on a proxied REQUEST body. Exported so the CapabilityBroker's REST
@@ -267,6 +268,22 @@ async function withProgressEnd<T>(
 }
 
 /**
+ * A string body that is exactly what a VFS read returned is sent as the bytes
+ * that read saw, whatever the Content-Type says. `curl -d @file` can only hand
+ * just-bash's string-typed `SecureFetchOptions.body` a decoded string, and no
+ * Content-Type rule recovers the file's bytes from it: a payload that is not
+ * valid UTF-8 goes out double-encoded under a text Content-Type, and valid
+ * UTF-8 collapses onto one byte per character under a binary one. See
+ * `request-body-provenance.ts` for how the read's bytes get here.
+ */
+export function resolveExactRequestBody(
+  body: SecureFetchRequestBody | undefined
+): SecureFetchRequestBody | undefined {
+  if (typeof body !== 'string' || body === '') return body;
+  return lookupReadBytes(body) ?? body;
+}
+
+/**
  * Bodies that are NOT text-shaped (multipart form payloads, git packfiles,
  * application/octet-stream, etc.) reach this layer either as a `Uint8Array`
  * (the jsh `fetch` adapter — never a JS string, so native `fetch` cannot
@@ -279,9 +296,10 @@ async function withProgressEnd<T>(
  * `Uint8Array` bodies in a Blob unconditionally, so the binary survives.
  */
 export function prepareRequestBody(
-  body: SecureFetchRequestBody | undefined,
+  rawBody: SecureFetchRequestBody | undefined,
   headers?: Record<string, string>
 ): BodyInit | undefined {
+  const body = resolveExactRequestBody(rawBody);
   if (body == null || body === '') return undefined;
   // Already bytes: the caller resolved the encoding itself (jsh fetch and
   // the CapabilityBroker adapters). Wrap as Blob unconditionally — native
@@ -631,6 +649,13 @@ export function createProxiedFetch(fetchOptions: ProxiedFetchOptions = {}): Secu
       // page-side collector encodes forbidden headers exactly once and
       // prepares the body via the same `prepareRequestBody` contract.
       const plainHeaders = headersToRecord(options?.headers) ?? {};
+      // Byte provenance is per-realm, and `prepareRequestBody` runs on the
+      // PAGE side of this hop, so resolve the read's bytes here — in the realm
+      // that holds them — rather than forwarding a string the page cannot
+      // recover them from.
+      const exactBody = resolveExactRequestBody(
+        options?.body as SecureFetchRequestBody | undefined
+      );
       // The page realm collects the chunks; the worker only sees the whole
       // body, so this path reports an indeterminate in-flight unit.
       progress?.start(url, undefined);
@@ -641,7 +666,7 @@ export function createProxiedFetch(fetchOptions: ProxiedFetchOptions = {}): Secu
             url,
             method,
             headers: plainHeaders,
-            body: options?.body as string | Uint8Array | undefined,
+            body: exactBody,
           },
           // Generous timeout — multi-MB wasm / package downloads outlast the
           // panel-RPC default 15s.

--- a/packages/webapp/src/shell/request-body-provenance.ts
+++ b/packages/webapp/src/shell/request-body-provenance.ts
@@ -19,10 +19,28 @@
  *
  * A string cannot carry the answer (`café` read from a UTF-8 file and from a
  * latin1 file are the same string), so the read parks its exact bytes here
- * under the string it returned and the fetch boundary looks them up. A hit is
- * proof, not a guess: the key is the string itself. A miss (a body the shell
- * assembled from several pieces, a read past the budget below) just falls back
- * to the Content-Type convention.
+ * under the string it returned and the fetch boundary looks them up. A miss (a
+ * body the shell assembled from several pieces, a read past the budget below)
+ * just falls back to the Content-Type convention.
+ *
+ * The string alone is NOT proof that a body came from the read that parked it:
+ * an inline `curl -d 'é'` is the same string as a latin1 read of the single
+ * byte `E9`, and substituting the file's bytes there would send `E9` where the
+ * caller typed text that means `C3 A9`. Two guards keep a lookup honest:
+ *
+ *   - **one command line at a time** — `AlmostBashShellHeadless.runCommand`
+ *     resets the table before each command, and a `curl` reads its `@file` and
+ *     issues its request inside one command, so a read cannot reach an
+ *     unrelated later body (nor another shell's, since the reset is global);
+ *   - **ambiguity poisons the entry** — when two reads of DIFFERENT bytes
+ *     decode to the same string (a latin1 `E9` file and a UTF-8 `C3 A9` one),
+ *     neither can claim it, so the string stops resolving until the next
+ *     command.
+ *
+ * What is left is a body prepared after the command that read it — a detached
+ * job (`curl -d @f &`) whose fetch lands past the reset. That falls back to the
+ * Content-Type convention, i.e. the behavior this module improves on, never a
+ * substitution of some other file's bytes.
  *
  * This is the request-side sibling of `binary-cache.ts`, which does the same
  * for response bodies on their way to `writeFile`.
@@ -52,6 +70,13 @@ interface ParkedRead {
 /** Insertion-ordered so the oldest entry is the first eviction candidate. */
 const parked = new Map<string, ParkedRead>();
 let parkedBytes = 0;
+
+/**
+ * Strings two reads decoded from different bytes. They stay unresolvable for
+ * the rest of the command: whichever read a body came from is exactly what this
+ * module cannot tell, and guessing is what it exists to avoid.
+ */
+const ambiguous = new Set<string>();
 
 function drop(text: string): void {
   const entry = parked.get(text);
@@ -95,9 +120,25 @@ export function parkReadBytes(text: string, bytes: Uint8Array): void {
   if (withoutNewlines !== text) parkOne(withoutNewlines, stripNewlines(bytes));
 }
 
+/** Byte-for-byte equality, so a re-read of one file is not read as a conflict. */
+function sameBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
 function parkOne(text: string, bytes: Uint8Array): void {
   if (bytes.byteLength === 0 || bytes.byteLength > MAX_PARKED_BYTES) return;
   if (!hasHighByte(bytes)) return;
+  if (ambiguous.has(text)) return;
+  const existing = parked.get(text);
+  if (existing && !sameBytes(existing.bytes, bytes)) {
+    drop(text);
+    ambiguous.add(text);
+    return;
+  }
   drop(text);
   // Evict oldest-first until the newcomer fits.
   for (const key of parked.keys()) {
@@ -120,7 +161,12 @@ export function lookupReadBytes(text: string): Uint8Array | null {
   return parked.get(text)?.bytes ?? null;
 }
 
-/** Drop every parked read. For tests that assert the fallback path. */
+/**
+ * Forget every parked read. Called at each shell command boundary (see the
+ * module comment) so a read can only answer for a body in its own command, and
+ * by tests that assert the fallback path.
+ */
 export function clearReadByteProvenance(): void {
   for (const key of [...parked.keys()]) drop(key);
+  ambiguous.clear();
 }

--- a/packages/webapp/src/shell/request-body-provenance.ts
+++ b/packages/webapp/src/shell/request-body-provenance.ts
@@ -1,0 +1,126 @@
+/**
+ * Byte provenance for strings that came out of a VFS read.
+ *
+ * just-bash's `SecureFetchOptions.body` is typed `string`, so `curl -d @file`
+ * / `-T file` can only hand us a JS string. `VfsAdapter.readFile` has to
+ * decide how to turn the file's bytes into that string (UTF-8 when the bytes
+ * decode cleanly, one-char-per-byte latin1 otherwise), and
+ * `prepareRequestBody` has to decide how to turn the string back into bytes
+ * (latin1 for a binary Content-Type, UTF-8 otherwise). Those two decisions
+ * are made from different evidence, and when they disagree the request body
+ * is silently corrupted:
+ *
+ *   - a file whose bytes are NOT valid UTF-8 sent with a text Content-Type
+ *     took the latin1 read and the UTF-8 encode, so every byte ≥0x80 went out
+ *     double-encoded (`E2 86 92` → `C3 A2 C2 86 C2 92`, i.e. `→` → `â†’`);
+ *   - a valid UTF-8 file sent with a binary Content-Type took the UTF-8 read
+ *     and the latin1 encode, so every multi-byte character collapsed onto one
+ *     wrong byte (`→` → `92`).
+ *
+ * A string cannot carry the answer (`café` read from a UTF-8 file and from a
+ * latin1 file are the same string), so the read parks its exact bytes here
+ * under the string it returned and the fetch boundary looks them up. A hit is
+ * proof, not a guess: the key is the string itself. A miss (a body the shell
+ * assembled from several pieces, a read past the budget below) just falls back
+ * to the Content-Type convention.
+ *
+ * This is the request-side sibling of `binary-cache.ts`, which does the same
+ * for response bodies on their way to `writeFile`.
+ */
+
+/**
+ * Longest a parked entry stays available. A body is handed to `fetch` in the
+ * same turn as the read that produced it, so this only has to outlive the
+ * command's own argument assembly.
+ */
+const TTL_MS = 10_000;
+
+/**
+ * Ceiling on the bytes parked at any one time. Every entry retains a copy of
+ * the file's bytes for {@link TTL_MS}, so the budget bounds what a read loop
+ * (`for f in *; do cat "$f"; done`) can pin. Bodies past it fall back to the
+ * Content-Type convention, which is already correct for the large-payload case
+ * that matters (a binary upload with a binary Content-Type).
+ */
+const MAX_PARKED_BYTES = 8 * 1024 * 1024;
+
+interface ParkedRead {
+  bytes: Uint8Array;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Insertion-ordered so the oldest entry is the first eviction candidate. */
+const parked = new Map<string, ParkedRead>();
+let parkedBytes = 0;
+
+function drop(text: string): void {
+  const entry = parked.get(text);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  parked.delete(text);
+  parkedBytes -= entry.bytes.byteLength;
+}
+
+/** True when any byte needs a decoding decision (i.e. the string is ambiguous). */
+function hasHighByte(bytes: Uint8Array): boolean {
+  for (const byte of bytes) {
+    if (byte >= 0x80) return true;
+  }
+  return false;
+}
+
+/** Drop CR and LF, the transform `curl -d @file` applies to a file it read. */
+function stripNewlines(bytes: Uint8Array): Uint8Array {
+  const out = new Uint8Array(bytes.byteLength);
+  let length = 0;
+  for (const byte of bytes) {
+    if (byte !== 0x0a && byte !== 0x0d) out[length++] = byte;
+  }
+  return out.slice(0, length);
+}
+
+/**
+ * Remember that `text` is exactly what `bytes` decode to, so a later fetch can
+ * send the bytes the file actually holds. All-ASCII reads are skipped: latin1
+ * and UTF-8 agree on them, so there is nothing to recover.
+ *
+ * `curl -d @file` (as opposed to `--data-binary @file`) strips CR and LF from
+ * what it read, so the newline-free form is parked too — it is the string that
+ * reaches the fetch boundary. Removing those bytes cannot disturb a multi-byte
+ * UTF-8 sequence, whose continuation bytes are all ≥0x80.
+ */
+export function parkReadBytes(text: string, bytes: Uint8Array): void {
+  parkOne(text, bytes);
+  const withoutNewlines = text.replace(/[\r\n]/g, '');
+  if (withoutNewlines !== text) parkOne(withoutNewlines, stripNewlines(bytes));
+}
+
+function parkOne(text: string, bytes: Uint8Array): void {
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_PARKED_BYTES) return;
+  if (!hasHighByte(bytes)) return;
+  drop(text);
+  // Evict oldest-first until the newcomer fits.
+  for (const key of parked.keys()) {
+    if (parkedBytes + bytes.byteLength <= MAX_PARKED_BYTES) break;
+    drop(key);
+  }
+  parked.set(text, {
+    bytes,
+    timer: setTimeout(() => drop(text), TTL_MS),
+  });
+  parkedBytes += bytes.byteLength;
+}
+
+/**
+ * The exact bytes `text` was decoded from, or `null` when it did not come
+ * from a read this realm parked. Does NOT consume the entry: the same body
+ * can be prepared more than once (a redirect re-sends it, `-v` prints it).
+ */
+export function lookupReadBytes(text: string): Uint8Array | null {
+  return parked.get(text)?.bytes ?? null;
+}
+
+/** Drop every parked read. For tests that assert the fallback path. */
+export function clearReadByteProvenance(): void {
+  for (const key of [...parked.keys()]) drop(key);
+}

--- a/packages/webapp/src/shell/vfs-adapter.ts
+++ b/packages/webapp/src/shell/vfs-adapter.ts
@@ -18,6 +18,7 @@ import * as justBash from 'just-bash';
 import type { DirEntry, Stats, VirtualFS } from '../fs/index.js';
 import { FsError, joinPath, normalizePath, statsFromDirEntry } from '../fs/index.js';
 import { consumeCachedBinary } from './binary-cache.js';
+import { parkReadBytes } from './request-body-provenance.js';
 
 // just-bash v3 ships `DefenseInDepthBox` from `security/index.js` (re-exported
 // at the package root for the Node bundle, but NOT from the browser bundle).
@@ -46,6 +47,25 @@ interface DirentEntry {
   isFile: boolean;
   isDirectory: boolean;
   isSymbolicLink: boolean;
+}
+
+/**
+ * Decode a file's bytes into the string just-bash's `readFile` contract
+ * returns. UTF-8 first — valid text files decode cleanly. Binary files (PNG,
+ * JPEG, …) contain invalid UTF-8 sequences; fall back to latin1, which maps
+ * each byte to a char and so preserves every value.
+ */
+function decodeReadBytes(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    // Don't use TextDecoder('iso-8859-1') — browsers treat it as windows-1252
+    // per WHATWG spec, remapping bytes 0x80-0x9F to different codepoints.
+    // String.fromCharCode maps each byte directly to its Unicode codepoint.
+    const chars = new Array(bytes.length);
+    for (let i = 0; i < bytes.length; i++) chars[i] = String.fromCharCode(bytes[i]);
+    return chars.join('');
+  }
 }
 
 /**
@@ -328,19 +348,12 @@ export class VfsAdapter implements IFileSystem {
       const normalized = normalizePath(path);
       const raw = await this.vfs.readFile(normalized, { encoding: 'binary' });
       const bytes = raw instanceof Uint8Array ? raw : new TextEncoder().encode(raw as string);
-      // Try UTF-8 first — valid text files decode cleanly.
-      // Binary files (PNG, JPEG, etc.) contain invalid UTF-8 sequences;
-      // fall back to latin1 which maps each byte to a char, preserving all values.
-      try {
-        return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
-      } catch {
-        // Don't use TextDecoder('iso-8859-1') — browsers treat it as windows-1252
-        // per WHATWG spec, remapping bytes 0x80-0x9F to different codepoints.
-        // String.fromCharCode maps each byte directly to its Unicode codepoint.
-        const chars = new Array(bytes.length);
-        for (let i = 0; i < bytes.length; i++) chars[i] = String.fromCharCode(bytes[i]);
-        return chars.join('');
-      }
+      const text = decodeReadBytes(bytes);
+      // Which of the two decodings ran is not recoverable from the string, and
+      // a `curl -d @file` body has to be sent as the bytes on disk rather than
+      // a re-encoding of the string (see request-body-provenance.ts).
+      parkReadBytes(text, bytes);
+      return text;
     });
   }
 

--- a/packages/webapp/tests/shell/curl-request-body-encoding.test.ts
+++ b/packages/webapp/tests/shell/curl-request-body-encoding.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `curl -d @file` / `--data-binary @file` byte fidelity, end to end:
+ * `AlmostBashShellHeadless` → just-bash curl → `SecureFetch`
+ * (`createProxiedFetch()`'s CLI branch) → mocked
+ * `globalThis.fetch('/api/fetch-proxy', init)`.
+ *
+ * just-bash hands a request body to `SecureFetch` as a `string`, so the file's
+ * bytes make a round trip through a decode and an encode chosen by two
+ * different layers. When those two disagree the body is silently corrupted:
+ * a payload that is not valid UTF-8 went out double-encoded under a text
+ * Content-Type (`→` as `â†’`, the U+00E2 mojibake signature), and valid UTF-8
+ * collapsed onto one byte per character under a binary one. What reaches the
+ * wire must be what is on disk, in every combination.
+ */
+
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../src/shell/almost-bash-shell-headless.js';
+
+let dbCounter = 0;
+let fs: VirtualFS;
+let proxyFetch: ReturnType<typeof vi.fn>;
+let realFetch: typeof globalThis.fetch | undefined;
+let realChrome: unknown;
+
+const PAYLOAD = '{"body":"plan → build — ship ✓ café"}';
+const utf8 = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+/** The bytes the mocked proxy hop was asked to send. */
+async function sentBytes(): Promise<Uint8Array> {
+  expect(proxyFetch).toHaveBeenCalledTimes(1);
+  const init = proxyFetch.mock.calls[0][1] as RequestInit;
+  return new Uint8Array(await new Response(init.body).arrayBuffer());
+}
+
+/** Characters in the C1 range — the reliable signature of a double-encode. */
+function c1Chars(bytes: Uint8Array): number {
+  let count = 0;
+  for (const char of new TextDecoder().decode(bytes)) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code >= 0x80 && code <= 0x9f) count++;
+  }
+  return count;
+}
+
+async function post(args: string): Promise<void> {
+  const shell = new AlmostBashShellHeadless({ fs });
+  const result = await shell.executeCommand(
+    `curl -s -X POST ${args} https://api.example.com/repos/o/r/issues/46`
+  );
+  expect(result.stderr).toBe('');
+  expect(result.exitCode).toBe(0);
+}
+
+beforeEach(async () => {
+  fs = await VirtualFS.create({ dbName: `test-curl-body-${dbCounter++}`, wipe: true });
+  realChrome = (globalThis as { chrome?: unknown }).chrome;
+  realFetch = globalThis.fetch;
+  // CLI mode — createProxiedFetch() routes through globalThis.fetch('/api/fetch-proxy', …).
+  (globalThis as { chrome?: unknown }).chrome = undefined;
+  proxyFetch = vi.fn(
+    async () =>
+      new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } })
+  );
+  (globalThis as { fetch: typeof globalThis.fetch }).fetch =
+    proxyFetch as unknown as typeof globalThis.fetch;
+});
+
+afterEach(async () => {
+  (globalThis as { chrome?: unknown }).chrome = realChrome;
+  if (realFetch) (globalThis as { fetch: typeof globalThis.fetch }).fetch = realFetch;
+  vi.restoreAllMocks();
+  await fs.dispose();
+});
+
+describe('curl request bodies keep their bytes', () => {
+  it('--data-binary @file with a UTF-8 JSON payload', async () => {
+    await fs.writeFile('/workspace/body.json', PAYLOAD);
+    await post("-H 'Content-Type: application/json' --data-binary @/workspace/body.json");
+    expect(await sentBytes()).toEqual(utf8(PAYLOAD));
+  });
+
+  it('--data-binary @file whose bytes are not valid UTF-8, under a text Content-Type', async () => {
+    // One stray byte forces the whole read onto the latin1 fallback, which is
+    // where the double-encode used to happen: 45 bytes went out as 57.
+    const onDisk = new Uint8Array([...utf8(PAYLOAD), 0xff]);
+    await fs.writeFile('/workspace/mixed.bin', onDisk);
+    await post("-H 'Content-Type: application/json' --data-binary @/workspace/mixed.bin");
+    const sent = await sentBytes();
+    expect(sent).toEqual(onDisk);
+    expect(c1Chars(sent)).toBe(0);
+  });
+
+  it('--data-binary @file with a UTF-8 payload, under a binary Content-Type', async () => {
+    await fs.writeFile('/workspace/body.json', PAYLOAD);
+    await post("-H 'Content-Type: application/octet-stream' --data-binary @/workspace/body.json");
+    expect(await sentBytes()).toEqual(utf8(PAYLOAD));
+  });
+
+  it('-d @file strips newlines but keeps every other byte', async () => {
+    await fs.writeFile('/workspace/lines.json', `${PAYLOAD}\n`);
+    await post("-H 'Content-Type: application/json' -d @/workspace/lines.json");
+    expect(await sentBytes()).toEqual(utf8(PAYLOAD));
+  });
+
+  it('--data-binary @file with binary content under a binary Content-Type', async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xd8]);
+    await fs.writeFile('/workspace/x.png', png);
+    await post("-H 'Content-Type: application/octet-stream' --data-binary @/workspace/x.png");
+    expect(await sentBytes()).toEqual(png);
+  });
+
+  it('inline -d with non-ASCII text', async () => {
+    await post(`-H 'Content-Type: application/json' -d '${PAYLOAD}'`);
+    expect(await sentBytes()).toEqual(utf8(PAYLOAD));
+  });
+
+  it('-T @file upload keeps its bytes', async () => {
+    const onDisk = new Uint8Array([...utf8('note: a → b'), 0xfe]);
+    await fs.writeFile('/workspace/upload.bin', onDisk);
+    await post('-T /workspace/upload.bin');
+    expect(await sentBytes()).toEqual(onDisk);
+  });
+});

--- a/packages/webapp/tests/shell/curl-request-body-encoding.test.ts
+++ b/packages/webapp/tests/shell/curl-request-body-encoding.test.ts
@@ -27,10 +27,10 @@ let realChrome: unknown;
 const PAYLOAD = '{"body":"plan → build — ship ✓ café"}';
 const utf8 = (text: string): Uint8Array => new TextEncoder().encode(text);
 
-/** The bytes the mocked proxy hop was asked to send. */
-async function sentBytes(): Promise<Uint8Array> {
-  expect(proxyFetch).toHaveBeenCalledTimes(1);
-  const init = proxyFetch.mock.calls[0][1] as RequestInit;
+/** The bytes the mocked proxy hop was asked to send on its `index`-th call. */
+async function sentBytes(index = 0): Promise<Uint8Array> {
+  expect(proxyFetch.mock.calls.length).toBeGreaterThan(index);
+  const init = proxyFetch.mock.calls[index][1] as RequestInit;
   return new Uint8Array(await new Response(init.body).arrayBuffer());
 }
 
@@ -44,11 +44,10 @@ function c1Chars(bytes: Uint8Array): number {
   return count;
 }
 
-async function post(args: string): Promise<void> {
-  const shell = new AlmostBashShellHeadless({ fs });
-  const result = await shell.executeCommand(
-    `curl -s -X POST ${args} https://api.example.com/repos/o/r/issues/46`
-  );
+const URL = 'https://api.example.com/repos/o/r/issues/46';
+
+async function post(args: string, shell = new AlmostBashShellHeadless({ fs })): Promise<void> {
+  const result = await shell.executeCommand(`curl -s -X POST ${args} ${URL}`);
   expect(result.stderr).toBe('');
   expect(result.exitCode).toBe(0);
 }
@@ -114,6 +113,36 @@ describe('curl request bodies keep their bytes', () => {
   it('inline -d with non-ASCII text', async () => {
     await post(`-H 'Content-Type: application/json' -d '${PAYLOAD}'`);
     expect(await sentBytes()).toEqual(utf8(PAYLOAD));
+  });
+
+  it('a read in an EARLIER command never answers for a later inline body', async () => {
+    // The read and the request have to belong to one command for the read's
+    // bytes to count. A latin1 file holding `E9` reads as "é"; an unrelated
+    // `-d 'é'` in a later command means the TEXT, so it must go out as UTF-8
+    // `C3 A9` rather than the earlier file's byte.
+    const shell = new AlmostBashShellHeadless({ fs });
+    await fs.writeFile('/workspace/legacy.txt', new Uint8Array([0xe9]));
+    await post("-H 'Content-Type: application/json' --data-binary @/workspace/legacy.txt", shell);
+    expect(await sentBytes(0)).toEqual(new Uint8Array([0xe9]));
+    await post(`-H 'Content-Type: application/json' -d 'é'`, shell);
+    expect(await sentBytes(1)).toEqual(utf8('é'));
+  });
+
+  it('two files that read as the same string each still send their own bytes', async () => {
+    // A latin1 `E9` file and a UTF-8 `C3 A9` file both read as "é". Each
+    // request must carry the bytes of the file IT named. (Reads that collide
+    // while a request is in flight instead stop resolving — see
+    // `request-body-provenance.test.ts`.)
+    await fs.writeFile('/workspace/latin1.txt', new Uint8Array([0xe9]));
+    await fs.writeFile('/workspace/utf8.txt', utf8('é'));
+    const shell = new AlmostBashShellHeadless({ fs });
+    const result = await shell.executeCommand(
+      `curl -s -X POST -H 'Content-Type: application/json' --data-binary @/workspace/latin1.txt ${URL} ` +
+        `&& curl -s -X POST -H 'Content-Type: application/json' --data-binary @/workspace/utf8.txt ${URL}`
+    );
+    expect(result.exitCode).toBe(0);
+    expect(await sentBytes(0)).toEqual(new Uint8Array([0xe9]));
+    expect(await sentBytes(1)).toEqual(utf8('é'));
   });
 
   it('-T @file upload keeps its bytes', async () => {

--- a/packages/webapp/tests/shell/request-body-provenance.test.ts
+++ b/packages/webapp/tests/shell/request-body-provenance.test.ts
@@ -87,6 +87,27 @@ describe('parkReadBytes', () => {
   it('does not report a string it never parked', () => {
     expect(lookupReadBytes('never read')).toBeNull();
   });
+
+  it('stops resolving a string two reads decoded from different bytes', () => {
+    // A latin1 file holding `E9` and a UTF-8 file holding `C3 A9` both read as
+    // "é". Neither can claim a body typed as "é", so the string goes quiet.
+    parkReadBytes('é', new Uint8Array([0xe9]));
+    parkReadBytes('é', utf8('é'));
+    expect(lookupReadBytes('é')).toBeNull();
+  });
+
+  it('keeps resolving when the same file is read twice', () => {
+    parkReadBytes('é', utf8('é'));
+    parkReadBytes('é', utf8('é'));
+    expect(Array.from(lookupReadBytes('é') as Uint8Array)).toEqual(Array.from(utf8('é')));
+  });
+
+  it('stays quiet for a poisoned string even if a third read follows', () => {
+    parkReadBytes('é', new Uint8Array([0xe9]));
+    parkReadBytes('é', utf8('é'));
+    parkReadBytes('é', new Uint8Array([0xe9]));
+    expect(lookupReadBytes('é')).toBeNull();
+  });
 });
 
 describe('resolveExactRequestBody', () => {

--- a/packages/webapp/tests/shell/request-body-provenance.test.ts
+++ b/packages/webapp/tests/shell/request-body-provenance.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Byte provenance for VFS reads that become request bodies, and the two
+ * decisions it takes out of the Content-Type's hands (see
+ * `src/shell/request-body-provenance.ts`).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { getFetchBodyBytes } from '../../src/shell/fetch-body.js';
+import { prepareRequestBody, resolveExactRequestBody } from '../../src/shell/proxied-fetch.js';
+import {
+  clearReadByteProvenance,
+  lookupReadBytes,
+  parkReadBytes,
+} from '../../src/shell/request-body-provenance.js';
+
+const utf8 = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+/** The string a latin1 (one char per byte) read of `bytes` returns. */
+function latin1(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += String.fromCharCode(byte);
+  return out;
+}
+
+async function bodyBytes(body: BodyInit | undefined): Promise<Uint8Array> {
+  return new Uint8Array(await new Response(body).arrayBuffer());
+}
+
+afterEach(() => {
+  clearReadByteProvenance();
+});
+
+describe('parkReadBytes', () => {
+  it('recovers the exact bytes a decoded string came from', () => {
+    const bytes = utf8('plan → ship');
+    parkReadBytes('plan → ship', bytes);
+    expect(lookupReadBytes('plan → ship')).toBe(bytes);
+  });
+
+  it('does not park an all-ASCII read — latin1 and UTF-8 agree on it', () => {
+    parkReadBytes('plain ascii', utf8('plain ascii'));
+    expect(lookupReadBytes('plain ascii')).toBeNull();
+  });
+
+  it('does not park an empty read', () => {
+    parkReadBytes('', new Uint8Array(0));
+    expect(lookupReadBytes('')).toBeNull();
+  });
+
+  it('also parks the newline-free form, which is what `curl -d @file` sends', () => {
+    const bytes = utf8('a → 1\nb → 2\r\n');
+    parkReadBytes('a → 1\nb → 2\r\n', bytes);
+    const stripped = lookupReadBytes('a → 1b → 2');
+    expect(stripped).not.toBeNull();
+    expect(Array.from(stripped as Uint8Array)).toEqual(Array.from(utf8('a → 1b → 2')));
+  });
+
+  it('keeps the entry available for repeated lookups (a redirect re-sends the body)', () => {
+    parkReadBytes('é', utf8('é'));
+    expect(lookupReadBytes('é')).not.toBeNull();
+    expect(lookupReadBytes('é')).not.toBeNull();
+  });
+
+  it('refuses a read past the parking budget', () => {
+    const huge = new Uint8Array(9 * 1024 * 1024);
+    huge.fill(0xc3);
+    parkReadBytes('past the budget', huge);
+    expect(lookupReadBytes('past the budget')).toBeNull();
+  });
+
+  it('evicts oldest-first once the budget is spent', () => {
+    const chunk = (fill: number): Uint8Array => {
+      const bytes = new Uint8Array(3 * 1024 * 1024);
+      bytes.fill(fill);
+      return bytes;
+    };
+    const first = chunk(0x81);
+    const second = chunk(0x82);
+    const third = chunk(0x83);
+    parkReadBytes('first', first);
+    parkReadBytes('second', second);
+    parkReadBytes('third', third);
+    expect(lookupReadBytes('first')).toBeNull();
+    expect(lookupReadBytes('third')).toBe(third);
+  });
+
+  it('does not report a string it never parked', () => {
+    expect(lookupReadBytes('never read')).toBeNull();
+  });
+});
+
+describe('resolveExactRequestBody', () => {
+  it('swaps a parked string for its bytes', () => {
+    const bytes = utf8('café → ok');
+    parkReadBytes('café → ok', bytes);
+    expect(resolveExactRequestBody('café → ok')).toBe(bytes);
+  });
+
+  it('leaves an unparked string, bytes and undefined alone', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(resolveExactRequestBody('hand-typed')).toBe('hand-typed');
+    expect(resolveExactRequestBody(bytes)).toBe(bytes);
+    expect(resolveExactRequestBody(undefined)).toBeUndefined();
+    expect(resolveExactRequestBody('')).toBe('');
+  });
+});
+
+describe('prepareRequestBody with a parked read', () => {
+  it('sends a payload that is not valid UTF-8 verbatim under a text Content-Type', async () => {
+    // A UTF-8 JSON body plus one stray byte: the read falls back to latin1 for
+    // the whole file, and UTF-8-encoding that string would double-encode every
+    // arrow (`E2 86 92` → `C3 A2 C2 86 C2 92`).
+    const onDisk = new Uint8Array([...utf8('{"note":"a → b"}'), 0xff]);
+    const asRead = latin1(onDisk);
+    parkReadBytes(asRead, onDisk);
+    const prepared = prepareRequestBody(asRead, { 'Content-Type': 'application/json' });
+    expect(await bodyBytes(prepared)).toEqual(onDisk);
+  });
+
+  it('sends valid UTF-8 verbatim under a binary Content-Type', async () => {
+    const onDisk = utf8('{"note":"a → b"}');
+    parkReadBytes('{"note":"a → b"}', onDisk);
+    const prepared = prepareRequestBody('{"note":"a → b"}', {
+      'Content-Type': 'application/octet-stream',
+    });
+    expect(await bodyBytes(prepared)).toEqual(onDisk);
+  });
+
+  it('falls back to the Content-Type convention for an unparked string', async () => {
+    const prepared = prepareRequestBody('{"note":"a → b"}', {
+      'Content-Type': 'application/json',
+    });
+    expect(prepared).toBe('{"note":"a → b"}');
+  });
+});
+
+describe('getFetchBodyBytes', () => {
+  it('reads a latin1 byte string one byte per char', () => {
+    const bytes = new Uint8Array([0x00, 0x80, 0xff, 0x41]);
+    expect(Array.from(getFetchBodyBytes(latin1(bytes)))).toEqual(Array.from(bytes));
+  });
+
+  it('UTF-8-encodes a string that cannot be a byte string instead of masking it', () => {
+    // `→` is U+2192; masking it to `0x92` was silent corruption.
+    expect(Array.from(getFetchBodyBytes('→'))).toEqual([0xe2, 0x86, 0x92]);
+  });
+
+  it('passes bytes through untouched', () => {
+    const bytes = new Uint8Array([0xff, 0xd8]);
+    expect(getFetchBodyBytes(bytes)).toBe(bytes);
+  });
+});


### PR DESCRIPTION
## Summary

`curl -d @file` / `--data-binary @file` / `-T file` silently corrupted a request body whenever the read's decoding and the fetch boundary's encoding disagreed. Before: a payload that was not valid UTF-8 went out double-encoded under `application/json` (45 bytes as 57, `E2 86 92` as `C3 A2 C2 86 C2 92` — an arrow as `â†’`), and valid UTF-8 collapsed onto one byte per character under `application/octet-stream` (44 bytes as 37, an arrow as a lone `0x92`). Now the bytes on the wire are the bytes on disk in every combination.

## Why

just-bash types `SecureFetchOptions.body` as `string`, so a file-backed body makes a round trip through two independent guesses:

- `VfsAdapter.readFile` decodes — strict UTF-8, or one-char-per-byte latin1 when that fails;
- `prepareRequestBody` re-encodes — latin1 when the Content-Type is not text-shaped, UTF-8 otherwise.

They are inverses only when both land on the same convention. Crossed, they corrupt, and the request still succeeds, so the damage shows up later as mojibake in whatever the server stored. The double-encode signature starts at U+00E2, not U+00C2, so a regex hunting for `Â` misses it — counting C1-range characters is the reliable test, and the new test asserts zero.

**Repro** (fails on `main`, passes here):

1. `npx vitest run packages/webapp/tests/shell/curl-request-body-encoding.test.ts`
2. The two crossed cases are `--data-binary @file whose bytes are not valid UTF-8, under a text Content-Type` and `--data-binary @file with a UTF-8 payload, under a binary Content-Type`.

Expected: the wire bytes equal the file's bytes.
Actual on `main`: 45 bytes sent as 57 with 6 C1 characters, and 44 bytes sent as 37.

## Approach / Implementation notes

A string cannot carry which decoding ran — `café` read from a UTF-8 file and from a latin1 file are the same string — so no rule at the fetch boundary can recover the file's bytes from it. Rejected on that basis: sniffing the string (would corrupt the common "UTF-8 JSON with an accent" case) and picking one convention globally (breaks the other half).

Instead the read records what it knows. New `shell/request-body-provenance.ts` parks the exact bytes under the string `readFile` returned, and `resolveExactRequestBody` swaps them back in at the fetch boundary. A hit is proof rather than a heuristic, because the key is the string itself; a miss falls back to today's Content-Type convention, so nothing that already worked changes.

- It is the request-side sibling of `binary-cache.ts`, which already does this for response bodies on their way to `writeFile`.
- Bounded: 8 MiB parked at once with oldest-first eviction, 10 s TTL, and all-ASCII reads skipped (latin1 and UTF-8 agree on them). Lookups do not consume the entry — a redirect re-sends the body.
- It also parks the newline-free form, because that is the string `curl -d @file` actually sends. Dropping CR/LF cannot disturb a UTF-8 sequence, whose continuation bytes are all ≥0x80.
- Provenance is per-realm, so the worker→page hop resolves the body **before** the panel-RPC call, in the realm that holds the bytes.

Second change: `getFetchBodyBytes` no longer masks a code unit above `0xFF`. Such a string was never a latin1 byte string, and `charCodeAt(i) & 0xff` dropped the high bits (U+2192 → `0x92`). It is UTF-8-encoded instead.

Known limit: a body the shell assembles from several pieces (`-F` multipart, `-d a=1 -d @f`) has no single parked string and still rides the Content-Type convention. The complete fix is upstream — `SecureFetchOptions.body` accepting a `Uint8Array` so curl never builds a string.

## Cross-cutting impact

- **Floats exercised**: CLI (`/api/fetch-proxy` branch, covered by the new end-to-end test) and, by construction, the extension Port branch and the worker→page panel-RPC branch — all three now see either a Unicode string or exact bytes. Nothing native changed.
- **Other callers of the changed contracts**: `prepareRequestBody` gains one lookup before its existing logic and is otherwise untouched (`prepare-request-body.test.ts`, the git-packfile regression suite, still passes unchanged). `getFetchBodyBytes` is also called on RESPONSE bodies by `di/fetcher`, `ipk/registry`, `upgrade-command`, `upskill/github-zip` and `work-unit/capability/request-body`; those hand it a `Uint8Array` or a latin1 string, neither of which can hold a code unit above `0xFF`, so their behavior is identical.
- **Persisted state**: none. The parking table is in-memory with a 10 s TTL.
- **Memory**: every non-ASCII read under the cap retains its bytes for 10 s, bounded at 8 MiB in total across entries.

## Test plan

- [x] `npx vitest run packages/webapp/tests/shell/curl-request-body-encoding.test.ts` — 7 passing; end to end through `AlmostBashShellHeadless` → just-bash curl → `SecureFetch` → mocked `/api/fetch-proxy`, asserting wire bytes for both crossed cases plus UTF-8 JSON, `-d @file` newline stripping, a PNG, inline `-d`, and `-T`.
- [x] `npx vitest run packages/webapp/tests/shell/request-body-provenance.test.ts` — 16 passing; parking rules (ASCII skip, newline variant, budget refusal, oldest-first eviction, repeat lookups), `resolveExactRequestBody`, `prepareRequestBody` with a parked read, `getFetchBodyBytes`.
- [x] `npm run verify` — 8/8 checks
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 21,049 passing, 61 skipped, no new failures
- [x] `npm run test:coverage`
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK, budgets unchanged
- [x] No UI change, so no screencast

**Pre-existing failures**: none observed.

## Documentation

- [x] `docs/` — `docs/shell-reference.md` → Proxied Fetch / Request Bodies documents byte provenance and the `getFetchBodyBytes` rule
- [ ] No other tier applies (no user-facing UI change, no shell-command surface change)

## Risk & rollback

Blast radius is the shell's request-body path in every float. The fallback is today's behavior, so a provenance miss cannot be worse than `main`; the new risk is the opposite direction — sending raw bytes where a re-encode was wanted — which requires an exact string match against a read this realm just did. Reverts cleanly: one commit, no migration, no flag.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public API / shell-command changes are intentional and reflected in docs
- [x] Contract shared across floats (CLI ↔ extension ↔ worker) checked on all three legs
