### PR TITLE
feat(webapp): let a human hand SLICC a secret from the UI

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -87,11 +87,13 @@ The swift-server also supports `--env-file` for loading additional secrets from 
 
 ### Option 3: the composer (UI)
 
-**Share secret securely** in the composer's `+` menu (below file upload and screen sharing) opens a secret-entry dialog: name, value (masked as you type, with a reveal toggle), and an **Additional options** drawer holding one row per allowed domain (− / + to edit the list) and a **Keep after this session** checkbox. Unchecked — the default — the secret is session-only; checked, it persists to `.env`/Keychain/`chrome.storage.local` like `--persist`.
+**Share secret securely** in the composer's `+` menu (below file upload and screen sharing) opens a secret-entry dialog: name, value (masked as you type, with a reveal toggle), and an **Additional options** drawer — open from the start — holding one row per allowed domain (− / + to edit the list) and a **Keep after this session** checkbox. There is no default scope: at least one domain must be typed, so a credential is never stored against a wildcard nobody read. Unchecked — the default — the secret is session-only; checked, it persists to `.env`/Keychain/`chrome.storage.local` like `--persist`.
 
 The agent can also ask for one: the `request_secret` tool ([tools reference](tools-reference.md)) opens the same dialog with the agent's stated reason, so a credential request is always answered by a human at a real browser prompt rather than by the agent typing a value it read somewhere. Declining is a normal outcome and is reported back as an error so the agent stops instead of guessing.
 
-Either way the typed value goes straight from the dialog to the trusted-realm store; the agent's realm receives only `{ name, maskedValue, domains, persisted }` and the masked value is published as `$NAME` in the agent shell (subject to the POSIX-name rule above). The dialog mounts into the **trusted layer**, above every panel and sprinkle, so page content can neither cover it nor forge a look-alike "enter your API key" form.
+Either way the typed value goes straight from the dialog to the trusted-realm store; the agent's realm receives only `{ name, maskedValue, domains, persisted }`. The two paths differ in what reaches the shell: `request_secret` publishes the mask as `$NAME` in the requesting unit's shell (subject to the POSIX-name rule above), while the composer path puts the mask in the draft and points at `secret get <name>`, because the composer has no handle on a running shell. The proxy unmasks at the network boundary in both cases.
+
+The dialog mounts into the **trusted layer**, above every panel and sprinkle, so page content can neither cover it nor forge a look-alike "enter your API key" form. A float with no trusted layer refuses to prompt at all and reports the request as unavailable — `secret set` and the settings UI remain the way in.
 
 ## The `secret` shell command
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -85,6 +85,14 @@ security add-generic-password \
 
 The swift-server also supports `--env-file` for loading additional secrets from a `.env` file alongside Keychain secrets.
 
+### Option 3: the composer (UI)
+
+**Share secret securely** in the composer's `+` menu (below file upload and screen sharing) opens a secret-entry dialog: name, value (masked as you type, with a reveal toggle), and an **Additional options** drawer holding one row per allowed domain (− / + to edit the list) and a **Keep after this session** checkbox. Unchecked — the default — the secret is session-only; checked, it persists to `.env`/Keychain/`chrome.storage.local` like `--persist`.
+
+The agent can also ask for one: the `request_secret` tool ([tools reference](tools-reference.md)) opens the same dialog with the agent's stated reason, so a credential request is always answered by a human at a real browser prompt rather than by the agent typing a value it read somewhere. Declining is a normal outcome and is reported back as an error so the agent stops instead of guessing.
+
+Either way the typed value goes straight from the dialog to the trusted-realm store; the agent's realm receives only `{ name, maskedValue, domains, persisted }` and the masked value is published as `$NAME` in the agent shell (subject to the POSIX-name rule above). The dialog mounts into the **trusted layer**, above every panel and sprinkle, so page content can neither cover it nor forge a look-alike "enter your API key" form.
+
 ## The `secret` shell command
 
 Inside the SLICC shell, the `secret` command manages secrets:

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -347,6 +347,35 @@ rg "createBashTool" /workspace/src --type ts
 
 ---
 
+### request_secret
+
+Ask the human for a credential the agent needs but must never read. Opens the
+secret-entry dialog in the page's trusted layer (name prefilled, the agent's
+`reason` shown verbatim, domain scope and a persist checkbox under "Additional
+options"). Resolves when the human submits or dismisses it; a 5-minute budget
+applies when the call has to cross panel-RPC to reach the page realm.
+
+**File**: `packages/webapp/src/tools/request-secret-tool.ts`
+
+| Property   | Value                                                                     |
+| ---------- | ------------------------------------------------------------------------- |
+| **Name**   | `request_secret`                                                          |
+| **Input**  | `{ name: string, reason: string, domains?: string[], persist?: boolean }` |
+| **Output** | `{ content: "Stored secret \"NAME\". Masked value: ..." }`                |
+
+The result carries only the **masked** value, its scope, and whether it was
+persisted — never the real value, in any field. The mask is also published as
+`$NAME` in the agent's shell (POSIX-named secrets only, see
+[`docs/secrets.md`](./secrets.md)), so the agent can use the credential through
+the fetch proxy without knowing it.
+
+A dismissal, or a float with no entry surface, returns `isError: true` so the
+agent stops rather than proceeding with a value it invented. `domains` defaults
+to what the human types in the dialog; a request with no domains still cannot be
+saved without one — every secret is domain-scoped.
+
+---
+
 ## Scoop Management Tools (Multi-Scoop)
 
 These tools are MCP-style tools for messaging and scoop management.
@@ -559,6 +588,7 @@ Hidden from the chat UI via `hidden-tools.ts`.
 | read_file                | ✓    | ✓ (restricted) | Active in `ScoopContext`                                              |
 | write_file               | ✓    | ✓ (restricted) | Active in `ScoopContext`                                              |
 | edit_file                | ✓    | ✓ (restricted) | Active in `ScoopContext`                                              |
+| **request_secret**       | ✓    | ✓              | Human types the value; the agent only ever receives the mask          |
 | **send_message**         | ✗    | ✓              | Scoop-only management tool (scoop→cone progress/result channel)       |
 | **list_scoops**          | ✓    | grant          | `canManageChildren` — lists the caller's subtree                      |
 | **scoop_scoop**          | ✓    | grant          | `canCreateChildren` — roots, and children given nested delegation     |

--- a/docs/webcomponents-details.md
+++ b/docs/webcomponents-details.md
@@ -509,6 +509,45 @@ a chip. Three design points, all load-bearing.
   The `summarizing` breath is a CSS animation, not a rAF loop: no frame budget,
   and it pauses with the tab on its own.
 
+## Secret entry (`<slicc-secret-dialog>`)
+
+One component serves both ways a credential arrives: the composer's `+` menu
+("Share secret securely") and the agent's `request_secret` tool. Four points are
+load-bearing.
+
+- **The value never becomes state anything else can read.** It lives only in the
+  input, is never reflected to an attribute or a property, and is cleared on
+  every close (including a reopen of the same instance). Callers get it exactly
+  once, in the `secret-submit` detail. The host that receives it — the webapp's
+  `wc-secret-request.ts` — is the only module in the app that holds a plaintext
+  credential, and it hands onward only the mask.
+- **The store's verdict decides whether the dialog closes.** The host sets
+  `submitHandler`; returning a string keeps the dialog open, with the typed value
+  intact, and shows that string as the error. A Keychain timeout must not read as
+  "saved", and it must not cost the human their typing either.
+- **`persistent`, deliberately.** Backdrop-click-to-dismiss is right for a
+  chooser and wrong here: a stray click on a half-typed credential is unrecoverable
+  work. Escape and Cancel still close it.
+- **Password by default, reveal is opt-in.** The toggle exists because a
+  mistyped secret fails later, opaquely, in a fetch the human never sees.
+  "Additional options" hides the domain rows and the persist checkbox — both
+  have safe defaults (the requester's suggested scope, session-only) so the
+  common path is name + value + Enter.
+- **One row per domain, with − / + trailing each row.** A comma-separated field
+  reads as one value and a scope is a list; the row a human edits is the row
+  whose buttons they click. The last row's − stays disabled, because the stores
+  reject a secret with no scope, so the UI never offers the state that fails.
+- **The description names the provider.** "Secure secrets cannot be read by
+  Anthropic" is checkable in a way that "the agent" is not; `wc-secret-request.ts`
+  derives the label from the selected model, and the component falls back to
+  "the model" when nothing is named.
+
+Validation is split by consequence: an empty field, a bad name charset, or a
+missing scope block submission; a non-POSIX name (no `$NAME` in the shell) or a
+wildcard scope only warn. A **multi-line paste** gets its own warning because the
+single-line input joins the breaks itself — silently mangling a PEM key the
+line-oriented stores would reject anyway (see [`docs/secrets.md`](secrets.md)).
+
 ## Slotted containment + chat-prose wrapping
 
 Extended reference for two related Conventions bullets in the package guide.

--- a/docs/webcomponents-details.md
+++ b/docs/webcomponents-details.md
@@ -517,30 +517,40 @@ load-bearing.
 
 - **The value never becomes state anything else can read.** It lives only in the
   input, is never reflected to an attribute or a property, and is cleared on
-  every close (including a reopen of the same instance). Callers get it exactly
-  once, in the `secret-submit` detail. The host that receives it — the webapp's
-  `wc-secret-request.ts` — is the only module in the app that holds a plaintext
-  credential, and it hands onward only the mask.
+  every close (including a reopen of the same instance). It reaches the host by
+  exactly two private routes: the `submitHandler` argument and the promise
+  `open()` returns. The bubbling, composed `slicc-secret-submit` event carries a
+  value-free summary (`name`, `domains`, `persist`) — that event leaves the
+  component and anything in the page can hear it, so the detail is built without
+  the credential rather than trusted not to be read. The host that receives the
+  plaintext — the webapp's `wc-secret-request.ts` — is the only module in the app
+  that holds one, and it hands onward only the mask.
 - **The store's verdict decides whether the dialog closes.** The host sets
   `submitHandler`; returning a string keeps the dialog open, with the typed value
   intact, and shows that string as the error. A Keychain timeout must not read as
-  "saved", and it must not cost the human their typing either.
+  "saved", and it must not cost the human their typing either. While that write is
+  in flight the dialog cannot be dismissed — Cancel is disabled and Escape / ✕ are
+  refused — because the write cannot be recalled, and answering "cancelled" over a
+  secret that then lands would be a lie.
 - **`persistent`, deliberately.** Backdrop-click-to-dismiss is right for a
   chooser and wrong here: a stray click on a half-typed credential is unrecoverable
   work. Escape and Cancel still close it.
 - **Password by default, reveal is opt-in.** The toggle exists because a
   mistyped secret fails later, opaquely, in a fetch the human never sees.
-  "Additional options" hides the domain rows and the persist checkbox — both
-  have safe defaults (the requester's suggested scope, session-only) so the
-  common path is name + value + Enter.
+  "Additional options" holds the domain rows and the persist checkbox, and `open()`
+  expands it every time: the scope is the entire security claim, so it is reviewed
+  rather than collapsed. There is no default scope either — with nothing suggested
+  the first row starts empty and submission is blocked until it is filled in,
+  because a wildcard the human never chose is a wildcard they never read.
 - **One row per domain, with − / + trailing each row.** A comma-separated field
   reads as one value and a scope is a list; the row a human edits is the row
   whose buttons they click. The last row's − stays disabled, because the stores
   reject a secret with no scope, so the UI never offers the state that fails.
 - **The description names the provider.** "Secure secrets cannot be read by
-  Anthropic" is checkable in a way that "the agent" is not; `wc-secret-request.ts`
-  derives the label from the selected model, and the component falls back to
-  "the model" when nothing is named.
+  Anthropic" is checkable in a way that "the agent" is not. For an agent request
+  the label comes from the ASKING unit's model (a background scoop can run on a
+  different provider than the page's selection); the composer path falls back to
+  the selected provider, and the component to "the model" when nothing is named.
 
 Validation is split by consequence: an empty field, a bad name charset, or a
 missing scope block submission; a non-POSIX name (no `$NAME` in the shell) or a

--- a/packages/webapp/src/base/provider-labels.ts
+++ b/packages/webapp/src/base/provider-labels.ts
@@ -1,0 +1,33 @@
+/**
+ * Human-readable names for provider ids, for the few places a person reads the
+ * provider rather than the machine routing on it.
+ *
+ * Lives in `base/` because both the secret-entry surface (`ui/`) and the tool
+ * wiring that supplies it (`scoops/`) need the same wording, and neither may
+ * import the other.
+ *
+ * Deliberately NOT a catalogue: an id with no entry is shown as-is. A provider
+ * added tomorrow reads slightly worse rather than reading as "unknown".
+ */
+
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  google: 'Google',
+  adobe: 'Adobe',
+  github: 'GitHub',
+  bedrock: 'AWS Bedrock',
+  azure: 'Azure',
+  'azure-openai': 'Azure OpenAI',
+  'azure-ai-foundry': 'Azure AI Foundry',
+  groq: 'Groq',
+  xai: 'xAI',
+  openrouter: 'OpenRouter',
+  local: 'your local model',
+};
+
+/** The display name for `id`, the id itself when unknown, `undefined` when absent. */
+export function providerLabel(id: string | null | undefined): string | undefined {
+  if (!id) return undefined;
+  return PROVIDER_LABELS[id] ?? id;
+}

--- a/packages/webapp/src/base/secret-request-registry.ts
+++ b/packages/webapp/src/base/secret-request-registry.ts
@@ -29,6 +29,13 @@ export interface SecretRequest {
   requester?: string;
   /** Start with "keep after this session ends" checked. */
   persist?: boolean;
+  /**
+   * The model provider serving the ASKING unit, named in the dialog as the party
+   * that cannot read the value. Carried on the request because a background scoop
+   * can run on a provider the page's selected model knows nothing about, and a
+   * promise naming the wrong company is worse than a vague one.
+   */
+  provider?: string;
 }
 
 /** A stored secret, described WITHOUT its value. */

--- a/packages/webapp/src/base/secret-request-registry.ts
+++ b/packages/webapp/src/base/secret-request-registry.ts
@@ -1,0 +1,75 @@
+/**
+ * Per-realm singleton holding the page's secret-entry surface — the one place
+ * a human hands SLICC a credential.
+ *
+ * Lives in `base/` (the bottom rung of the layer stack) so every ranked layer
+ * can resolve it without importing upward: `tools/request-secret-tool.ts` needs
+ * it, and so would any future shell command. The UI layer owns registering it
+ * (`ui/wc/wc-secret-request.ts` is the only setter).
+ *
+ * The surface, not its callers, holds the plaintext: it opens
+ * `<slicc-secret-dialog>` in the trusted layer, writes to the secret store, and
+ * hands back only the MASKED stand-in. That is what makes it safe for an
+ * agent-invoked tool to trigger — the tool learns a name and a mask, never the
+ * credential.
+ *
+ * `null` when no surface is registered (a follower with no reachable secret
+ * store, pre-boot, or after dispose).
+ */
+
+/** What the caller is asking a human for. */
+export interface SecretRequest {
+  /** Suggested secret name (`GITHUB_TOKEN`, `s3.r2.access_key_id`). */
+  name?: string;
+  /** Suggested domain allowlist; the human can edit or widen it. */
+  domains?: string[];
+  /** Why it is needed. Shown verbatim, so keep it one plain sentence. */
+  reason?: string;
+  /** Who is asking — a system-derived label, never model-authored prose. */
+  requester?: string;
+  /** Start with "keep after this session ends" checked. */
+  persist?: boolean;
+}
+
+/** A stored secret, described WITHOUT its value. */
+export interface SecretRequestStored {
+  stored: true;
+  /** The store key the human confirmed (may differ from the suggestion). */
+  name: string;
+  /**
+   * The session-stable masked stand-in. Safe for agent context: the fetch proxy
+   * swaps in the real value at the network boundary, and only for `domains`.
+   * `null` when the store accepted the write but could not report a mask.
+   */
+  maskedValue: string | null;
+  /** The scope the human confirmed. */
+  domains: string[];
+  /** true → written to the saved store; false → in-memory for this session. */
+  persisted: boolean;
+}
+
+/** Nothing was stored, and why. */
+export interface SecretRequestDeclined {
+  stored: false;
+  /** `cancelled` — the human dismissed the dialog; `unavailable` — no surface. */
+  reason: 'cancelled' | 'unavailable' | 'failed';
+  /** Operator-readable detail for `failed`. */
+  detail?: string;
+}
+
+export type SecretRequestOutcome = SecretRequestStored | SecretRequestDeclined;
+
+/** The page-realm capability the registry hands out. */
+export type SecretRequestSurface = (request: SecretRequest) => Promise<SecretRequestOutcome>;
+
+let surface: SecretRequestSurface | null = null;
+
+/** The registered secret-entry surface, or `null` when this float has none. */
+export function getSecretRequestSurface(): SecretRequestSurface | null {
+  return surface;
+}
+
+/** Register the surface. Passing `null` clears the registry. */
+export function setSecretRequestSurface(value: SecretRequestSurface | null): void {
+  surface = value;
+}

--- a/packages/webapp/src/kernel/panel-rpc.ts
+++ b/packages/webapp/src/kernel/panel-rpc.ts
@@ -44,6 +44,7 @@ import type {
   OAuthExtraDomainsStore,
   SignAndForwardReply,
 } from '@slicc/shared-ts';
+import type { SecretRequest, SecretRequestOutcome } from '../base/secret-request-registry.js';
 import type {
   DockTreeSpecLike,
   DockZoneName,
@@ -683,6 +684,22 @@ export type PanelRpcRequest =
       };
     }
   | {
+      // Ask a human for a credential through the page's secret-entry surface
+      // (`ui/wc/wc-secret-request.ts`), which the kernel-worker realm cannot
+      // raise itself (no DOM, no trusted layer). Mirrors `permission-request`:
+      // the worker sends the framing, the page owns the dialog.
+      //
+      // The plaintext NEVER crosses back over this bridge — the page writes it
+      // straight to the secret store and the result carries only the name, the
+      // masked stand-in, and the confirmed scope. That is what makes this op
+      // safe to expose to an agent-invoked tool.
+      //
+      // Payload and result are the registry's own types, referenced rather than
+      // restated, so a field cannot exist on one side of this boundary only.
+      op: 'secret-request';
+      payload: SecretRequest;
+    }
+  | {
       op: 'theme-apply';
       payload: { themeJson?: string; action: 'apply' | 'reset' };
     }
@@ -878,6 +895,8 @@ export interface PanelRpcResults {
     body: ArrayBuffer;
   };
   'permission-request': { grants: PermissionRpcGrant[] };
+  // Value-free by construction: see the `secret-request` op comment.
+  'secret-request': SecretRequestOutcome;
   'sudo-request': { decision: SudoDecision; handled?: boolean };
   'secrets-bridge': { response: unknown };
   'mount-sign-and-forward': { response: SignAndForwardReply };

--- a/packages/webapp/src/scoops/scoop-context/tools.ts
+++ b/packages/webapp/src/scoops/scoop-context/tools.ts
@@ -17,7 +17,7 @@ import type { ProcessManager, ProcessOwner } from '../../kernel/process-manager.
 import { resolveModelSelectionForScoop } from '../../providers/account-store.js';
 import type { AlmostBashShellHeadless } from '../../shell/almost-bash-shell-headless.js';
 import type { TurnGuestGate } from '../../sudo/types.js';
-import { createBashTool, createFileTools } from '../../tools/index.js';
+import { createBashTool, createFileTools, createRequestSecretTool } from '../../tools/index.js';
 import type { BashJobProcess } from '../../tools/types.js';
 import type { WorkUnitDescriptor } from '../../work-unit/types.js';
 import type { ScoopContextCallbacks } from '../scoop-context.js';
@@ -153,6 +153,14 @@ export async function buildScoopTools(deps: ScoopToolsDeps) {
       },
     }),
     ...scoopManagementTools,
+    // Asking a human for a credential. The tool never receives the value — the
+    // page's entry surface stores it and reports back a mask — so the shell-env
+    // hook below can only ever publish a masked stand-in, exactly like
+    // `secret set`.
+    createRequestSecretTool({
+      requester: scoop.assistantLabel || scoop.name,
+      setEnv: (name, maskedValue) => deps.shell.setMaskedEnvVar(name, maskedValue),
+    }),
   ];
 
   if (scoop.config?.structuredOutputSchema) {

--- a/packages/webapp/src/scoops/scoop-context/tools.ts
+++ b/packages/webapp/src/scoops/scoop-context/tools.ts
@@ -10,6 +10,7 @@
  * to be read alongside the retry loop.
  */
 
+import { providerLabel } from '../../base/provider-labels.js';
 import { adaptTools, createLogger, type ToolAdapterGateConfig } from '../../core/index.js';
 import { getToolResultScrubber } from '../../core/secret-scrub.js';
 import type { VirtualFS } from '../../fs/index.js';
@@ -26,6 +27,7 @@ import {
   type ScoopManagementToolsConfig,
 } from '../scoop-management-tools.js';
 import type { RegisteredScoop } from '../types.js';
+import { resolveScoopModel } from './model-resolution.js';
 
 const log = createLogger('scoop-context');
 
@@ -160,6 +162,10 @@ export async function buildScoopTools(deps: ScoopToolsDeps) {
     createRequestSecretTool({
       requester: scoop.assistantLabel || scoop.name,
       setEnv: (name, maskedValue) => deps.shell.setMaskedEnvVar(name, maskedValue),
+      // THIS unit's provider, resolved per call. A background scoop can run on a
+      // provider the page's selected model knows nothing about, and the dialog
+      // promises the credential is unreadable by whoever is actually serving it.
+      getProvider: () => providerLabel(resolveScoopModel(scoop).provider),
     }),
   ];
 

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -739,6 +739,23 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     return { ...this.lastEnv };
   }
 
+  /**
+   * Publish a masked secret value as `$name` for the rest of the session.
+   *
+   * The same write `secret set` performs through its internal `setEnv` hook,
+   * exposed for callers OUTSIDE a `bash.exec()` — the `request_secret` tool,
+   * whose secret is stored by the page while no command is running. Queued as
+   * well as applied because the next `exec` overwrites `lastEnv` with its own
+   * snapshot, which does not know about this write.
+   *
+   * Masked values only: a real credential in the shell env is exactly what the
+   * masking pipeline exists to prevent.
+   */
+  setMaskedEnvVar(name: string, maskedValue: string): void {
+    this.pendingEnvWrites.set(name, maskedValue);
+    this.lastEnv[name] = maskedValue;
+  }
+
   /** Merge per-request overrides into a persistent terminal shell. */
   applySessionOverrides(options: { cwd?: string; env?: Record<string, string> }): void {
     if (options.cwd !== undefined) {

--- a/packages/webapp/src/tools/index.ts
+++ b/packages/webapp/src/tools/index.ts
@@ -1,2 +1,6 @@
 export { createBashTool } from './bash-tool.js';
 export { createFileTools } from './file-tools.js';
+export {
+  createRequestSecretTool,
+  type RequestSecretToolDeps,
+} from './request-secret-tool.js';

--- a/packages/webapp/src/tools/request-secret-tool.ts
+++ b/packages/webapp/src/tools/request-secret-tool.ts
@@ -1,0 +1,229 @@
+/**
+ * `request_secret` — the agent asks a human for a credential it must never see.
+ *
+ * The tool does not collect the value; it triggers the page's secret-entry
+ * surface (`ui/wc/wc-secret-request.ts`), which stores the credential in the
+ * trusted realm and reports back only the NAME, the session-stable MASKED
+ * stand-in, and the confirmed domain scope. Whatever the model does with that
+ * result, it cannot exfiltrate a value it was never given: the fetch proxy swaps
+ * the mask for the real value at the network boundary, and only for the allowed
+ * domains.
+ *
+ * Two realms reach the surface:
+ *  - **page realm** (extension offscreen doc, fixtures) — the registry directly;
+ *  - **kernel worker** (standalone leader, cloud cone) — the `secret-request`
+ *    panel-RPC op, mirroring how `ffmpeg` reaches `<slicc-permissions>`.
+ *
+ * A float with no surface (a follower, no leader UI) reports that plainly rather
+ * than hanging: the human it would prompt is not there.
+ */
+
+import { createLogger } from '../base/logger.js';
+import type { SecretRequest, SecretRequestOutcome } from '../base/secret-request-registry.js';
+import { getSecretRequestSurface } from '../base/secret-request-registry.js';
+import { isValidShellEnvName } from '../base/shell-env-name.js';
+import type { ToolDefinition, ToolResult } from './types.js';
+
+const log = createLogger('tool:request-secret');
+
+/**
+ * How long the bridged request may wait for a human. Matches the
+ * `permission-request` budget — someone has to find the credential in a password
+ * manager first, and a shorter cap turns a normal pause into a failure.
+ */
+const SECRET_REQUEST_TIMEOUT_MS = 5 * 60_000;
+
+export interface RequestSecretToolDeps {
+  /**
+   * Write the masked value into the owning shell's live env, so `$NAME` resolves
+   * for the rest of the session exactly as it does after `secret set`. Omitted
+   * (or skipped for a non-POSIX name) leaves the mask usable inline only.
+   */
+  setEnv?: (name: string, value: string) => void;
+  /** Label shown as "who is asking" in the dialog. System-derived. */
+  requester?: string;
+  /** Panel-RPC seam (tests). Defaults to the realm's client, if any. */
+  callPanelRpc?: (request: SecretRequest) => Promise<SecretRequestOutcome>;
+}
+
+/** Resolve the request through whichever realm can reach a human. */
+async function requestSecret(
+  request: SecretRequest,
+  deps: RequestSecretToolDeps
+): Promise<SecretRequestOutcome> {
+  // Page realm: the surface is right here. Resolved per call, not captured, so a
+  // tool built before the leader UI booted still finds it.
+  const surface = getSecretRequestSurface();
+  if (surface) return surface(request);
+
+  const bridged = deps.callPanelRpc ?? (await defaultPanelRpcBridge());
+  if (bridged) return bridged(request);
+
+  return { stored: false, reason: 'unavailable' };
+}
+
+/** The kernel-worker bridge, when this realm has a panel-RPC client. */
+async function defaultPanelRpcBridge(): Promise<
+  ((request: SecretRequest) => Promise<SecretRequestOutcome>) | null
+> {
+  const { getPanelRpcClient } = await import('../kernel/panel-rpc.js');
+  const client = getPanelRpcClient();
+  if (!client) return null;
+  return (request) =>
+    client.call('secret-request', request, { timeoutMs: SECRET_REQUEST_TIMEOUT_MS });
+}
+
+/** Parse the model's `domains` argument; a non-array or empty list means "unset". */
+function readDomains(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const domains = raw
+    .filter((d): d is string => typeof d === 'string')
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+  return domains.length > 0 ? domains : undefined;
+}
+
+/** The success report — name, mask, scope, lifetime. Never a value. */
+function describeStored(
+  outcome: Extract<SecretRequestOutcome, { stored: true }>,
+  envInjected: boolean
+): string {
+  const lines = [
+    `The user stored the secret "${outcome.name}".`,
+    `Scope: ${outcome.domains.join(', ')} — it is only unmasked for requests to these hosts.`,
+    outcome.persisted
+      ? 'Lifetime: saved (survives this session).'
+      : 'Lifetime: this session only (held in memory).',
+  ];
+  if (outcome.maskedValue) {
+    lines.push(
+      `Masked value: ${outcome.maskedValue}`,
+      'Use the masked value wherever the credential goes (headers, request bodies). SLICC ' +
+        'substitutes the real value at the network boundary. You will never see the real value.'
+    );
+    if (envInjected) lines.push(`It is also available as $${outcome.name} in bash.`);
+  } else {
+    lines.push(
+      `The store did not report a masked value; run \`secret get ${outcome.name}\` to read it.`
+    );
+  }
+  return lines.join('\n');
+}
+
+/** Why nothing was stored, phrased so the model stops asking. */
+function describeDeclined(outcome: Extract<SecretRequestOutcome, { stored: false }>): string {
+  switch (outcome.reason) {
+    case 'cancelled':
+      return 'The user dismissed the secret prompt — nothing was stored. Do not retry; ask what to do instead.';
+    case 'unavailable':
+      return 'This float cannot prompt for a secret (no secret-entry surface). Ask the user to add it from the leader UI or with `secret set`.';
+    default:
+      return `The secret could not be stored${outcome.detail ? `: ${outcome.detail}` : ''}.`;
+  }
+}
+
+/**
+ * Build the `request_secret` tool.
+ *
+ * @param deps - shell-env injection hook + the requester label shown to the human
+ */
+export function createRequestSecretTool(deps: RequestSecretToolDeps = {}): ToolDefinition {
+  return {
+    name: 'request_secret',
+    description:
+      'Ask the user for a credential (API key, token, password) through a secure prompt. ' +
+      'You never receive the real value: the result carries only the secret name, a masked ' +
+      'stand-in to use in requests, and the domains it may be sent to. Use this instead of ' +
+      'asking for a credential in chat, which would put it in the transcript.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description:
+            'Suggested secret name, e.g. GITHUB_TOKEN. Use an uppercase POSIX identifier so it ' +
+            'is also available as $NAME in bash. The user can change it.',
+        },
+        reason: {
+          type: 'string',
+          description:
+            'One plain sentence saying what the credential is for. Shown verbatim to the user.',
+        },
+        domains: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Suggested hosts the value may be sent to, e.g. ["api.github.com", "*.github.com"]. ' +
+            'Be as narrow as the task allows; the user reviews and can edit this.',
+        },
+        persist: {
+          type: 'boolean',
+          description:
+            'Suggest keeping the secret beyond this session. Defaults to false (session-only).',
+        },
+      },
+      required: ['name', 'reason'],
+    },
+    async execute(input): Promise<ToolResult> {
+      const name = typeof input.name === 'string' ? input.name.trim() : '';
+      const reason = typeof input.reason === 'string' ? input.reason.trim() : '';
+      if (!name || !reason) {
+        return { content: 'request_secret needs both `name` and `reason`.', isError: true };
+      }
+
+      const request: SecretRequest = {
+        name,
+        reason,
+        domains: readDomains(input.domains),
+        persist: input.persist === true,
+        requester: deps.requester,
+      };
+
+      let outcome: SecretRequestOutcome;
+      try {
+        outcome = await requestSecret(request, deps);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('secret request failed', { name, error: message });
+        return { content: `The secret prompt failed: ${message}`, isError: true };
+      }
+
+      if (!outcome.stored) {
+        // A decline is a real answer, not a tool malfunction — but it must read
+        // as a failure so the model does not proceed as if it has the credential.
+        return { content: describeDeclined(outcome), isError: true };
+      }
+
+      const envInjected = injectMaskedEnv(outcome.name, outcome.maskedValue, deps);
+      log.info('secret stored via request_secret', {
+        name: outcome.name,
+        persisted: outcome.persisted,
+      });
+      return { content: describeStored(outcome, envInjected) };
+    },
+  };
+}
+
+/**
+ * Best-effort `$NAME` parity with `secret set`. Skipped for a name that is not a
+ * POSIX identifier (a dotted subsystem secret would not resolve in a shell
+ * anyway) and for a store that reported no mask. Never fails the tool call: the
+ * secret is already stored by this point.
+ */
+function injectMaskedEnv(
+  name: string,
+  maskedValue: string | null,
+  deps: RequestSecretToolDeps
+): boolean {
+  if (!deps.setEnv || !maskedValue || !isValidShellEnvName(name)) return false;
+  try {
+    deps.setEnv(name, maskedValue);
+    return true;
+  } catch (err) {
+    log.warn('could not inject the masked value into the shell env', {
+      name,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/packages/webapp/src/tools/request-secret-tool.ts
+++ b/packages/webapp/src/tools/request-secret-tool.ts
@@ -42,6 +42,13 @@ export interface RequestSecretToolDeps {
   setEnv?: (name: string, value: string) => void;
   /** Label shown as "who is asking" in the dialog. System-derived. */
   requester?: string;
+  /**
+   * The provider serving THIS unit, named in the dialog as the party that cannot
+   * read the value. Read per call, not captured: a unit's model can be switched
+   * mid-session, and the dialog must name whoever is actually about to receive
+   * the mask.
+   */
+  getProvider?: () => string | undefined;
   /** Panel-RPC seam (tests). Defaults to the realm's client, if any. */
   callPanelRpc?: (request: SecretRequest) => Promise<SecretRequestOutcome>;
 }
@@ -71,6 +78,21 @@ async function defaultPanelRpcBridge(): Promise<
   if (!client) return null;
   return (request) =>
     client.call('secret-request', request, { timeoutMs: SECRET_REQUEST_TIMEOUT_MS });
+}
+
+/**
+ * This unit's provider, or `undefined`. Never fatal: the dialog falls back to
+ * generic wording, and a resolver that throws must not cost the human a prompt.
+ */
+function readProvider(deps: RequestSecretToolDeps): string | undefined {
+  try {
+    return deps.getProvider?.() || undefined;
+  } catch (err) {
+    log.warn('could not resolve this unit’s provider for the secret prompt', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
 }
 
 /** Parse the model's `domains` argument; a non-array or empty list means "unset". */
@@ -177,6 +199,7 @@ export function createRequestSecretTool(deps: RequestSecretToolDeps = {}): ToolD
         domains: readDomains(input.domains),
         persist: input.persist === true,
         requester: deps.requester,
+        provider: readProvider(deps),
       };
 
       let outcome: SecretRequestOutcome;

--- a/packages/webapp/src/ui/panel-rpc-handlers.ts
+++ b/packages/webapp/src/ui/panel-rpc-handlers.ts
@@ -298,6 +298,7 @@ export function createStandalonePanelRpcHandlers(
     ...buildPermissionRequestHandler(options),
     ...buildProxiedFetchHandler(),
     ...buildSudoRequestHandler(),
+    ...buildSecretRequestHandler(),
     ...buildSecretsBridgeHandler(),
     ...buildMountBridgeHandler(),
     ...buildThemeHandler(),
@@ -359,6 +360,27 @@ function buildSudoRequestHandler() {
     'sudo-request': async ({ request, mode }) => {
       const { resolveSudoApprovalInPage } = await import('../sudo/page-approval-service.js');
       return resolveSudoApprovalInPage(request, mode ?? 'resolve');
+    },
+  } satisfies Partial<PanelRpcHandlers>;
+}
+
+/**
+ * `secret-request`: raise the page's secret-entry dialog for a worker-realm
+ * caller (today the `request_secret` tool) and return the VALUE-FREE outcome.
+ *
+ * The registry is consulted per call rather than captured: the surface is
+ * installed during leader boot, so a tool constructed earlier still resolves it.
+ * An absent surface resolves `{ stored: false, reason: 'unavailable' }` instead
+ * of rejecting — "this float cannot collect a secret" is an answer the caller
+ * reports to the user, not a transport failure.
+ */
+function buildSecretRequestHandler() {
+  return {
+    'secret-request': async (payload) => {
+      const { getSecretRequestSurface } = await import('../base/secret-request-registry.js');
+      const surface = getSecretRequestSurface();
+      if (!surface) return { stored: false, reason: 'unavailable' };
+      return surface(payload);
     },
   } satisfies Partial<PanelRpcHandlers>;
 }

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -796,6 +796,12 @@ function insertSkillMention(label: string, inputCard: WireWcAttachDeps['inputCar
  * The mention rides the next submit rather than being sent on its own, so the
  * user can say what the credential is for in the same turn. A dismissal leaves
  * the draft untouched: nothing was stored, so there is nothing to mention.
+ *
+ * No `$NAME` is published here, unlike the `request_secret` tool path. The
+ * composer has no handle on the running shell — masked env vars are loaded when a
+ * shell initialises — so the draft carries the mask itself, plus `secret get` as
+ * the way to look it up again. The proxy still unmasks it at the boundary either
+ * way; only the shell variable is missing.
  */
 async function stageSecret(deps: WireWcAttachDeps): Promise<void> {
   const { requestSecretFromUser } = await import('./wc-secret-request.js');

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -585,6 +585,14 @@ export interface WireWcAttachDeps {
    * (getDisplayMedia) and upload are unaffected.
    */
   noCamera?: boolean;
+  /**
+   * Offer the "Share secret securely" quick-action. Set by floats that can
+   * reach a secret store (the leader); left unset by a follower, whose menu
+   * then never shows an action that would dead-end. Selecting it opens the
+   * trusted secret dialog — the value goes straight to the store, and only the
+   * masked stand-in is mentioned in the draft.
+   */
+  secretEntry?: boolean;
   log: { error(message: string, ...data: unknown[]): void };
 }
 
@@ -769,11 +777,38 @@ async function stageVfsFile(
   stage.add(await referenceVfsFile(id, name, openReader));
 }
 
-/** Append a skill mention to the composer's draft. */
-function insertSkillMention(label: string, inputCard: WireWcAttachDeps['inputCard']): void {
+/** Append text to the composer's draft, spacing it off whatever is there. */
+function appendToDraft(text: string, inputCard: WireWcAttachDeps['inputCard']): void {
   const current = inputCard.value ?? inputCard.getAttribute('value') ?? '';
   const sep = current && !current.endsWith(' ') ? ' ' : '';
-  inputCard.setAttribute('value', `${current}${sep}Use the "${label}" skill: `);
+  inputCard.setAttribute('value', `${current}${sep}${text}`);
+}
+
+/** Append a skill mention to the composer's draft. */
+function insertSkillMention(label: string, inputCard: WireWcAttachDeps['inputCard']): void {
+  appendToDraft(`Use the "${label}" skill: `, inputCard);
+}
+
+/**
+ * Open the trusted secret dialog and tell the agent about the result IN THE
+ * DRAFT — the name, the masked stand-in, and the scope, never the value.
+ *
+ * The mention rides the next submit rather than being sent on its own, so the
+ * user can say what the credential is for in the same turn. A dismissal leaves
+ * the draft untouched: nothing was stored, so there is nothing to mention.
+ */
+async function stageSecret(deps: WireWcAttachDeps): Promise<void> {
+  const { requestSecretFromUser } = await import('./wc-secret-request.js');
+  const outcome = await requestSecretFromUser();
+  if (!outcome.stored) return;
+  const scope = outcome.domains.join(', ');
+  const lifetime = outcome.persisted ? 'saved' : 'this session only';
+  appendToDraft(
+    outcome.maskedValue
+      ? `I stored the secret ${outcome.name} (masked value ${outcome.maskedValue}, scope: ${scope}, ${lifetime}). Use the masked value — SLICC swaps in the real one at the network boundary. `
+      : `I stored the secret ${outcome.name} (scope: ${scope}, ${lifetime}). Run \`secret get ${outcome.name}\` for its masked value. `,
+    deps.inputCard
+  );
 }
 
 /** A user cancelling / denying a capture picker (getDisplayMedia's share dialog
@@ -796,6 +831,8 @@ async function handleAdd(
   } else if (detail.kind === 'file' && typeof detail.id === 'string' && deps.openReader) {
     // VFS file picks only exist when the float has a reader (leader, not follower).
     await stageVfsFile(detail.id, deps.openReader, stage, deps.log);
+  } else if (detail.kind === 'secret') {
+    await stageSecret(deps);
   } else if (detail.kind === 'skill' && typeof detail.label === 'string') {
     insertSkillMention(detail.label, deps.inputCard);
   } else if (detail.kind === 'conversation' && typeof detail.id === 'string') {
@@ -843,6 +880,10 @@ export function wireWcAttach(deps: WireWcAttachDeps): WcAttachmentStage {
     // Hide the camera "Take a photo" action where getUserMedia can't be granted
     // (extension side-panel follower). Screenshot + upload stay.
     if (deps.noCamera) menu.setAttribute('no-camera', '');
+    // Opt into the secret row only where a secret store is reachable — the
+    // action is off by default in the component precisely so a follower never
+    // offers a prompt whose write would have nowhere to land.
+    if (deps.secretEntry) menu.setAttribute('secret-action', '');
   }
 
   inputCard.addEventListener('slicc-add', (event) => {

--- a/packages/webapp/src/ui/wc/wc-live-composer.ts
+++ b/packages/webapp/src/ui/wc/wc-live-composer.ts
@@ -57,6 +57,9 @@ export function wireWcComposer(deps: {
         composer: refs.composer,
         openReader,
         openWriter: deps.openWriter,
+        // The leader can reach a secret store, so it offers the composer's
+        // "Share secret securely" action.
+        secretEntry: true,
         listConversations: async () => {
           const { readSessionsIndex } = await import('../session-freezer.js');
           const entries = await readSessionsIndex(await openReader());

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -917,6 +917,17 @@ function wireWcPermissionsSurface(
       installMountPendingConsumer({ runShell: makeDropMountRunner(boot, client) });
     })
     .catch((err) => log.warn('WC permissions surface wiring failed', err));
+
+  // The secret-entry surface rides the same boot stage for the same reason: it
+  // is the leader's one gesture-and-trust entry point for a credential, and the
+  // `request_secret` tool reaches it (directly in this realm, over the
+  // `secret-request` panel-RPC op from the kernel worker) through the registry
+  // this installs. A cherry follower installs nothing — no local secret store.
+  if ((options.standalone?.runtimeMode ?? 'standalone') !== 'cherry') {
+    void import('./wc-secret-request.js')
+      .then(({ installSecretRequestSurface }) => installSecretRequestSurface())
+      .catch((err) => log.warn('WC secret request surface wiring failed', err));
+  }
 }
 
 /**

--- a/packages/webapp/src/ui/wc/wc-secret-request.ts
+++ b/packages/webapp/src/ui/wc/wc-secret-request.ts
@@ -20,15 +20,20 @@
  *
  * `trusted-layer.ts` exists because a main-realm panel can draw a convincing
  * fake "enter your API key" form. This dialog is exactly that form, so it mounts
- * through `mountTrusted` and paints above every panel. A float that has no
- * trusted layer (a bare fixture, a test harness) falls back to `document.body`
- * with a warning rather than refusing to collect a secret the user asked to
- * share — the fallback is visually spoofable, which is why it is loud.
+ * through `mountTrusted` and paints above every panel.
+ *
+ * A float with no trusted layer FAILS CLOSED: it reports `unavailable` and never
+ * shows the form. Mounting into `document.body` instead would ask for a
+ * credential on a surface a panel can cover or impersonate, and a console warning
+ * is addressed to an operator while the risk lands on whoever is typing. "No
+ * prompt" is a recoverable state — `secret set` and the settings UI still work —
+ * whereas a credential entered into spoofable chrome is not.
  */
 
 import type { SecretDialogRequest, SliccSecretDialog } from '@slicc/webcomponents';
 
 import { createLogger } from '../../base/logger.js';
+import { providerLabel } from '../../base/provider-labels.js';
 import type { SecretRequest, SecretRequestOutcome } from '../../base/secret-request-registry.js';
 import { setSecretRequestSurface } from '../../base/secret-request-registry.js';
 import { resolveSecretTopology } from '../../core/secret-topology.js';
@@ -49,44 +54,34 @@ export interface SecretRequestSurfaceDeps {
   createDialog?: () => SliccSecretDialog;
 }
 
-/** Mount the dialog into the trusted layer, or loudly into the body. */
-function mountDialog(element: HTMLElement): void {
+/** Mount into the trusted layer, or refuse: `false` means nothing was mounted. */
+function mountDialog(element: HTMLElement): boolean {
   try {
     mountTrusted(element, document);
-  } catch {
-    log.warn(
-      'no trusted layer in this float — the secret dialog mounted into document.body and is ' +
-        'occludable by a panel (see trusted-layer.ts)'
+    return true;
+  } catch (err) {
+    log.error(
+      'no trusted layer in this float — refusing to collect a secret on spoofable chrome; ' +
+        'use `secret set` or the settings UI instead (see trusted-layer.ts)',
+      { error: err instanceof Error ? err.message : String(err) }
     );
-    document.body.append(element);
+    return false;
   }
 }
 
 /**
- * The provider the credential is being kept FROM, named in the dialog. Derived
- * from the selected model rather than passed in, so the promise on screen tracks
- * whoever is actually serving this session. Best-effort: an unreadable selection
- * falls back to the component's generic wording.
+ * The page's selected provider — the FALLBACK label, used only when the caller
+ * named none (the composer action, where the human is asking on their own
+ * behalf). Best-effort: an unreadable selection leaves the component's generic
+ * wording in place.
  */
-function providerLabel(): string | undefined {
+function selectedProviderLabel(): string | undefined {
   try {
-    const id = getSelectedProvider();
-    return id ? (PROVIDER_LABELS[id] ?? id) : undefined;
+    return providerLabel(getSelectedProvider());
   } catch {
     return undefined;
   }
 }
-
-/** Display names for the provider ids that have one worth spelling out. */
-const PROVIDER_LABELS: Record<string, string> = {
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  google: 'Google',
-  adobe: 'Adobe',
-  github: 'GitHub',
-  bedrock: 'AWS Bedrock',
-  azure: 'Azure',
-};
 
 /** Translate the registry's request into the component's prefill shape. */
 function toDialogRequest(request: SecretRequest): SecretDialogRequest {
@@ -96,7 +91,9 @@ function toDialogRequest(request: SecretRequest): SecretDialogRequest {
     reason: request.reason,
     requester: request.requester,
     persist: request.persist,
-    provider: providerLabel(),
+    // The asking unit's own provider when it named one; the page's selection is
+    // only the fallback, because a background scoop can run on a different one.
+    provider: request.provider ?? selectedProviderLabel(),
   };
 }
 
@@ -107,7 +104,8 @@ function toDialogRequest(request: SecretRequest): SecretDialogRequest {
  *
  * A failed store keeps the dialog open with the value intact (the component's
  * `submitHandler` contract), so a stalled Keychain costs a click rather than a
- * re-paste from the password manager.
+ * re-paste from the password manager. A float with no trusted layer resolves
+ * `{ stored: false, reason: 'unavailable' }` without ever showing the form.
  */
 export async function requestSecretFromUser(
   request: SecretRequest = {},
@@ -116,7 +114,8 @@ export async function requestSecretFromUser(
   const backend = deps.backend ?? createDefaultSecretBackend(resolveSecretTopology());
   const dialog =
     deps.createDialog?.() ?? (document.createElement('slicc-secret-dialog') as SliccSecretDialog);
-  (deps.mount ?? mountDialog)(dialog);
+  if (deps.mount) deps.mount(dialog);
+  else if (!mountDialog(dialog)) return { stored: false, reason: 'unavailable' };
 
   // Filled by the submit handler so the resolved outcome can describe what
   // actually landed (the human may have edited the name or the scope). Held in a

--- a/packages/webapp/src/ui/wc/wc-secret-request.ts
+++ b/packages/webapp/src/ui/wc/wc-secret-request.ts
@@ -1,0 +1,180 @@
+/**
+ * The secret-entry surface: the only place in SLICC where a human types a
+ * credential.
+ *
+ * Two callers share it — the composer's "Share secret securely" action
+ * (`wc-attach.ts`) and the agent's `request_secret` tool (page realm directly,
+ * kernel worker via the `secret-request` panel-RPC op). Both get the same
+ * chrome, and both get back the same value-free outcome.
+ *
+ * ## Why the write happens HERE
+ *
+ * The plaintext must not travel further than it has to. This module opens the
+ * dialog, hands the typed value straight to the trusted-realm secret store
+ * (node-server `/api/secrets*`, the extension SW, …) via the existing
+ * `SecretBackend`, reads the masked stand-in back, and returns only that. The
+ * caller — including a tool the model invoked — never sees the credential, so an
+ * agent asking for a secret cannot learn it by asking.
+ *
+ * ## Why the trusted layer
+ *
+ * `trusted-layer.ts` exists because a main-realm panel can draw a convincing
+ * fake "enter your API key" form. This dialog is exactly that form, so it mounts
+ * through `mountTrusted` and paints above every panel. A float that has no
+ * trusted layer (a bare fixture, a test harness) falls back to `document.body`
+ * with a warning rather than refusing to collect a secret the user asked to
+ * share — the fallback is visually spoofable, which is why it is loud.
+ */
+
+import type { SecretDialogRequest, SliccSecretDialog } from '@slicc/webcomponents';
+
+import { createLogger } from '../../base/logger.js';
+import type { SecretRequest, SecretRequestOutcome } from '../../base/secret-request-registry.js';
+import { setSecretRequestSurface } from '../../base/secret-request-registry.js';
+import { resolveSecretTopology } from '../../core/secret-topology.js';
+import { getSelectedProvider } from '../../providers/account-store.js';
+import type { SecretBackend } from '../../shell/supplemental-commands/secret-backends.js';
+import { createDefaultSecretBackend } from '../../shell/supplemental-commands/secret-backends.js';
+import { mountTrusted } from './trusted-layer.js';
+
+const log = createLogger('wc-secret-request');
+
+/** Injectable seams (tests, floats with a non-default store). */
+export interface SecretRequestSurfaceDeps {
+  /** Store to write into. Defaults to the topology's production backend. */
+  backend?: SecretBackend;
+  /** Where the dialog mounts. Defaults to the trusted layer. */
+  mount?: (element: HTMLElement) => void;
+  /** Element factory (tests inject a stub dialog). */
+  createDialog?: () => SliccSecretDialog;
+}
+
+/** Mount the dialog into the trusted layer, or loudly into the body. */
+function mountDialog(element: HTMLElement): void {
+  try {
+    mountTrusted(element, document);
+  } catch {
+    log.warn(
+      'no trusted layer in this float — the secret dialog mounted into document.body and is ' +
+        'occludable by a panel (see trusted-layer.ts)'
+    );
+    document.body.append(element);
+  }
+}
+
+/**
+ * The provider the credential is being kept FROM, named in the dialog. Derived
+ * from the selected model rather than passed in, so the promise on screen tracks
+ * whoever is actually serving this session. Best-effort: an unreadable selection
+ * falls back to the component's generic wording.
+ */
+function providerLabel(): string | undefined {
+  try {
+    const id = getSelectedProvider();
+    return id ? (PROVIDER_LABELS[id] ?? id) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Display names for the provider ids that have one worth spelling out. */
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  google: 'Google',
+  adobe: 'Adobe',
+  github: 'GitHub',
+  bedrock: 'AWS Bedrock',
+  azure: 'Azure',
+};
+
+/** Translate the registry's request into the component's prefill shape. */
+function toDialogRequest(request: SecretRequest): SecretDialogRequest {
+  return {
+    name: request.name,
+    domains: request.domains,
+    reason: request.reason,
+    requester: request.requester,
+    persist: request.persist,
+    provider: providerLabel(),
+  };
+}
+
+/**
+ * Open the dialog, store what the human typed, and resolve with the stored
+ * secret's NAME, MASK, and scope — never its value. A dismissal resolves
+ * `{ stored: false, reason: 'cancelled' }`; the promise never rejects.
+ *
+ * A failed store keeps the dialog open with the value intact (the component's
+ * `submitHandler` contract), so a stalled Keychain costs a click rather than a
+ * re-paste from the password manager.
+ */
+export async function requestSecretFromUser(
+  request: SecretRequest = {},
+  deps: SecretRequestSurfaceDeps = {}
+): Promise<SecretRequestOutcome> {
+  const backend = deps.backend ?? createDefaultSecretBackend(resolveSecretTopology());
+  const dialog =
+    deps.createDialog?.() ?? (document.createElement('slicc-secret-dialog') as SliccSecretDialog);
+  (deps.mount ?? mountDialog)(dialog);
+
+  // Filled by the submit handler so the resolved outcome can describe what
+  // actually landed (the human may have edited the name or the scope). Held in a
+  // box rather than a bare `let` because the write happens inside the handler
+  // closure, which control-flow narrowing does not see.
+  const stored: { entry?: { name: string; domains: string[]; persisted: boolean } } = {};
+
+  dialog.submitHandler = async (detail) => {
+    try {
+      if (detail.persist) await backend.setPersisted(detail.name, detail.value, detail.domains);
+      else await backend.setSession(detail.name, detail.value, detail.domains);
+    } catch (err) {
+      // Returned, not thrown: the dialog shows it and stays open.
+      return err instanceof Error ? err.message : String(err);
+    }
+    stored.entry = { name: detail.name, domains: detail.domains, persisted: detail.persist };
+    return null;
+  };
+
+  try {
+    const submitted = await dialog.open(toDialogRequest(request));
+    const entry = stored.entry;
+    if (!submitted || !entry) return { stored: false, reason: 'cancelled' };
+    return {
+      stored: true,
+      name: entry.name,
+      // Best-effort: a store that accepted the write but cannot report a mask
+      // still stored the secret, so this is not a failure — the caller says so.
+      maskedValue: await readMask(backend, entry.name),
+      domains: entry.domains,
+      persisted: entry.persisted,
+    };
+  } finally {
+    dialog.remove();
+  }
+}
+
+/** The masked stand-in for `name`, or `null` when the store can't report one. */
+async function readMask(backend: SecretBackend, name: string): Promise<string | null> {
+  try {
+    return (await backend.getMasked(name))?.maskedValue ?? null;
+  } catch (err) {
+    log.warn('secret stored, but the mask could not be read back', {
+      name,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Publish this float's secret-entry surface so the tool layer (and the
+ * `secret-request` panel-RPC handler) can reach it. Call from the LEADER boot
+ * path only: a follower has no local secret store to write into, and leaving the
+ * registry empty is what makes both entry points hide themselves instead of
+ * dead-ending.
+ */
+export function installSecretRequestSurface(deps: SecretRequestSurfaceDeps = {}): () => void {
+  setSecretRequestSurface((request) => requestSecretFromUser(request, deps));
+  return () => setSecretRequestSurface(null);
+}

--- a/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
@@ -73,11 +73,13 @@ vi.mock('@earendil-works/pi-ai/compat', () => ({
 vi.mock('../../src/tools/index.js', () => ({
   createFileTools: () => [],
   createBashTool: () => ({ name: 'bash' }),
+  createRequestSecretTool: () => ({ name: 'request_secret' }),
 }));
 
 vi.mock('../../src/shell/almost-bash-shell-headless.js', () => ({
   AlmostBashShellHeadless: vi.fn(function () {
-    return {};
+    // `setMaskedEnvVar` is how `request_secret` publishes a mask as `$NAME`.
+    return { setMaskedEnvVar: vi.fn() };
   }),
 }));
 

--- a/packages/webapp/tests/scoops/scoop-context.model-provider.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.model-provider.test.ts
@@ -73,11 +73,13 @@ vi.mock('@earendil-works/pi-ai/compat', () => ({
 vi.mock('../../src/tools/index.js', () => ({
   createFileTools: () => [],
   createBashTool: () => ({ name: 'bash' }),
+  createRequestSecretTool: () => ({ name: 'request_secret' }),
 }));
 
 vi.mock('../../src/shell/almost-bash-shell-headless.js', () => ({
   AlmostBashShellHeadless: vi.fn(function () {
-    return {};
+    // `setMaskedEnvVar` is how `request_secret` publishes a mask as `$NAME`.
+    return { setMaskedEnvVar: vi.fn() };
   }),
 }));
 

--- a/packages/webapp/tests/scoops/scoop-context.restore-orphans.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.restore-orphans.test.ts
@@ -59,11 +59,13 @@ vi.mock('@earendil-works/pi-ai/compat', () => ({
 vi.mock('../../src/tools/index.js', () => ({
   createFileTools: () => [],
   createBashTool: () => ({ name: 'bash' }),
+  createRequestSecretTool: () => ({ name: 'request_secret' }),
 }));
 
 vi.mock('../../src/shell/almost-bash-shell-headless.js', () => ({
   AlmostBashShellHeadless: vi.fn(function () {
-    return {};
+    // `setMaskedEnvVar` is how `request_secret` publishes a mask as `$NAME`.
+    return { setMaskedEnvVar: vi.fn() };
   }),
 }));
 

--- a/packages/webapp/tests/scoops/scoop-context.session-id.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.session-id.test.ts
@@ -82,11 +82,13 @@ vi.mock('@earendil-works/pi-ai/compat', () => ({
 vi.mock('../../src/tools/index.js', () => ({
   createFileTools: () => [],
   createBashTool: () => ({ name: 'bash' }),
+  createRequestSecretTool: () => ({ name: 'request_secret' }),
 }));
 
 vi.mock('../../src/shell/almost-bash-shell-headless.js', () => ({
   AlmostBashShellHeadless: vi.fn(function () {
-    return {};
+    // `setMaskedEnvVar` is how `request_secret` publishes a mask as `$NAME`.
+    return { setMaskedEnvVar: vi.fn() };
   }),
 }));
 

--- a/packages/webapp/tests/scoops/scoop-context.tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.tools.test.ts
@@ -24,11 +24,13 @@ const mocks = vi.hoisted(() => {
       { name: 'edit_file' },
     ]),
     createBashTool: vi.fn(() => ({ name: 'bash' })),
+    createRequestSecretTool: vi.fn((_deps: unknown) => ({ name: 'request_secret' })),
     createScoopManagementTools: vi.fn(() => [{ name: 'send_message' }]),
     AlmostBashShellHeadless: vi.fn(function () {
       // `dispose` is real on the shell and `ScoopContext.dispose()` calls it, so
       // the stub needs it for any test that exercises teardown.
-      return { dispose: vi.fn() };
+      // `setMaskedEnvVar` is how `request_secret` publishes a mask as `$NAME`.
+      return { dispose: vi.fn(), setMaskedEnvVar: vi.fn() };
     }),
     getApiKey: vi.fn(() => 'test-api-key'),
     getSelectedProvider: vi.fn(() => 'anthropic'),
@@ -53,6 +55,7 @@ vi.mock('../../src/core/index.js', () => ({
 vi.mock('../../src/tools/index.js', () => ({
   createFileTools: mocks.createFileTools,
   createBashTool: mocks.createBashTool,
+  createRequestSecretTool: mocks.createRequestSecretTool,
 }));
 
 vi.mock('../../src/shell/almost-bash-shell-headless.js', () => ({
@@ -134,9 +137,35 @@ describe('ScoopContext active tool surface', () => {
     const toolNames = mocks.agentCtorCalls[0].initialState.tools.map(
       (tool: { name: string }) => tool.name
     );
-    expect(toolNames).toEqual(['read_file', 'write_file', 'edit_file', 'bash', 'send_message']);
+    expect(toolNames).toEqual([
+      'read_file',
+      'write_file',
+      'edit_file',
+      'bash',
+      'send_message',
+      'request_secret',
+    ]);
     expect(toolNames).not.toContain('grep');
     expect(toolNames).not.toContain('find');
+  });
+
+  // The tool asks a human for a credential; the masked value it gets back has to
+  // land in the SAME shell the agent's `bash` runs in, or `$NAME` never resolves.
+  it('wires request_secret to the scoop shell env with the unit label as requester', async () => {
+    const ctx = new ScoopContext(testScoop, createMockCallbacks(), createMockFs() as any);
+
+    await ctx.init();
+
+    const deps = mocks.createRequestSecretTool.mock.calls[0]?.[0] as unknown as {
+      requester?: string;
+      setEnv?: (name: string, value: string) => void;
+    };
+    expect(deps.requester).toBe(testScoop.assistantLabel);
+    const shell = mocks.AlmostBashShellHeadless.mock.results[0]?.value as unknown as {
+      setMaskedEnvVar: ReturnType<typeof vi.fn>;
+    };
+    deps.setEnv?.('GITHUB_TOKEN', 'ghp_MASKED');
+    expect(shell.setMaskedEnvVar).toHaveBeenCalledWith('GITHUB_TOKEN', 'ghp_MASKED');
   });
 
   // Regression for PR #1166 (P1): the agent's bash-tool shell must be built

--- a/packages/webapp/tests/shell/almost-bash-shell-secret.integration.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell-secret.integration.test.ts
@@ -159,6 +159,30 @@ describe('AlmostBashShellHeadless + secret set — masked-env injection (LLM-con
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  // `setMaskedEnvVar` is the seam the `request_secret` tool uses: the human types
+  // the secret in a page-realm dialog (the worker never sees the plaintext), and
+  // only the mask is handed to the shell so `$NAME` resolves for the agent.
+  it('publishes a mask through setMaskedEnvVar without any secret command', async () => {
+    const shell = new AlmostBashShellHeadless({ fs });
+    shell.setMaskedEnvVar('UI_TOKEN', 'mskd-ui');
+
+    const echoRes = await shell.executeCommand('echo $UI_TOKEN');
+    expect(echoRes.exitCode).toBe(0);
+    expect(echoRes.stdout.trim()).toBe('mskd-ui');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('reapplies the mask after the bash.exec env snapshot would drop it', async () => {
+    const shell = new AlmostBashShellHeadless({ fs });
+    // First exec establishes an env snapshot that predates the write.
+    await shell.executeCommand('echo warm');
+    shell.setMaskedEnvVar('UI_TOKEN', 'mskd-ui');
+
+    expect((await shell.executeCommand('echo $UI_TOKEN')).stdout.trim()).toBe('mskd-ui');
+    // The snapshot returned by the previous exec must not clobber it either.
+    expect((await shell.executeCommand('echo $UI_TOKEN')).stdout.trim()).toBe('mskd-ui');
+  });
+
   it('errors when both arg and stdin are provided', async () => {
     const shell = new AlmostBashShellHeadless({ fs });
     const res = await shell.executeCommand('echo stdin-v | secret set K arg-v --domain api.x.com');

--- a/packages/webapp/tests/tools/request-secret-tool.test.ts
+++ b/packages/webapp/tests/tools/request-secret-tool.test.ts
@@ -1,0 +1,180 @@
+/**
+ * `request_secret`: the tool asks a human for a credential and is told only
+ * the name, the mask, and the scope. The tests that matter most assert what it
+ * does NOT get — a real value — plus how each decline reads back to the model.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type SecretRequestOutcome,
+  setSecretRequestSurface,
+} from '../../src/base/secret-request-registry.js';
+import { createRequestSecretTool } from '../../src/tools/request-secret-tool.js';
+
+const STORED: SecretRequestOutcome = {
+  stored: true,
+  name: 'GITHUB_TOKEN',
+  maskedValue: 'ghp_MASKED000',
+  domains: ['api.github.com'],
+  persisted: false,
+};
+
+describe('request_secret', () => {
+  beforeEach(() => {
+    setSecretRequestSurface(null);
+  });
+
+  it('declares a schema that requires a name and a reason', () => {
+    const tool = createRequestSecretTool();
+    expect(tool.name).toBe('request_secret');
+    expect(tool.inputSchema.required).toEqual(['name', 'reason']);
+    expect(Object.keys(tool.inputSchema.properties ?? {})).toEqual([
+      'name',
+      'reason',
+      'domains',
+      'persist',
+    ]);
+  });
+
+  it('forwards the request to the page surface and reports name, mask, and scope', async () => {
+    const surface = vi.fn().mockResolvedValue(STORED);
+    setSecretRequestSurface(surface);
+
+    const tool = createRequestSecretTool({ requester: 'Cone' });
+    const result = await tool.execute({
+      name: 'GITHUB_TOKEN',
+      reason: 'push to the repo',
+      domains: ['api.github.com', ' ', '*.github.com'],
+      persist: true,
+    });
+
+    expect(surface).toHaveBeenCalledWith({
+      name: 'GITHUB_TOKEN',
+      reason: 'push to the repo',
+      // Blank entries dropped; the rest passed through as suggestions.
+      domains: ['api.github.com', '*.github.com'],
+      persist: true,
+      requester: 'Cone',
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('GITHUB_TOKEN');
+    expect(result.content).toContain('ghp_MASKED000');
+    expect(result.content).toContain('api.github.com');
+    expect(result.content).toContain('this session only');
+  });
+
+  it('never reports a real value — the surface has no channel to return one', async () => {
+    setSecretRequestSurface(async () => STORED);
+    const tool = createRequestSecretTool();
+    const result = await tool.execute({ name: 'GITHUB_TOKEN', reason: 'why' });
+    // The only credential-shaped string in the report is the mask.
+    expect(result.content).not.toContain('ghp_real');
+    expect(result.content).toContain('never see the real value');
+  });
+
+  it('injects the mask as $NAME and says so', async () => {
+    setSecretRequestSurface(async () => STORED);
+    const setEnv = vi.fn();
+    const tool = createRequestSecretTool({ setEnv });
+    const result = await tool.execute({ name: 'GITHUB_TOKEN', reason: 'why' });
+
+    expect(setEnv).toHaveBeenCalledWith('GITHUB_TOKEN', 'ghp_MASKED000');
+    expect(result.content).toContain('$GITHUB_TOKEN');
+  });
+
+  it('skips env injection for a name no shell could resolve', async () => {
+    setSecretRequestSurface(async () => ({
+      ...STORED,
+      name: 's3.r2.secret_access_key',
+    }));
+    const setEnv = vi.fn();
+    const tool = createRequestSecretTool({ setEnv });
+    const result = await tool.execute({ name: 's3.r2.secret_access_key', reason: 'mount' });
+
+    expect(setEnv).not.toHaveBeenCalled();
+    expect(result.content).not.toContain('available as $');
+  });
+
+  it('still succeeds when the store reports no mask', async () => {
+    setSecretRequestSurface(async () => ({ ...STORED, maskedValue: null }));
+    const setEnv = vi.fn();
+    const result = await createRequestSecretTool({ setEnv }).execute({
+      name: 'GITHUB_TOKEN',
+      reason: 'why',
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('secret get GITHUB_TOKEN');
+    expect(setEnv).not.toHaveBeenCalled();
+  });
+
+  it('reports a dismissal as an error so the model does not proceed regardless', async () => {
+    setSecretRequestSurface(async () => ({ stored: false, reason: 'cancelled' }));
+    const result = await createRequestSecretTool().execute({ name: 'T', reason: 'why' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/dismissed/i);
+    expect(result.content).toMatch(/do not retry/i);
+  });
+
+  it('points at `secret set` when this float cannot prompt at all', async () => {
+    // No surface, no panel-RPC client (node test realm) — the tool must answer
+    // rather than hang on a human who is not there.
+    const result = await createRequestSecretTool().execute({ name: 'T', reason: 'why' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/secret set/);
+  });
+
+  it('bridges to the page over panel-RPC when this realm has no surface', async () => {
+    const callPanelRpc = vi.fn().mockResolvedValue(STORED);
+    const result = await createRequestSecretTool({ callPanelRpc }).execute({
+      name: 'GITHUB_TOKEN',
+      reason: 'why',
+    });
+
+    expect(callPanelRpc).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('prefers the in-realm surface over the bridge', async () => {
+    const callPanelRpc = vi.fn();
+    setSecretRequestSurface(async () => STORED);
+    await createRequestSecretTool({ callPanelRpc }).execute({ name: 'T', reason: 'why' });
+
+    expect(callPanelRpc).not.toHaveBeenCalled();
+  });
+
+  it('rejects a call missing name or reason without prompting anyone', async () => {
+    const surface = vi.fn();
+    setSecretRequestSurface(surface);
+    const tool = createRequestSecretTool();
+
+    expect((await tool.execute({ reason: 'why' })).isError).toBe(true);
+    expect((await tool.execute({ name: 'T' })).isError).toBe(true);
+    expect((await tool.execute({ name: '  ', reason: '  ' })).isError).toBe(true);
+    expect(surface).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a thrown transport failure as a tool error', async () => {
+    setSecretRequestSurface(async () => {
+      throw new Error('bridge closed');
+    });
+    const result = await createRequestSecretTool().execute({ name: 'T', reason: 'why' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('bridge closed');
+  });
+
+  it('does not fail a stored secret when env injection throws', async () => {
+    setSecretRequestSurface(async () => STORED);
+    const result = await createRequestSecretTool({
+      setEnv: () => {
+        throw new Error('shell gone');
+      },
+    }).execute({ name: 'GITHUB_TOKEN', reason: 'why' });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('GITHUB_TOKEN');
+  });
+});

--- a/packages/webapp/tests/tools/request-secret-tool.test.ts
+++ b/packages/webapp/tests/tools/request-secret-tool.test.ts
@@ -63,6 +63,37 @@ describe('request_secret', () => {
     expect(result.content).toContain('this session only');
   });
 
+  // The dialog promises the credential is unreadable by a NAMED provider. That
+  // name has to come from the unit that is asking — a scoop can run on a provider
+  // the page's selected model knows nothing about — and it is read per call,
+  // because a unit's model can be switched mid-session.
+  it('names the asking unit’s provider, resolved on every call', async () => {
+    const surface = vi.fn().mockResolvedValue(STORED);
+    setSecretRequestSurface(surface);
+    const providers = ['Anthropic', 'OpenAI'];
+    const tool = createRequestSecretTool({ getProvider: () => providers.shift() });
+
+    await tool.execute({ name: 'A', reason: 'why' });
+    await tool.execute({ name: 'B', reason: 'why' });
+
+    expect(surface.mock.calls[0]?.[0]).toMatchObject({ provider: 'Anthropic' });
+    expect(surface.mock.calls[1]?.[0]).toMatchObject({ provider: 'OpenAI' });
+  });
+
+  it('still prompts when the provider cannot be resolved', async () => {
+    const surface = vi.fn().mockResolvedValue(STORED);
+    setSecretRequestSurface(surface);
+    const tool = createRequestSecretTool({
+      getProvider: () => {
+        throw new Error('no model selected');
+      },
+    });
+
+    const result = await tool.execute({ name: 'GITHUB_TOKEN', reason: 'why' });
+    expect(result.isError).toBeFalsy();
+    expect(surface.mock.calls[0]?.[0]).toMatchObject({ provider: undefined });
+  });
+
   it('never reports a real value — the surface has no channel to return one', async () => {
     setSecretRequestSurface(async () => STORED);
     const tool = createRequestSecretTool();

--- a/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
+++ b/packages/webapp/tests/ui/panel-rpc-handlers.test.ts
@@ -1,5 +1,6 @@
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setSecretRequestSurface } from '../../src/base/secret-request-registry.js';
 import { loadAndClearPendingHandle } from '../../src/fs/mount-picker-popup.js';
 import { getSharedHidRegistry } from '../../src/kernel/hid-device-registry.js';
 import { getSharedSerialRegistry } from '../../src/kernel/serial-port-registry.js';
@@ -559,6 +560,46 @@ describe('createStandalonePanelRpcHandlers — secrets-bridge', () => {
     const handlers = createStandalonePanelRpcHandlers({});
     const result = await handlers['secrets-bridge']!({ type: 'secrets.session.list' });
     expect(result).toEqual({ response: undefined });
+  });
+});
+
+describe('createStandalonePanelRpcHandlers — secret-request', () => {
+  afterEach(() => setSecretRequestSurface(null));
+
+  it('answers "unavailable" instead of rejecting when no surface is installed', async () => {
+    const handlers = createStandalonePanelRpcHandlers({});
+    // A float that cannot collect a secret is an ANSWER the worker-side tool
+    // reports to the user, not a transport failure it should retry.
+    await expect(handlers['secret-request']!({ name: 'T', reason: 'why' })).resolves.toEqual({
+      stored: false,
+      reason: 'unavailable',
+    });
+  });
+
+  it('forwards the request to the installed surface and returns its outcome verbatim', async () => {
+    const outcome = {
+      stored: true as const,
+      name: 'GITHUB_TOKEN',
+      maskedValue: 'ghp_MASKED',
+      domains: ['api.github.com'],
+      persisted: false,
+    };
+    const surface = vi.fn().mockResolvedValue(outcome);
+    setSecretRequestSurface(surface);
+
+    const handlers = createStandalonePanelRpcHandlers({});
+    const request = { name: 'GITHUB_TOKEN', reason: 'push', domains: ['api.github.com'] };
+    await expect(handlers['secret-request']!(request)).resolves.toEqual(outcome);
+    expect(surface).toHaveBeenCalledWith(request);
+  });
+
+  it('resolves the surface per call, so one installed after boot is still found', async () => {
+    const handlers = createStandalonePanelRpcHandlers({});
+    setSecretRequestSurface(async () => ({ stored: false, reason: 'cancelled' }));
+    await expect(handlers['secret-request']!({})).resolves.toEqual({
+      stored: false,
+      reason: 'cancelled',
+    });
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -9,6 +9,17 @@ import 'fake-indexeddb/auto';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
+// The secret action opens the trusted entry surface through a dynamic import;
+// mock it so this suite asserts the ROUTING (menu opt-in, draft mention) without
+// mounting a real dialog. The surface itself is covered by
+// `tests/ui/wc/wc-secret-request.test.ts`.
+const { mockRequestSecretFromUser } = vi.hoisted(() => ({
+  mockRequestSecretFromUser: vi.fn(),
+}));
+vi.mock('../../../src/ui/wc/wc-secret-request.js', () => ({
+  requestSecretFromUser: mockRequestSecretFromUser,
+}));
+
 installWcDomStubs();
 
 import { VirtualFS } from '../../../src/fs/index.js';
@@ -250,6 +261,21 @@ describe('wireWcAttach add-menu source (follower vs leader)', () => {
     wireWcAttach({ inputCard, freezer, log });
     expect(menu.results).toEqual([]);
     expect(menu.provider == null).toBe(true);
+  });
+
+  it('offers the secret action only where a secret store is reachable', () => {
+    const follower = makeCard();
+    wireWcAttach({ inputCard: follower.inputCard, freezer: follower.freezer, log });
+    expect(follower.menu.hasAttribute('secret-action')).toBe(false);
+
+    const leader = makeCard();
+    wireWcAttach({
+      inputCard: leader.inputCard,
+      freezer: leader.freezer,
+      secretEntry: true,
+      log,
+    });
+    expect(leader.menu.hasAttribute('secret-action')).toBe(true);
   });
 
   it('wires a live provider (leaving results unset) when a VFS reader IS supplied (leader)', async () => {
@@ -517,6 +543,54 @@ describe('wireWcAttach action routing', () => {
     await vi.waitFor(() => {
       expect(inputCard.getAttribute('value')).toBe('please Use the "sprinkles" skill: ');
     });
+  });
+
+  it('mentions a stored secret by name and MASK in the draft, never its value', async () => {
+    const { inputCard } = await setup();
+    mockRequestSecretFromUser.mockResolvedValue({
+      stored: true,
+      name: 'STAGING_TOKEN',
+      maskedValue: 'stg_MASKED123',
+      domains: ['api.staging.example.com'],
+      persisted: false,
+    });
+    inputCard.setAttribute('value', 'deploy this');
+    emitAdd(inputCard, { kind: 'secret', label: 'Share secret securely' });
+
+    await vi.waitFor(() => {
+      const draft = inputCard.getAttribute('value') ?? '';
+      expect(draft).toContain('deploy this ');
+      expect(draft).toContain('STAGING_TOKEN');
+      expect(draft).toContain('stg_MASKED123');
+      expect(draft).toContain('api.staging.example.com');
+      expect(draft).toContain('this session only');
+    });
+  });
+
+  it('points at `secret get` when the store reported no mask', async () => {
+    const { inputCard } = await setup();
+    mockRequestSecretFromUser.mockResolvedValue({
+      stored: true,
+      name: 'STAGING_TOKEN',
+      maskedValue: null,
+      domains: ['*'],
+      persisted: true,
+    });
+    emitAdd(inputCard, { kind: 'secret', label: 'Share secret securely' });
+
+    await vi.waitFor(() => {
+      expect(inputCard.getAttribute('value')).toContain('secret get STAGING_TOKEN');
+    });
+  });
+
+  it('leaves the draft untouched when the secret prompt is dismissed', async () => {
+    const { inputCard } = await setup();
+    mockRequestSecretFromUser.mockResolvedValue({ stored: false, reason: 'cancelled' });
+    inputCard.setAttribute('value', 'unchanged');
+    emitAdd(inputCard, { kind: 'secret', label: 'Share secret securely' });
+
+    await vi.waitFor(() => expect(mockRequestSecretFromUser).toHaveBeenCalled());
+    expect(inputCard.getAttribute('value')).toBe('unchanged');
   });
 
   it('routes a conversation pick through the freezer-card-select path', async () => {

--- a/packages/webapp/tests/ui/wc/wc-secret-request.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-secret-request.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+/**
+ * The secret-entry surface: the one module that holds a plaintext credential.
+ * These tests pin the two properties that make it safe to expose to an
+ * agent-invoked tool — the value goes to the store and NOWHERE else, and the
+ * resolved outcome carries only the mask.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { installWcDomStubs } from './wc-dom-stubs.js';
+
+installWcDomStubs();
+
+import {
+  getSecretRequestSurface,
+  setSecretRequestSurface,
+} from '../../../src/base/secret-request-registry.js';
+import type { SecretBackend } from '../../../src/shell/supplemental-commands/secret-backends.js';
+import { TRUSTED_LAYER_CLASS } from '../../../src/ui/wc/trusted-layer.js';
+import {
+  installSecretRequestSurface,
+  requestSecretFromUser,
+} from '../../../src/ui/wc/wc-secret-request.js';
+
+/** A recording stand-in for the trusted-realm secret store. */
+function fakeBackend(overrides: Partial<SecretBackend> = {}) {
+  const calls = {
+    session: [] as Array<{ name: string; value: string; domains: string[] }>,
+    persisted: [] as Array<{ name: string; value: string; domains: string[] }>,
+  };
+  const backend = {
+    setSession: vi.fn(async (name: string, value: string, domains: string[]) => {
+      calls.session.push({ name, value, domains });
+    }),
+    setPersisted: vi.fn(async (name: string, value: string, domains: string[]) => {
+      calls.persisted.push({ name, value, domains });
+    }),
+    getMasked: vi.fn(async (name: string) => ({
+      name,
+      maskedValue: `masked-${name}`,
+      domains: [],
+    })),
+    ...overrides,
+  } as unknown as SecretBackend;
+  return { backend, calls };
+}
+
+/**
+ * A stub dialog with the component's contract: `open()` resolves what the human
+ * "typed", running the host's `submitHandler` first, exactly as the real element
+ * does. Keeps this suite off a real custom-element registry.
+ */
+function stubDialog(
+  typed: { name: string; value: string; domains: string[]; persist: boolean } | null
+) {
+  const element = document.createElement('div') as unknown as HTMLElement & {
+    submitHandler?: (d: typeof typed) => Promise<string | null> | string | null;
+    open: (req?: unknown) => Promise<typeof typed>;
+    errors: string[];
+    lastRequest?: unknown;
+  };
+  element.errors = [];
+  element.open = async (req?: unknown) => {
+    element.lastRequest = req;
+    if (!typed) return null;
+    const problem = await element.submitHandler?.(typed);
+    if (problem) {
+      element.errors.push(problem);
+      return null;
+    }
+    return typed;
+  };
+  return element;
+}
+
+const TYPED = {
+  name: 'GITHUB_TOKEN',
+  value: 'ghp_realsecret',
+  domains: ['api.github.com'],
+  persist: false,
+};
+
+describe('requestSecretFromUser', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    setSecretRequestSurface(null);
+  });
+
+  it('writes the value to the session store and returns only the mask', async () => {
+    const { backend, calls } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+
+    const outcome = await requestSecretFromUser(
+      { name: 'GITHUB_TOKEN', reason: 'push', domains: ['api.github.com'] },
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    expect(calls.session).toEqual([
+      { name: 'GITHUB_TOKEN', value: 'ghp_realsecret', domains: ['api.github.com'] },
+    ]);
+    expect(calls.persisted).toEqual([]);
+    expect(outcome).toEqual({
+      stored: true,
+      name: 'GITHUB_TOKEN',
+      maskedValue: 'masked-GITHUB_TOKEN',
+      domains: ['api.github.com'],
+      persisted: false,
+    });
+    // The plaintext is not in the outcome under any key.
+    expect(JSON.stringify(outcome)).not.toContain('ghp_realsecret');
+  });
+
+  it('routes a persist opt-in to the saved store instead', async () => {
+    const { backend, calls } = fakeBackend();
+    const dialog = stubDialog({ ...TYPED, persist: true });
+
+    const outcome = await requestSecretFromUser(
+      {},
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    expect(calls.persisted).toHaveLength(1);
+    expect(calls.session).toEqual([]);
+    expect(outcome).toMatchObject({ stored: true, persisted: true });
+  });
+
+  it('forwards the request framing to the dialog', async () => {
+    const { backend } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+    await requestSecretFromUser(
+      { name: 'T', domains: ['a.example'], reason: 'because', requester: 'Cone', persist: true },
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    expect(dialog.lastRequest).toMatchObject({
+      name: 'T',
+      domains: ['a.example'],
+      reason: 'because',
+      requester: 'Cone',
+      persist: true,
+    });
+  });
+
+  it('names the current provider, so the promise on screen is about a real one', async () => {
+    const { backend } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+    await requestSecretFromUser(
+      {},
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    expect((dialog.lastRequest as { provider?: string }).provider).toBe('Anthropic');
+  });
+
+  it('reports a dismissal as cancelled and writes nothing', async () => {
+    const { backend, calls } = fakeBackend();
+    const dialog = stubDialog(null);
+
+    const outcome = await requestSecretFromUser(
+      {},
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    expect(outcome).toEqual({ stored: false, reason: 'cancelled' });
+    expect(calls.session).toEqual([]);
+  });
+
+  it('hands a store failure back to the dialog instead of throwing', async () => {
+    const { backend } = fakeBackend({
+      setSession: vi.fn(async () => {
+        throw new Error('Keychain did not respond within 10s');
+      }),
+    });
+    const dialog = stubDialog(TYPED);
+
+    const outcome = await requestSecretFromUser(
+      {},
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    // The component keeps itself open on a returned message; from here the call
+    // reads as "nothing stored".
+    expect(dialog.errors).toEqual(['Keychain did not respond within 10s']);
+    expect(outcome).toEqual({ stored: false, reason: 'cancelled' });
+  });
+
+  it('still reports success when the mask cannot be read back', async () => {
+    const { backend } = fakeBackend({
+      getMasked: vi.fn(async () => {
+        throw new Error('store unreachable');
+      }),
+    });
+    const dialog = stubDialog(TYPED);
+
+    const outcome = await requestSecretFromUser(
+      {},
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    expect(outcome).toMatchObject({ stored: true, maskedValue: null });
+  });
+
+  it('mounts into the trusted layer so no panel can spoof or cover it', async () => {
+    const layer = document.createElement('div');
+    layer.className = TRUSTED_LAYER_CLASS;
+    document.body.append(layer);
+    const { backend } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+
+    let mountedIn: Element | null = null;
+    dialog.open = async () => {
+      mountedIn = dialog.parentElement;
+      await dialog.submitHandler?.(TYPED);
+      return TYPED;
+    };
+
+    await requestSecretFromUser({}, { backend, createDialog: () => dialog as never });
+    expect(mountedIn).toBe(layer);
+  });
+
+  it('falls back to the body — loudly — when the float has no trusted layer', async () => {
+    const { backend } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+    let mountedIn: Element | null = null;
+    dialog.open = async () => {
+      mountedIn = dialog.parentElement;
+      await dialog.submitHandler?.(TYPED);
+      return TYPED;
+    };
+
+    await requestSecretFromUser({}, { backend, createDialog: () => dialog as never });
+    expect(mountedIn).toBe(document.body);
+  });
+
+  it('removes the dialog once the flow ends, so no value lingers in the DOM', async () => {
+    const { backend } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+    await requestSecretFromUser(
+      {},
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+    expect(dialog.isConnected).toBe(false);
+  });
+});
+
+describe('installSecretRequestSurface', () => {
+  beforeEach(() => setSecretRequestSurface(null));
+
+  it('publishes the surface for the tool layer and clears it on dispose', async () => {
+    expect(getSecretRequestSurface()).toBeNull();
+
+    const { backend } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+    const dispose = installSecretRequestSurface({
+      backend,
+      mount: (el) => document.body.append(el),
+      createDialog: () => dialog as never,
+    });
+
+    const surface = getSecretRequestSurface();
+    expect(surface).not.toBeNull();
+    await expect(surface?.({ name: 'GITHUB_TOKEN', reason: 'push' })).resolves.toMatchObject({
+      stored: true,
+      name: 'GITHUB_TOKEN',
+    });
+
+    dispose();
+    expect(getSecretRequestSurface()).toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-secret-request.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-secret-request.test.ts
@@ -141,7 +141,7 @@ describe('requestSecretFromUser', () => {
     });
   });
 
-  it('names the current provider, so the promise on screen is about a real one', async () => {
+  it('falls back to the page provider when the caller named none', async () => {
     const { backend } = fakeBackend();
     const dialog = stubDialog(TYPED);
     await requestSecretFromUser(
@@ -150,6 +150,19 @@ describe('requestSecretFromUser', () => {
     );
 
     expect((dialog.lastRequest as { provider?: string }).provider).toBe('Anthropic');
+  });
+
+  // A background scoop can run on a provider the page's selection knows nothing
+  // about; naming the wrong company is worse than naming none.
+  it('prefers the asking unit’s provider over the page selection', async () => {
+    const { backend } = fakeBackend();
+    const dialog = stubDialog(TYPED);
+    await requestSecretFromUser(
+      { provider: 'OpenAI' },
+      { backend, mount: (el) => document.body.append(el), createDialog: () => dialog as never }
+    );
+
+    expect((dialog.lastRequest as { provider?: string }).provider).toBe('OpenAI');
   });
 
   it('reports a dismissal as cancelled and writes nothing', async () => {
@@ -218,18 +231,23 @@ describe('requestSecretFromUser', () => {
     expect(mountedIn).toBe(layer);
   });
 
-  it('falls back to the body — loudly — when the float has no trusted layer', async () => {
-    const { backend } = fakeBackend();
+  // Fail closed: `document.body` is coverable and impersonable by any panel, so a
+  // float without the trusted layer must not ask for a credential at all.
+  it('refuses to prompt at all when the float has no trusted layer', async () => {
+    const { backend, calls } = fakeBackend();
     const dialog = stubDialog(TYPED);
-    let mountedIn: Element | null = null;
-    dialog.open = async () => {
-      mountedIn = dialog.parentElement;
-      await dialog.submitHandler?.(TYPED);
-      return TYPED;
-    };
+    const opened = vi.fn(async () => TYPED);
+    dialog.open = opened;
 
-    await requestSecretFromUser({}, { backend, createDialog: () => dialog as never });
-    expect(mountedIn).toBe(document.body);
+    const outcome = await requestSecretFromUser(
+      {},
+      { backend, createDialog: () => dialog as never }
+    );
+
+    expect(outcome).toEqual({ stored: false, reason: 'unavailable' });
+    expect(opened).not.toHaveBeenCalled();
+    expect(calls.session).toEqual([]);
+    expect(dialog.isConnected).toBe(false);
   });
 
   it('removes the dialog once the flow ends, so no value lingers in the DOM', async () => {

--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -11,7 +11,7 @@ src/
   primitives/    token-only leaves (logo, tag, icon-button, send-button, eyes, …)
   pill/ add-menu/  shadow-DOM elements lifted verbatim from the prototype
   chat/          message/card/dip composites + verbatim pure modules
-  overlay/       slicc-dialog (modal shell) + viewport overlays
+  overlay/       slicc-dialog (modal shell), slicc-secret-dialog + viewport overlays
   composer/ switcher/ workbench/ dock/ freezer/ nav/ shell/ memory/ showcase/
 ```
 

--- a/packages/webcomponents/src/add-menu/slicc-add-menu.stories.ts
+++ b/packages/webcomponents/src/add-menu/slicc-add-menu.stories.ts
@@ -9,6 +9,8 @@ interface AddMenuArgs {
   query?: string;
   /** Inject a custom results dataset in place of the built-in demo data. */
   results?: SliccAddSection[];
+  /** Opt into the "Share secret securely" quick action. */
+  secretAction?: boolean;
 }
 
 /** A small custom dataset demonstrating the injectable `results` property. */
@@ -37,13 +39,14 @@ const CUSTOM_RESULTS: SliccAddSection[] = [
  * Mount inside a faux composer footer band so the upward-popping results panel
  * has room to overlay content above it (matching the prototype context).
  */
-function buildAddMenu({ open, query, results }: AddMenuArgs): HTMLElement {
+function buildAddMenu({ open, query, results, secretAction }: AddMenuArgs): HTMLElement {
   const frame = document.createElement('div');
   frame.style.cssText =
     'width:420px;padding:14px;background:var(--canvas);border:1px solid var(--line);border-radius:14px;font-family:var(--ui);margin-top:320px;';
 
   const el = document.createElement('slicc-add-menu') as SliccAddMenu;
   if (results) el.results = results;
+  if (secretAction) el.setAttribute('secret-action', '');
   frame.appendChild(el);
 
   // Open / pre-search after the element has connected and rendered its shadow.
@@ -101,6 +104,17 @@ export const QuickActions: Story = { args: { query: 'take' } };
 
 /** Open with a host-injected `results` dataset replacing the built-in demo data. */
 export const OpenWithResults: Story = { args: { open: true, results: CUSTOM_RESULTS } };
+
+/**
+ * `secret-action` opt-in: "Share secret securely" (lucide `key-round`) sits
+ * BELOW the upload and capture rows. Selecting it emits `slicc-add` with
+ * `{ kind: 'secret' }` and nothing else — the credential is typed into the
+ * host's own trusted surface, never into this menu.
+ */
+export const SecretAction: Story = { args: { open: true, secretAction: true } };
+
+/** The secret row surfaced by search — typing "secret" finds it. */
+export const SecretActionSearch: Story = { args: { query: 'secret', secretAction: true } };
 
 /**
  * The trigger glyph swap, side by side: closed renders the lucide `plus`, open

--- a/packages/webcomponents/src/add-menu/slicc-add-menu.ts
+++ b/packages/webcomponents/src/add-menu/slicc-add-menu.ts
@@ -129,11 +129,14 @@ export type SliccAddDetail =
   // content; it is absent only for the synthetic quick-action row itself.
   | { kind: 'upload'; name: string; size: number; file?: File }
   | { kind: 'capture'; mode: 'photo' | 'screenshot'; label: string }
+  // The secret action carries NO value: the host opens its own trusted entry
+  // surface, and the credential never travels through this component.
+  | { kind: 'secret'; label: string }
   | { kind: string; id: string; label: string };
 
 /** Quick-action rows (always synthesized, never supplied by the data source). */
 interface QuickAction {
-  kind: 'upload' | 'capture';
+  kind: 'upload' | 'capture' | 'secret';
   mode?: 'photo' | 'screenshot';
   icon: string;
   label: string;
@@ -204,14 +207,36 @@ const QUICK_ACTIONS: QuickAction[] = [
 ];
 
 /**
+ * The secret quick-action, appended AFTER the upload / capture rows and only
+ * when the host opts in via `secret-action`. Kept out of {@link QUICK_ACTIONS}
+ * because it is the one action the component cannot service on its own — the
+ * host must own a credential store and a trusted entry surface.
+ */
+const SECRET_ACTION: QuickAction = {
+  kind: 'secret',
+  icon: 'key-round',
+  label: 'Share secret securely',
+  sub: 'The agent only sees a masked value',
+  quick: true,
+};
+
+/** The `slicc-add` detail one quick-action row stands for. */
+function quickDetail(action: QuickAction): SliccAddDetail {
+  if (action.kind === 'upload') return { kind: 'upload', name: '', size: 0 };
+  if (action.kind === 'secret') return { kind: 'secret', label: action.label };
+  return { kind: 'capture', mode: action.mode ?? 'photo', label: action.label };
+}
+
+/**
  * `<slicc-add-menu>` — the prototype's composer "add to prompt" menu. A trigger
  * whose glyph swaps between the lucide `plus` (closed) and `x` (open) — with the
  * prototype's quarter-turn rotate riding on the swap — slides in a search box;
  * the matching results pop upward out of the footer band into an
  * absolutely-positioned panel so the surrounding layout never reflows. Quick
  * actions (upload / photo / screenshot, rendered with the lucide `upload` /
- * `image` / `monitor` glyphs) sit above Files / Skills / Conversations sections,
- * all keyboard navigable. Files can also be added by drag-and-drop onto the wrap.
+ * `image` / `monitor` glyphs, plus an opt-in "Share secret securely" row under
+ * them) sit above Files / Skills / Conversations sections, all keyboard
+ * navigable. Files can also be added by drag-and-drop onto the wrap.
  *
  * All glyphs are lucide `<svg>`s via the shared `iconEl` helper — never emoji
  * or bespoke unicode symbols. The trigger spin holds a static end state under
@@ -235,6 +260,12 @@ const QUICK_ACTIONS: QuickAction[] = [
  *   dragged anywhere on the owning document opens the menu, activates the drop
  *   zone, and lands its drop as `slicc-add` upload events. Absent (the default),
  *   only the wrap-scoped drop zone is active and no document listeners exist.
+ * @attr secret-action - OPT-IN: append a "Share secret securely" row below the
+ *   upload / capture actions. Off by default because the component cannot
+ *   service it alone: selecting it emits `slicc-add` with `{ kind: 'secret' }`
+ *   and the HOST must open its own trusted entry surface and own the credential
+ *   store. A float with no reachable secret store (a follower, Cherry) leaves it
+ *   unset so the menu never offers an action that would dead-end.
  * @attr no-camera - OPT-IN: hide the "Take a photo" (camera / getUserMedia)
  *   quick-action. For hosts where camera capture can't work (e.g. a Chrome
  *   extension side-panel iframe, where the getUserMedia permission prompt is
@@ -249,7 +280,7 @@ const QUICK_ACTIONS: QuickAction[] = [
  *   selection of a row, a capture quick-action, or a file upload / drop
  */
 export class SliccAddMenu extends HTMLElement {
-  static readonly observedAttributes = ['theme', 'global-drop', 'no-camera'];
+  static readonly observedAttributes = ['theme', 'global-drop', 'no-camera', 'secret-action'];
 
   #root: ShadowRoot;
 
@@ -403,15 +434,20 @@ export class SliccAddMenu extends HTMLElement {
     // `theme` only flips CSS custom-property scopes; no re-render required.
     // `global-drop` toggles the document-level drop listeners on/off.
     if (name === 'global-drop') this.#syncGlobalDrop();
-    // `no-camera` changes which quick-actions render — repaint if open.
-    else if (name === 'no-camera' && this.#open) void this.#renderBody();
+    // `no-camera` / `secret-action` change which quick-actions render — repaint
+    // if open.
+    else if ((name === 'no-camera' || name === 'secret-action') && this.#open)
+      void this.#renderBody();
   }
 
   /** Quick-actions offered for the current attributes: `no-camera` drops the
-   *  camera-based "Take a photo" action (upload + screenshot are unaffected). */
+   *  camera-based "Take a photo" action (upload + screenshot are unaffected),
+   *  and `secret-action` appends the secret row after them. */
   #quickActions(): QuickAction[] {
-    if (!this.hasAttribute('no-camera')) return QUICK_ACTIONS;
-    return QUICK_ACTIONS.filter((a) => !(a.kind === 'capture' && a.mode === 'photo'));
+    const base = this.hasAttribute('no-camera')
+      ? QUICK_ACTIONS.filter((a) => !(a.kind === 'capture' && a.mode === 'photo'))
+      : QUICK_ACTIONS;
+    return this.hasAttribute('secret-action') ? [...base, SECRET_ACTION] : base;
   }
 
   // ----- Public injectable API ---------------------------------------------
@@ -611,7 +647,7 @@ export class SliccAddMenu extends HTMLElement {
     const quickActions = this.#quickActions();
     if (!q) {
       for (const a of quickActions) items.push({ type: 'quick', data: a });
-    } else if ('upload take a photo screenshot'.includes(q)) {
+    } else if ('upload take a photo screenshot share secret securely'.includes(q)) {
       for (const a of quickActions) {
         if (a.label.toLowerCase().includes(q)) items.push({ type: 'quick', data: a });
       }
@@ -645,11 +681,7 @@ export class SliccAddMenu extends HTMLElement {
         prevQuick = false;
       } else if (it.type === 'quick') {
         const i = this.#items.length;
-        this.#items.push(
-          it.data.kind === 'upload'
-            ? { kind: 'upload', name: '', size: 0 }
-            : { kind: 'capture', mode: it.data.mode ?? 'photo', label: it.data.label }
-        );
+        this.#items.push(quickDetail(it.data));
         const tx = h('span', { class: 'tx' }, h('div', { class: 'lb' }, it.data.label));
         if (it.data.sub) tx.append(h('div', { class: 'sb' }, it.data.sub));
         nodes.push(

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -126,6 +126,12 @@ export {
   SliccPermissions,
   type UsbPermissionProvider,
 } from './overlay/slicc-permissions.js';
+export {
+  type SecretDialogRequest,
+  type SecretDialogSubmitDetail,
+  type SecretDialogSubmitHandler,
+  SliccSecretDialog,
+} from './overlay/slicc-secret-dialog.js';
 export { SliccTooltip } from './overlay/slicc-tooltip.js';
 export { liveArrangement } from './panel/center-ops.js';
 export {

--- a/packages/webcomponents/src/overlay/slicc-secret-dialog.stories.ts
+++ b/packages/webcomponents/src/overlay/slicc-secret-dialog.stories.ts
@@ -91,7 +91,7 @@ function storyHost(options: StoryOptions = {}): HTMLElement {
   return root;
 }
 
-/** Default: password-masked value, options collapsed, wildcard scope. */
+/** Default: password-masked value, an empty scope row waiting to be filled in. */
 export const Default: Story = {
   render: () => storyHost(),
 };
@@ -102,8 +102,8 @@ export const DefaultDark: Story = {
 };
 
 /**
- * Additional options expanded — one row per domain with the − / + pair that
- * edits the list, plus the session/saved choice.
+ * The options drawer, which `open()` always expands — one row per domain with the
+ * − / + pair that edits the list, plus the session/saved choice.
  */
 export const OptionsExpanded: Story = {
   render: () =>
@@ -113,20 +113,15 @@ export const OptionsExpanded: Story = {
     }),
 };
 
-/** The wildcard default calls itself out: the value could go anywhere. */
+/** A wildcard, once someone types one, calls itself out: the value could go anywhere. */
 export const WildcardScope: Story = {
-  render: () =>
-    storyHost({
-      after: (dialog) => {
-        dialog.querySelector('details')?.setAttribute('open', '');
-      },
-    }),
+  render: () => storyHost({ request: { domains: ['*'] }, provider: 'Anthropic' }),
 };
 
 /**
  * The agent's `request_secret` shape: a suggested name, a narrow suggested
- * scope, and the reason it is asking. A suggested scope opens the drawer so the
- * human reviews what they are allowing before they paste anything.
+ * scope, and the reason it is asking. The scope is on screen from the start, so
+ * the human reviews what they are allowing before they paste anything.
  */
 export const AgentRequest: Story = {
   render: () =>

--- a/packages/webcomponents/src/overlay/slicc-secret-dialog.stories.ts
+++ b/packages/webcomponents/src/overlay/slicc-secret-dialog.stories.ts
@@ -1,0 +1,205 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import type { SecretDialogRequest, SecretDialogSubmitHandler } from './slicc-secret-dialog.js';
+import './slicc-secret-dialog.js';
+
+const meta: Meta = {
+  title: 'Overlay/SecretDialog',
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj;
+
+/** Faux chat behind the modal, so the backdrop blur reads like the real app. */
+function backdropContent(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.style.cssText =
+    'min-height:100vh;padding:28px;background:var(--bg);color:var(--txt-2);font:400 13px var(--ui,sans-serif);' +
+    'display:flex;flex-direction:column;gap:10px;';
+  for (const line of [
+    'Configure the deploy script to push to the staging bucket.',
+    'I need an API token for that. I will ask for it rather than guess.',
+    'curl -H "Authorization: Bearer $STAGING_TOKEN" https://api.staging.example.com/deploy',
+  ]) {
+    const p = document.createElement('div');
+    p.textContent = line;
+    p.style.cssText =
+      'max-width:640px;padding:10px 12px;border:1px solid var(--line);border-radius:10px;' +
+      'background:var(--canvas);';
+    wrap.append(p);
+  }
+  return wrap;
+}
+
+/** Where the submitted (masked-in-real-life) outcome is echoed for the story. */
+function outcomeLine(): HTMLElement {
+  const el = document.createElement('div');
+  el.style.cssText =
+    'margin-top:6px;font:500 12.5px var(--ui,sans-serif);color:var(--ctx,#3b63fb);min-height:18px;';
+  return el;
+}
+
+interface StoryOptions {
+  /** What the flow asks for. */
+  request?: SecretDialogRequest;
+  /** The provider named as unable to read the value. */
+  provider?: string;
+  /** Simulated store step — return a message to keep the dialog open. */
+  submitHandler?: SecretDialogSubmitHandler;
+  /** Wrap in the dark theme scope. */
+  dark?: boolean;
+  /** Run after the dialog is open (drive a state the screenshot should show). */
+  after?: (dialog: HTMLElement) => void;
+}
+
+function storyHost(options: StoryOptions = {}): HTMLElement {
+  const root = document.createElement('div');
+  if (options.dark) root.className = 'dark';
+  root.style.cssText = 'position:relative;min-height:100vh;';
+
+  const dialog = document.createElement('slicc-secret-dialog');
+  const outcome = outcomeLine();
+  if (options.submitHandler) dialog.submitHandler = options.submitHandler;
+  if (options.provider) dialog.provider = options.provider;
+
+  const reopen = document.createElement('button');
+  reopen.type = 'button';
+  reopen.textContent = 'Open the secret dialog…';
+  reopen.style.cssText =
+    'align-self:flex-start;font:500 13px var(--ui,sans-serif);padding:8px 14px;' +
+    'border:1px solid var(--line,#ddd);border-radius:9px;background:var(--canvas,#fff);' +
+    'color:var(--ink,#131313);cursor:pointer;';
+
+  const run = (): void => {
+    void dialog.open(options.request ?? {}).then((detail) => {
+      outcome.textContent = detail
+        ? `Stored “${detail.name}” · scope ${detail.domains.join(', ')} · ${
+            detail.persist ? 'saved' : 'session-only'
+          } (the value never leaves this tab)`
+        : 'Cancelled — nothing stored.';
+    });
+    options.after?.(dialog);
+  };
+  reopen.addEventListener('click', run);
+
+  const page = backdropContent();
+  page.append(reopen, outcome);
+  root.append(page, dialog);
+  // Open on mount so the story (and the PR screenshot) shows the real surface
+  // instead of a button that has to be clicked first.
+  requestAnimationFrame(run);
+  return root;
+}
+
+/** Default: password-masked value, options collapsed, wildcard scope. */
+export const Default: Story = {
+  render: () => storyHost(),
+};
+
+/** The same surface in the dark theme scope. */
+export const DefaultDark: Story = {
+  render: () => storyHost({ dark: true }),
+};
+
+/**
+ * Additional options expanded — one row per domain with the − / + pair that
+ * edits the list, plus the session/saved choice.
+ */
+export const OptionsExpanded: Story = {
+  render: () =>
+    storyHost({
+      request: { domains: ['api.github.com', 'uploads.github.com'] },
+      provider: 'Anthropic',
+    }),
+};
+
+/** The wildcard default calls itself out: the value could go anywhere. */
+export const WildcardScope: Story = {
+  render: () =>
+    storyHost({
+      after: (dialog) => {
+        dialog.querySelector('details')?.setAttribute('open', '');
+      },
+    }),
+};
+
+/**
+ * The agent's `request_secret` shape: a suggested name, a narrow suggested
+ * scope, and the reason it is asking. A suggested scope opens the drawer so the
+ * human reviews what they are allowing before they paste anything.
+ */
+export const AgentRequest: Story = {
+  render: () =>
+    storyHost({
+      provider: 'Anthropic',
+      request: {
+        name: 'STAGING_TOKEN',
+        domains: ['api.staging.example.com'],
+        requester: 'Cone',
+        reason: 'The deploy script needs a bearer token for api.staging.example.com',
+      },
+    }),
+};
+
+/** Agent request, dark theme. */
+export const AgentRequestDark: Story = {
+  render: () =>
+    storyHost({
+      dark: true,
+      provider: 'Anthropic',
+      request: {
+        name: 'STAGING_TOKEN',
+        domains: ['api.staging.example.com'],
+        requester: 'Cone',
+        reason: 'The deploy script needs a bearer token for api.staging.example.com',
+      },
+    }),
+};
+
+/** A dotted subsystem name: legal in the store, but not a shell variable. */
+export const NonShellName: Story = {
+  render: () =>
+    storyHost({
+      request: {
+        name: 's3.r2.secret_access_key',
+        domains: ['*.r2.cloudflarestorage.com'],
+      },
+    }),
+};
+
+/**
+ * Validation: a pasted multi-line credential. The single-line input joins the
+ * breaks itself, so the mangling has to be said out loud.
+ */
+export const ValidationError: Story = {
+  render: () =>
+    storyHost({
+      after: (dialog) => {
+        const el = dialog as HTMLElement & { setError: (m: string) => void };
+        el.setError(
+          'That value spans multiple lines and was joined into one. Secrets must be single-line — base64-encode it first (base64 -w0 key.pem).'
+        );
+      },
+    }),
+};
+
+/**
+ * A failed store keeps the dialog open with the typed value intact, so a
+ * transient Keychain / bridge failure costs a click rather than a re-paste.
+ */
+export const StoreFailure: Story = {
+  render: () =>
+    storyHost({
+      submitHandler: () => 'Keychain did not respond within 10s — the secret was not stored.',
+      request: { domains: ['api.github.com'] },
+      // Drive a real submit so the story shows the state it is named for: the
+      // error line up, the credential still in the field.
+      after: (dialog) => {
+        const input = (name: string) =>
+          dialog.querySelector(`[part="${name}"]`) as HTMLInputElement;
+        input('name').value = 'GITHUB_TOKEN';
+        input('value').value = 'ghp_liveTokenStaysInTheField';
+        (dialog.querySelector('[part="save"]') as HTMLButtonElement).click();
+      },
+    }),
+};

--- a/packages/webcomponents/src/overlay/slicc-secret-dialog.ts
+++ b/packages/webcomponents/src/overlay/slicc-secret-dialog.ts
@@ -4,23 +4,39 @@ import { iconEl } from '../internal/icons.js';
 // Composed by tag — owns its registration.
 import './slicc-dialog.js';
 
-/** What the human typed, once every field validates. */
-export interface SecretDialogSubmitDetail {
+/**
+ * What was submitted, WITHOUT the credential. This is the shape that travels on
+ * the composed `slicc-secret-submit` event, so it must stay value-free: the
+ * event crosses into the page, where any panel or sprinkle can listen for it.
+ */
+export interface SecretDialogSubmitSummary {
   /** Secret name (the store key; `$NAME` in the shell when POSIX-shaped). */
   name: string;
-  /** The real credential. Never reflected to an attribute, never logged. */
-  value: string;
   /** Host/domain glob patterns the value may be unmasked for. */
   domains: string[];
   /** true → write to the persisted store; false → session-only, in-memory. */
   persist: boolean;
 }
 
+/**
+ * What the human typed, once every field validates — the summary plus the
+ * credential. Reaches only the two private paths: {@link
+ * SliccSecretDialog.submitHandler} and the promise `open()` returns. It is
+ * deliberately NOT what the DOM event carries.
+ */
+export interface SecretDialogSubmitDetail extends SecretDialogSubmitSummary {
+  /** The real credential. Never reflected to an attribute, never logged. */
+  value: string;
+}
+
 /** Prefill + framing for one open() call. */
 export interface SecretDialogRequest {
   /** Suggested secret name (the agent's proposal, or a remembered one). */
   name?: string;
-  /** Suggested domain allowlist. Defaults to {@link ANY_DOMAIN}. */
+  /**
+   * Suggested domain allowlist. With none, the human types one — there is no
+   * default scope, because a wildcard nobody chose is a wildcard nobody read.
+   */
   domains?: string[];
   /** Why the value is being asked for — shown verbatim under the heading. */
   reason?: string;
@@ -392,11 +408,10 @@ export class SliccSecretDialog extends HTMLElement {
     this.#setRevealed(false);
     this.#error.textContent = '';
     this.#setBusy(false);
-    // A suggested scope is the interesting part of an agent request — open the
-    // drawer so the human reviews what they are about to allow, instead of
-    // trusting a collapsed default they never saw.
-    const scope = this.#domainValues();
-    this.#options.open = !!req.domains?.length || scope.join(',') !== ANY_DOMAIN;
+    // The scope is the whole security claim, so it is never collapsed out of
+    // sight: the drawer opens whenever the human still has to supply or review
+    // one, which — with no default scope — is every time.
+    this.#options.open = true;
     this.#syncHints();
     this.#dialog.show?.();
     requestAnimationFrame(() => (this.#name.value ? this.#value : this.#name).focus());
@@ -416,6 +431,10 @@ export class SliccSecretDialog extends HTMLElement {
     this.#busy = busy;
     this.#save.disabled = busy;
     this.#save.textContent = busy ? 'Storing…' : 'Store secret';
+    // Cancel goes with it: the write is already in flight and cannot be recalled,
+    // so a "cancelled" answer over a secret that then lands is a lie. `#finish`
+    // enforces the same rule for Escape and ✕, which have no button to disable.
+    this.#cancel.disabled = busy;
   }
 
   #setRevealed(revealed: boolean): void {
@@ -448,9 +467,16 @@ export class SliccSecretDialog extends HTMLElement {
     return Array.from(this.#domainRows.querySelectorAll<HTMLInputElement>('[part="domain"]'));
   }
 
-  /** Rebuild the rows to match `domains`, keeping at least one (the wildcard). */
+  /**
+   * Rebuild the rows to match `domains`, always keeping one.
+   *
+   * With nothing suggested that row starts EMPTY rather than `*`: a scope is the
+   * only thing standing between a credential and any host the agent names, so it
+   * is typed deliberately, never inherited from a default. Submission is blocked
+   * until it is filled in.
+   */
   #setDomains(domains: string[]): void {
-    const list = domains.length > 0 ? domains : [ANY_DOMAIN];
+    const list = domains.length > 0 ? domains : [''];
     this.#domainRows.replaceChildren(...list.map((domain) => this.#domainRow(domain)));
     this.#syncDomainRows();
   }
@@ -552,9 +578,15 @@ export class SliccSecretDialog extends HTMLElement {
       }
       this.#setBusy(false);
     }
+    // Value-free BY CONSTRUCTION, not by convention: this event is composed and
+    // bubbling, so it leaves the component and reaches anything in the page that
+    // listens — including panel or sprinkle code the agent wrote. The credential
+    // travels only on `submitHandler` and the `open()` promise, both of which the
+    // host wires up in its own realm.
+    const { name, domains, persist } = collected;
     this.dispatchEvent(
-      new CustomEvent<SecretDialogSubmitDetail>('slicc-secret-submit', {
-        detail: collected,
+      new CustomEvent<SecretDialogSubmitSummary>('slicc-secret-submit', {
+        detail: { name, domains, persist },
         bubbles: true,
         composed: true,
       })
@@ -563,6 +595,11 @@ export class SliccSecretDialog extends HTMLElement {
   }
 
   #finish(detail: SecretDialogSubmitDetail | null): void {
+    // A dismissal DURING the write is refused rather than raced: the store call
+    // cannot be recalled, so answering "cancelled" here could leave a stored
+    // secret behind a cancelled outcome. The submit path resolves it either way —
+    // with the store's error, or with the detail on success.
+    if (this.#busy && !detail) return;
     const resolve = this.#resolve;
     this.#resolve = null;
     this.#dialog.hide?.();
@@ -768,7 +805,7 @@ declare global {
     'slicc-secret-dialog': SliccSecretDialog;
   }
   interface HTMLElementEventMap {
-    'slicc-secret-submit': CustomEvent<SecretDialogSubmitDetail>;
+    'slicc-secret-submit': CustomEvent<SecretDialogSubmitSummary>;
     'slicc-secret-cancel': CustomEvent<void>;
   }
 }

--- a/packages/webcomponents/src/overlay/slicc-secret-dialog.ts
+++ b/packages/webcomponents/src/overlay/slicc-secret-dialog.ts
@@ -1,0 +1,774 @@
+import { define } from '../internal/define.js';
+import { h } from '../internal/dom.js';
+import { iconEl } from '../internal/icons.js';
+// Composed by tag — owns its registration.
+import './slicc-dialog.js';
+
+/** What the human typed, once every field validates. */
+export interface SecretDialogSubmitDetail {
+  /** Secret name (the store key; `$NAME` in the shell when POSIX-shaped). */
+  name: string;
+  /** The real credential. Never reflected to an attribute, never logged. */
+  value: string;
+  /** Host/domain glob patterns the value may be unmasked for. */
+  domains: string[];
+  /** true → write to the persisted store; false → session-only, in-memory. */
+  persist: boolean;
+}
+
+/** Prefill + framing for one open() call. */
+export interface SecretDialogRequest {
+  /** Suggested secret name (the agent's proposal, or a remembered one). */
+  name?: string;
+  /** Suggested domain allowlist. Defaults to {@link ANY_DOMAIN}. */
+  domains?: string[];
+  /** Why the value is being asked for — shown verbatim under the heading. */
+  reason?: string;
+  /** Who is asking (agent label, scoop name). System-derived, never prose. */
+  requester?: string;
+  /** Initial state of the "keep after this session" checkbox. */
+  persist?: boolean;
+  /** Override the dialog title. */
+  heading?: string;
+  /**
+   * Who cannot read the value — the model provider, named in the description
+   * because "the agent" is abstract and a provider name is not.
+   */
+  provider?: string;
+}
+
+/**
+ * Host-supplied store step. Return `null` on success (the dialog closes) or a
+ * message to display while the dialog STAYS OPEN so the human can retry
+ * without retyping the credential.
+ */
+export type SecretDialogSubmitHandler = (
+  detail: SecretDialogSubmitDetail
+) => Promise<string | null> | string | null;
+
+/** The wildcard scope — every domain. Deliberately called out in the UI. */
+const ANY_DOMAIN = '*';
+
+const DEFAULT_HEADING = 'Share a secret securely';
+/** Stand-in when no provider is named — still true, just less concrete. */
+const DEFAULT_PROVIDER = 'the model';
+
+function describeSecrecy(provider: string): string {
+  return `Secure secrets cannot be read by ${provider}, and work only on the domains you specify.`;
+}
+
+/** Names that survive as `$NAME` in the agent shell (POSIX env identifiers). */
+const POSIX_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+/** Everything the secret stores accept as a key (dotted subsystem names included). */
+const ALLOWED_NAME = /^[A-Za-z0-9_.-]+$/;
+
+/**
+ * Scoped, document-level stylesheet. Light-DOM host (it composes
+ * `<slicc-dialog>` by tag), so the chrome is injected once into the host
+ * document and selected by the host tag. Token-driven (`--canvas` / `--ink` /
+ * `--line` / `--ghost` / `--txt-2` / `--txt-3` / `--ctx` / `--ui`) so dark mode
+ * flips through the inherited theme scope.
+ */
+const STYLE = `
+slicc-secret-dialog slicc-dialog::part(dialog) {
+  width: min(480px, 92vw);
+}
+slicc-secret-dialog .slicc-secret__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: var(--ui);
+}
+slicc-secret-dialog .slicc-secret__field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+slicc-secret-dialog .slicc-secret__label {
+  font: 600 11px var(--ui);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--txt-3);
+}
+slicc-secret-dialog .slicc-secret__input {
+  font: 400 13px var(--ui);
+  color: var(--ink);
+  background: var(--canvas);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px 10px;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+slicc-secret-dialog .slicc-secret__input:focus {
+  border-color: var(--ctx);
+}
+slicc-secret-dialog .slicc-secret__input--value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  padding-right: 38px;
+}
+slicc-secret-dialog .slicc-secret__value-wrap {
+  position: relative;
+}
+slicc-secret-dialog .slicc-secret__reveal {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  border-radius: 7px;
+  color: var(--txt-3);
+  cursor: pointer;
+}
+slicc-secret-dialog .slicc-secret__reveal:hover {
+  background: var(--ghost);
+  color: var(--ink);
+}
+slicc-secret-dialog .slicc-secret__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+slicc-secret-dialog .slicc-secret__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+slicc-secret-dialog .slicc-secret__row .slicc-secret__input {
+  flex: 1 1 auto;
+}
+slicc-secret-dialog .slicc-secret__row-btn {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--txt-3);
+  cursor: pointer;
+}
+slicc-secret-dialog .slicc-secret__row-btn:hover:not([disabled]) {
+  background: var(--ghost);
+  color: var(--ink);
+}
+slicc-secret-dialog .slicc-secret__row-btn[disabled] {
+  opacity: .4;
+  cursor: default;
+}
+slicc-secret-dialog .slicc-secret__hint {
+  font-size: 11.5px;
+  color: var(--txt-3);
+  line-height: 1.45;
+}
+slicc-secret-dialog .slicc-secret__hint[hidden] {
+  display: none;
+}
+slicc-secret-dialog .slicc-secret__error {
+  font-size: 12px;
+  color: var(--danger, #d7373f);
+  min-height: 15px;
+  line-height: 1.35;
+}
+slicc-secret-dialog .slicc-secret__options {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+}
+slicc-secret-dialog .slicc-secret__options[open] {
+  padding-bottom: 12px;
+}
+slicc-secret-dialog .slicc-secret__summary {
+  font: 500 12.5px var(--ui);
+  color: var(--txt-2);
+  cursor: pointer;
+  padding: 9px 0;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+slicc-secret-dialog .slicc-secret__summary::-webkit-details-marker {
+  display: none;
+}
+slicc-secret-dialog .slicc-secret__opts-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+slicc-secret-dialog .slicc-secret__check {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font: 400 12.5px var(--ui);
+  color: var(--ink);
+  cursor: pointer;
+}
+slicc-secret-dialog .slicc-secret__check input {
+  margin: 1px 0 0;
+  flex: 0 0 auto;
+}
+slicc-secret-dialog .slicc-secret__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 500 12px var(--ui);
+  color: var(--ink);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+slicc-secret-dialog .slicc-secret__btn:hover {
+  background: var(--ghost);
+}
+slicc-secret-dialog .slicc-secret__btn--save {
+  background: var(--ink);
+  color: var(--canvas);
+  border-color: var(--ink);
+}
+slicc-secret-dialog .slicc-secret__btn--save:hover {
+  background: color-mix(in srgb, var(--ink) 85%, var(--canvas));
+}
+slicc-secret-dialog .slicc-secret__btn[disabled] {
+  opacity: .55;
+  cursor: default;
+}
+`;
+
+const STYLE_ID = 'slicc-secret-dialog-style';
+
+function ensureSecretStyle(doc: Document): void {
+  if (doc.getElementById(STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = STYLE;
+  (doc.head ?? doc.documentElement).appendChild(style);
+}
+
+/** Split a comma/space separated mask list into patterns. */
+function parseDomains(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/)
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+}
+
+/**
+ * `<slicc-secret-dialog>` — the one surface for handing SLICC a credential.
+ * Shared by the composer's "Share secret securely" action and the agent's
+ * `request_secret` tool so a human sees the same chrome either way.
+ *
+ * The value field is a password input by default with an eye toggle to reveal
+ * it; Additional options carries the domain mask (what the fetch proxy will
+ * unmask the value for) and a "keep after this session ends" checkbox that
+ * chooses between the in-memory session store and the persisted one.
+ *
+ * Light DOM (it composes `<slicc-dialog>` BY TAG) with a scoped stylesheet
+ * injected once into the host document. The typed value lives only in the
+ * input: it is never reflected to an attribute, never emitted except in the
+ * submit detail, and the field is cleared whenever the dialog closes.
+ *
+ * Imperative API: `open(req)` prefills, shows the dialog, and resolves with the
+ * submitted {@link SecretDialogSubmitDetail} — or `null` on cancel (Cancel / ✕
+ * / Escape / backdrop). Hosts that need to store the value before the dialog
+ * goes away set {@link submitHandler}: returning a message keeps the dialog
+ * open with that error so the human can retry without retyping.
+ *
+ * @attr heading - dialog title (default "Share a secret securely")
+ * @attr secret-name - prefill for the name field
+ * @attr domain - prefill for the domain mask (default `*`); comma-separated
+ * @attr provider - the model provider named as unable to read the value
+ * @attr persist-default - boolean; start with "keep after this session" checked
+ * @csspart name - the name input
+ * @csspart value - the secret value input
+ * @csspart reveal - the show/hide toggle
+ * @csspart domain - a domain input (one per allowed domain)
+ * @csspart domain-add - the button that adds another domain row
+ * @csspart domain-remove - the button that drops a domain row
+ * @csspart persist - the persist checkbox
+ * @csspart save - the primary submit button
+ * @csspart cancel - the cancel button
+ * @fires slicc-secret-submit - composed + bubbling; `SecretDialogSubmitDetail`
+ * @fires slicc-secret-cancel - composed + bubbling; the human dismissed it
+ */
+export class SliccSecretDialog extends HTMLElement {
+  static readonly observedAttributes = [
+    'heading',
+    'secret-name',
+    'domain',
+    'provider',
+    'persist-default',
+  ];
+
+  /**
+   * Optional store step run on submit, before the dialog closes. Returning a
+   * string keeps the dialog open and shows it as the error.
+   */
+  submitHandler: SecretDialogSubmitHandler | null = null;
+
+  #dialog!: HTMLElement & { show?: () => void; hide?: () => void };
+  #name!: HTMLInputElement;
+  #value!: HTMLInputElement;
+  #reveal!: HTMLButtonElement;
+  #domainRows!: HTMLElement;
+  #persist!: HTMLInputElement;
+  #save!: HTMLButtonElement;
+  #cancel!: HTMLButtonElement;
+  #options!: HTMLDetailsElement;
+  #error!: HTMLElement;
+  #nameHint!: HTMLElement;
+  #domainHint!: HTMLElement;
+  #built = false;
+  #busy = false;
+  #resolve: ((detail: SecretDialogSubmitDetail | null) => void) | null = null;
+
+  connectedCallback(): void {
+    this.#build();
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (!this.#built) return;
+    if (name === 'heading') this.#dialog.setAttribute('heading', this.heading);
+    else if (name === 'secret-name') this.#name.value = this.getAttribute('secret-name') ?? '';
+    else if (name === 'domain') this.#setDomains(parseDomains(this.getAttribute('domain') ?? ''));
+    else if (name === 'provider')
+      this.#dialog.setAttribute('description', describeSecrecy(this.provider));
+    else if (name === 'persist-default') this.#persist.checked = this.persistDefault;
+  }
+
+  /** The provider named as unable to read the value. */
+  get provider(): string {
+    return this.getAttribute('provider') || DEFAULT_PROVIDER;
+  }
+
+  set provider(value: string | null) {
+    if (value == null) this.removeAttribute('provider');
+    else this.setAttribute('provider', value);
+  }
+
+  /** Dialog title (reflected from the `heading` attribute). */
+  get heading(): string {
+    return this.getAttribute('heading') ?? DEFAULT_HEADING;
+  }
+
+  set heading(value: string | null) {
+    if (value == null) this.removeAttribute('heading');
+    else this.setAttribute('heading', value);
+  }
+
+  /** Whether "keep after this session ends" starts checked. */
+  get persistDefault(): boolean {
+    return this.hasAttribute('persist-default');
+  }
+
+  set persistDefault(value: boolean) {
+    this.toggleAttribute('persist-default', value);
+  }
+
+  /**
+   * Prefill, show, and resolve with what the human submitted — `null` on any
+   * dismissal. The value field always starts empty and masked, whatever the
+   * previous call left behind.
+   */
+  open(req: SecretDialogRequest = {}): Promise<SecretDialogSubmitDetail | null> {
+    this.#build();
+    if (req.heading) this.heading = req.heading;
+    if (req.provider) this.provider = req.provider;
+    this.#dialog.setAttribute('heading', this.heading);
+    this.#dialog.setAttribute('description', describeRequest(req, this.provider));
+    this.#name.value = req.name ?? this.getAttribute('secret-name') ?? '';
+    this.#setDomains(req.domains ?? parseDomains(this.getAttribute('domain') ?? ''));
+    this.#persist.checked = req.persist ?? this.persistDefault;
+    this.#value.value = '';
+    this.#setRevealed(false);
+    this.#error.textContent = '';
+    this.#setBusy(false);
+    // A suggested scope is the interesting part of an agent request — open the
+    // drawer so the human reviews what they are about to allow, instead of
+    // trusting a collapsed default they never saw.
+    const scope = this.#domainValues();
+    this.#options.open = !!req.domains?.length || scope.join(',') !== ANY_DOMAIN;
+    this.#syncHints();
+    this.#dialog.show?.();
+    requestAnimationFrame(() => (this.#name.value ? this.#value : this.#name).focus());
+    return new Promise((resolve) => {
+      this.#resolve = resolve;
+    });
+  }
+
+  /** Show `message` as the dialog's error line (host-side store failures). */
+  setError(message: string): void {
+    this.#build();
+    this.#error.textContent = message;
+    this.#setBusy(false);
+  }
+
+  #setBusy(busy: boolean): void {
+    this.#busy = busy;
+    this.#save.disabled = busy;
+    this.#save.textContent = busy ? 'Storing…' : 'Store secret';
+  }
+
+  #setRevealed(revealed: boolean): void {
+    this.#value.type = revealed ? 'text' : 'password';
+    this.#reveal.setAttribute('aria-pressed', String(revealed));
+    this.#reveal.setAttribute('aria-label', revealed ? 'Hide secret' : 'Show secret');
+    this.#reveal.replaceChildren(iconEl(revealed ? 'eye-off' : 'eye', { size: 16 }));
+  }
+
+  /** Non-blocking guidance: shell visibility for the name, breadth for the scope. */
+  #syncHints(): void {
+    const name = this.#name.value.trim();
+    const posix = !name || POSIX_ENV_NAME.test(name);
+    this.#nameHint.textContent = posix ? '' : `Not a shell name — no $${name} in the shell.`;
+    this.#nameHint.toggleAttribute('hidden', posix);
+
+    const wildcard = this.#domainValues().includes(ANY_DOMAIN);
+    this.#domainHint.textContent = wildcard
+      ? '* allows any domain. Narrow it to the API host.'
+      : '';
+    this.#domainHint.toggleAttribute('hidden', !wildcard);
+  }
+
+  /** Every pattern currently in the rows, comma lists inside a row included. */
+  #domainValues(): string[] {
+    return this.#domainInputs().flatMap((input) => parseDomains(input.value));
+  }
+
+  #domainInputs(): HTMLInputElement[] {
+    return Array.from(this.#domainRows.querySelectorAll<HTMLInputElement>('[part="domain"]'));
+  }
+
+  /** Rebuild the rows to match `domains`, keeping at least one (the wildcard). */
+  #setDomains(domains: string[]): void {
+    const list = domains.length > 0 ? domains : [ANY_DOMAIN];
+    this.#domainRows.replaceChildren(...list.map((domain) => this.#domainRow(domain)));
+    this.#syncDomainRows();
+  }
+
+  /** One domain, with the − / + pair that edits the list trailing it. */
+  #domainRow(value: string): HTMLElement {
+    const input = h('input', {
+      type: 'text',
+      class: 'slicc-secret__input',
+      part: 'domain',
+      spellcheck: 'false',
+      autocomplete: 'off',
+      placeholder: 'api.github.com',
+      'aria-label': 'Allowed domain',
+    }) as HTMLInputElement;
+    input.value = value;
+    input.addEventListener('input', () => this.#syncHints());
+
+    const row = h(
+      'div',
+      { class: 'slicc-secret__row' },
+      input,
+      this.#rowButton('minus', 'Remove this domain', 'domain-remove', () => {
+        row.remove();
+        this.#syncDomainRows();
+        this.#syncHints();
+      }),
+      this.#rowButton('plus', 'Add another domain', 'domain-add', () => {
+        const added = this.#domainRow('');
+        row.after(added);
+        this.#syncDomainRows();
+        added.querySelector<HTMLInputElement>('[part="domain"]')?.focus();
+      })
+    );
+    return row;
+  }
+
+  #rowButton(
+    icon: 'plus' | 'minus',
+    label: string,
+    part: string,
+    onClick: () => void
+  ): HTMLButtonElement {
+    const button = h(
+      'button',
+      { type: 'button', class: 'slicc-secret__row-btn', part, 'aria-label': label, title: label },
+      iconEl(icon, { size: 14 })
+    ) as HTMLButtonElement;
+    button.addEventListener('click', onClick);
+    return button;
+  }
+
+  /** A lone row cannot be removed: the store rejects a secret with no scope. */
+  #syncDomainRows(): void {
+    const rows = Array.from(this.#domainRows.children);
+    for (const row of rows) {
+      const remove = row.querySelector<HTMLButtonElement>('[part="domain-remove"]');
+      if (remove) remove.disabled = rows.length === 1;
+    }
+  }
+
+  /** Validate the form; returns the detail or the first problem found. */
+  #collect(): SecretDialogSubmitDetail | string {
+    const name = this.#name.value.trim();
+    if (!name) return 'Give the secret a name.';
+    if (!ALLOWED_NAME.test(name)) {
+      return 'Use letters, digits, and . _ - in the name.';
+    }
+    const value = this.#value.value;
+    if (!value) return 'Paste the secret value.';
+    const domains = this.#domainValues();
+    if (domains.length === 0) {
+      return 'Every secret needs at least one allowed domain.';
+    }
+    return { name, value, domains, persist: this.#persist.checked };
+  }
+
+  async #submit(): Promise<void> {
+    if (this.#busy) return;
+    const collected = this.#collect();
+    if (typeof collected === 'string') {
+      this.#error.textContent = collected;
+      return;
+    }
+    this.#error.textContent = '';
+    if (this.submitHandler) {
+      this.#setBusy(true);
+      let problem: string | null;
+      try {
+        problem = await this.submitHandler(collected);
+      } catch (err) {
+        problem = err instanceof Error ? err.message : String(err);
+      }
+      if (problem) {
+        // Stay open with the value intact so a transient store failure costs a
+        // click, not a re-paste from the password manager.
+        this.setError(problem);
+        return;
+      }
+      this.#setBusy(false);
+    }
+    this.dispatchEvent(
+      new CustomEvent<SecretDialogSubmitDetail>('slicc-secret-submit', {
+        detail: collected,
+        bubbles: true,
+        composed: true,
+      })
+    );
+    this.#finish(collected);
+  }
+
+  #finish(detail: SecretDialogSubmitDetail | null): void {
+    const resolve = this.#resolve;
+    this.#resolve = null;
+    this.#dialog.hide?.();
+    // The plaintext never outlives the dialog: clearing here covers cancel,
+    // submit, and dismissal alike.
+    this.#value.value = '';
+    this.#setRevealed(false);
+    this.#setBusy(false);
+    if (!detail) {
+      this.dispatchEvent(new CustomEvent('slicc-secret-cancel', { bubbles: true, composed: true }));
+    }
+    resolve?.(detail);
+  }
+
+  /** The "Additional options" drawer: domain rows + session/saved choice. */
+  #buildOptions(): void {
+    this.#domainRows = h('div', { class: 'slicc-secret__rows' });
+    this.#setDomains(parseDomains(this.getAttribute('domain') ?? ''));
+
+    this.#persist = h('input', {
+      type: 'checkbox',
+      part: 'persist',
+    }) as HTMLInputElement;
+    this.#persist.checked = this.persistDefault;
+
+    this.#options = h(
+      'details',
+      { class: 'slicc-secret__options' },
+      h(
+        'summary',
+        { class: 'slicc-secret__summary' },
+        iconEl('sliders-horizontal', { size: 14 }),
+        'Additional options'
+      ),
+      h(
+        'div',
+        { class: 'slicc-secret__opts-body' },
+        h(
+          'div',
+          { class: 'slicc-secret__field' },
+          h('label', { class: 'slicc-secret__label' }, 'Domains'),
+          this.#domainRows,
+          h('div', { class: 'slicc-secret__hint' }, 'Globs allowed: *.github.com'),
+          this.#domainHint
+        ),
+        h(
+          'label',
+          { class: 'slicc-secret__check' },
+          this.#persist,
+          h(
+            'span',
+            {},
+            'Keep after this session ends',
+            h('div', { class: 'slicc-secret__hint' }, 'Off: this session only.')
+          )
+        )
+      )
+    ) as HTMLDetailsElement;
+  }
+
+  #build(): void {
+    if (this.#built) return;
+    this.#built = true;
+    // Injected here rather than in `connectedCallback` so a host that calls
+    // `open()` before appending the element still gets the chrome styled.
+    ensureSecretStyle(this.ownerDocument);
+
+    this.#name = h('input', {
+      type: 'text',
+      class: 'slicc-secret__input',
+      part: 'name',
+      spellcheck: 'false',
+      autocomplete: 'off',
+      placeholder: 'GITHUB_TOKEN',
+      'aria-label': 'Secret name',
+    }) as HTMLInputElement;
+    this.#name.value = this.getAttribute('secret-name') ?? '';
+    this.#name.addEventListener('input', () => this.#syncHints());
+
+    this.#value = h('input', {
+      type: 'password',
+      class: 'slicc-secret__input slicc-secret__input--value',
+      part: 'value',
+      spellcheck: 'false',
+      autocomplete: 'off',
+      placeholder: 'Paste the value',
+      'aria-label': 'Secret value',
+    }) as HTMLInputElement;
+    // A single-line input silently JOINS pasted line breaks, so a PEM key would
+    // look accepted and be stored mangled. The stores are line-oriented too and
+    // reject a newline with a 400 (docs/secrets.md), so say so at the paste.
+    this.#value.addEventListener('paste', (e) => {
+      const pasted = (e as ClipboardEvent).clipboardData?.getData('text') ?? '';
+      if (/[\r\n]/.test(pasted.trim())) {
+        this.#error.textContent =
+          'That value spans multiple lines and was joined into one. Secrets must be single-line — base64-encode it first (base64 -w0 key.pem).';
+      }
+    });
+    this.#value.addEventListener('keydown', (e) => {
+      if ((e as KeyboardEvent).key === 'Enter') {
+        e.preventDefault();
+        void this.#submit();
+      }
+    });
+
+    this.#reveal = h('button', {
+      type: 'button',
+      class: 'slicc-secret__reveal',
+      part: 'reveal',
+    }) as HTMLButtonElement;
+    this.#reveal.addEventListener('click', () =>
+      this.#setRevealed(this.#value.type === 'password')
+    );
+
+    this.#nameHint = h('div', { class: 'slicc-secret__hint', hidden: true });
+    this.#domainHint = h('div', { class: 'slicc-secret__hint', hidden: true });
+    this.#buildOptions();
+
+    this.#error = h('div', {
+      class: 'slicc-secret__error',
+      role: 'alert',
+      'aria-live': 'polite',
+    });
+
+    this.#cancel = h(
+      'button',
+      { type: 'button', class: 'slicc-secret__btn', part: 'cancel', slot: 'footer' },
+      'Cancel'
+    ) as HTMLButtonElement;
+    this.#cancel.addEventListener('click', () => this.#finish(null));
+
+    this.#save = h(
+      'button',
+      {
+        type: 'button',
+        class: 'slicc-secret__btn slicc-secret__btn--save',
+        part: 'save',
+        slot: 'footer',
+      },
+      'Store secret'
+    ) as HTMLButtonElement;
+    this.#save.addEventListener('click', () => void this.#submit());
+
+    const body = h(
+      'div',
+      { class: 'slicc-secret__body' },
+      h(
+        'div',
+        { class: 'slicc-secret__field' },
+        h('label', { class: 'slicc-secret__label' }, 'Name'),
+        this.#name,
+        this.#nameHint
+      ),
+      h(
+        'div',
+        { class: 'slicc-secret__field' },
+        h('label', { class: 'slicc-secret__label' }, 'Value'),
+        h('div', { class: 'slicc-secret__value-wrap' }, this.#value, this.#reveal),
+        h('div', { class: 'slicc-secret__hint' }, 'Single line. Stays in this tab.')
+      ),
+      this.#options,
+      this.#error
+    );
+
+    this.#setRevealed(false);
+
+    this.#dialog = this.ownerDocument.createElement('slicc-dialog') as HTMLElement & {
+      show?: () => void;
+      hide?: () => void;
+    };
+    this.#dialog.setAttribute('heading', this.heading);
+    this.#dialog.setAttribute('description', describeSecrecy(this.provider));
+    // A half-typed credential must not be lost to a stray backdrop click.
+    this.#dialog.setAttribute('persistent', '');
+    this.#dialog.append(body, this.#cancel, this.#save);
+    this.#dialog.addEventListener('slicc-dialog-close', () => {
+      if (this.#resolve) this.#finish(null);
+    });
+    this.append(this.#dialog);
+    this.#syncHints();
+  }
+}
+
+/**
+ * The description line. A request's reason leads (it is why the human is looking
+ * at this at all), and the secrecy promise follows it either way — that promise
+ * is the reason to type a credential here rather than nowhere.
+ */
+function describeRequest(req: SecretDialogRequest, provider: string): string {
+  const secrecy = describeSecrecy(provider);
+  if (!req.reason) return secrecy;
+  const who = req.requester ? `${req.requester}: ` : '';
+  // The reason is somebody else's sentence and may not be punctuated; without
+  // this the two run together ("…example.com Secure secrets cannot…").
+  const reason = /[.!?]$/.test(req.reason.trim()) ? req.reason.trim() : `${req.reason.trim()}.`;
+  return `${who}${reason} ${secrecy}`;
+}
+
+define('slicc-secret-dialog', SliccSecretDialog);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slicc-secret-dialog': SliccSecretDialog;
+  }
+  interface HTMLElementEventMap {
+    'slicc-secret-submit': CustomEvent<SecretDialogSubmitDetail>;
+    'slicc-secret-cancel': CustomEvent<void>;
+  }
+}

--- a/packages/webcomponents/src/register.ts
+++ b/packages/webcomponents/src/register.ts
@@ -37,6 +37,7 @@ import './nav/slicc-nav.js';
 import './overlay/slicc-camera-dialog.js';
 import './overlay/slicc-dialog.js';
 import './overlay/slicc-permissions.js';
+import './overlay/slicc-secret-dialog.js';
 import './overlay/slicc-tooltip.js';
 import './panel/slicc-layout.js';
 import './panel/slicc-panel.js';

--- a/packages/webcomponents/tests/add-menu/slicc-add-menu.test.ts
+++ b/packages/webcomponents/tests/add-menu/slicc-add-menu.test.ts
@@ -188,6 +188,71 @@ describe('slicc-add-menu', () => {
     expect(rows(el).map((r) => r.querySelector('.lb')?.textContent)).not.toContain('Take a photo');
   });
 
+  it('omits the secret action unless the host opts in with secret-action', async () => {
+    const el = mount();
+    el.open();
+    await flush();
+
+    expect(rows(el).map((r) => r.querySelector('.lb')?.textContent)).not.toContain(
+      'Share secret securely'
+    );
+  });
+
+  it('secret-action appends the secret row BELOW upload + capture', async () => {
+    const el = mount();
+    el.setAttribute('secret-action', '');
+    el.open();
+    await flush();
+
+    const labels = rows(el).map((r) => r.querySelector('.lb')?.textContent ?? '');
+    expect(labels.indexOf('Share secret securely')).toBeGreaterThan(
+      labels.indexOf('Take a screenshot')
+    );
+  });
+
+  it('secret-action set while open repaints the secret row in', async () => {
+    const el = mount();
+    el.open();
+    await flush();
+
+    el.setAttribute('secret-action', '');
+    await flush();
+    expect(rows(el).map((r) => r.querySelector('.lb')?.textContent)).toContain(
+      'Share secret securely'
+    );
+  });
+
+  it('emits a value-free { kind: "secret" } detail when the secret row is chosen', async () => {
+    const el = mount();
+    el.setAttribute('secret-action', '');
+    el.open();
+    await flush();
+
+    const seen: SliccAddDetail[] = [];
+    el.addEventListener('slicc-add', (e) => seen.push(e.detail));
+    const row = rows(el).find(
+      (r) => r.querySelector('.lb')?.textContent === 'Share secret securely'
+    );
+    row?.click();
+
+    expect(seen).toEqual([{ kind: 'secret', label: 'Share secret securely' }]);
+    // The menu closes; the credential is typed into the HOST's surface.
+    expect(el.isOpen).toBe(false);
+  });
+
+  it('surfaces the secret row for a "secret" search query', async () => {
+    const el = mount();
+    el.setAttribute('secret-action', '');
+    el.open();
+    await flush();
+
+    typeSearch(el, 'secret');
+    await flush();
+    expect(rows(el).map((r) => r.querySelector('.lb')?.textContent)).toContain(
+      'Share secret securely'
+    );
+  });
+
   it('filters results by the search query across sections', async () => {
     const el = mount();
     el.open();

--- a/packages/webcomponents/tests/overlay/slicc-secret-dialog.test.ts
+++ b/packages/webcomponents/tests/overlay/slicc-secret-dialog.test.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type SecretDialogSubmitDetail,
+  SliccSecretDialog,
+} from '../../src/overlay/slicc-secret-dialog.js';
+import { ensureGlobalTokens } from '../../src/theme/tokens.js';
+
+function mount(): SliccSecretDialog {
+  const el = document.createElement('slicc-secret-dialog');
+  document.body.appendChild(el);
+  return el;
+}
+
+const part = <T extends HTMLElement>(el: SliccSecretDialog, name: string): T =>
+  el.querySelector(`[part="${name}"]`) as T;
+
+const nameInput = (el: SliccSecretDialog) => part<HTMLInputElement>(el, 'name');
+const valueInput = (el: SliccSecretDialog) => part<HTMLInputElement>(el, 'value');
+const domainInput = (el: SliccSecretDialog) => part<HTMLInputElement>(el, 'domain');
+const domainInputs = (el: SliccSecretDialog) =>
+  Array.from(el.querySelectorAll<HTMLInputElement>('[part="domain"]'));
+const addBtns = (el: SliccSecretDialog) =>
+  Array.from(el.querySelectorAll<HTMLButtonElement>('[part="domain-add"]'));
+const removeBtns = (el: SliccSecretDialog) =>
+  Array.from(el.querySelectorAll<HTMLButtonElement>('[part="domain-remove"]'));
+const persistBox = (el: SliccSecretDialog) => part<HTMLInputElement>(el, 'persist');
+const saveBtn = (el: SliccSecretDialog) => part<HTMLButtonElement>(el, 'save');
+const cancelBtn = (el: SliccSecretDialog) => part<HTMLButtonElement>(el, 'cancel');
+const revealBtn = (el: SliccSecretDialog) => part<HTMLButtonElement>(el, 'reveal');
+const errorLine = (el: SliccSecretDialog) =>
+  el.querySelector('.slicc-secret__error') as HTMLElement;
+const innerDialog = (el: SliccSecretDialog) => el.querySelector('slicc-dialog') as HTMLElement;
+
+/** Fill the form with a valid credential across two domain rows. */
+function fill(el: SliccSecretDialog, value = 'ghp_realtoken'): void {
+  nameInput(el).value = 'GITHUB_TOKEN';
+  valueInput(el).value = value;
+  domainInput(el).value = 'api.github.com';
+  addBtns(el)[0].click();
+  domainInputs(el)[1].value = '*.github.com';
+}
+
+const flush = () => new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+/** Every hint currently on screen, joined — the non-blocking guidance. */
+const visibleHints = (el: SliccSecretDialog): string =>
+  Array.from(el.querySelectorAll('.slicc-secret__hint'))
+    .filter((hint) => !hint.hasAttribute('hidden'))
+    .map((hint) => hint.textContent ?? '')
+    .join(' ');
+
+describe('slicc-secret-dialog', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('slicc-secret-dialog')).toBe(SliccSecretDialog);
+  });
+
+  it('exposes the documented ::part hooks', () => {
+    const el = mount();
+    for (const name of [
+      'name',
+      'value',
+      'reveal',
+      'domain',
+      'domain-add',
+      'domain-remove',
+      'persist',
+      'save',
+      'cancel',
+    ]) {
+      expect(part(el, name), name).not.toBeNull();
+    }
+  });
+
+  it('masks the value by default and toggles to plain text on reveal', () => {
+    const el = mount();
+    expect(valueInput(el).type).toBe('password');
+    expect(revealBtn(el).getAttribute('aria-pressed')).toBe('false');
+
+    revealBtn(el).click();
+    expect(valueInput(el).type).toBe('text');
+    expect(revealBtn(el).getAttribute('aria-pressed')).toBe('true');
+
+    revealBtn(el).click();
+    expect(valueInput(el).type).toBe('password');
+  });
+
+  it('defaults the scope to a single wildcard row and warns what it means', async () => {
+    const el = mount();
+    void el.open();
+    await flush();
+    expect(domainInputs(el).map((i) => i.value)).toEqual(['*']);
+    expect(visibleHints(el)).toContain('any domain');
+  });
+
+  it('names the provider that cannot read the value', () => {
+    const el = mount();
+    el.provider = 'Anthropic';
+    expect(innerDialog(el).getAttribute('description')).toBe(
+      'Secure secrets cannot be read by Anthropic, and work only on the domains you specify.'
+    );
+    // Unset falls back to wording that is still true, just less concrete.
+    el.provider = null;
+    expect(innerDialog(el).getAttribute('description')).toContain('cannot be read by the model');
+  });
+
+  it('adds and removes domain rows, keeping one that cannot be removed', () => {
+    const el = mount();
+    void el.open();
+    expect(domainInputs(el)).toHaveLength(1);
+    // The last row's − is disabled: a secret with no scope cannot be stored.
+    expect(removeBtns(el)[0].disabled).toBe(true);
+
+    addBtns(el)[0].click();
+    expect(domainInputs(el)).toHaveLength(2);
+    expect(removeBtns(el).every((b) => b.disabled)).toBe(false);
+
+    domainInputs(el)[0].value = 'api.github.com';
+    domainInputs(el)[1].value = 'uploads.github.com';
+    removeBtns(el)[1].click();
+    expect(domainInputs(el).map((i) => i.value)).toEqual(['api.github.com']);
+    expect(removeBtns(el)[0].disabled).toBe(true);
+  });
+
+  it('adds the new row directly below the one that was clicked', () => {
+    const el = mount();
+    void el.open({ domains: ['a.example', 'b.example'] });
+    addBtns(el)[0].click();
+    domainInputs(el)[1].value = 'inserted.example';
+    expect(domainInputs(el).map((i) => i.value)).toEqual([
+      'a.example',
+      'inserted.example',
+      'b.example',
+    ]);
+  });
+
+  it('collects every row into the submitted scope', async () => {
+    const el = mount();
+    const pending = el.open({ domains: ['api.github.com', 'uploads.github.com'] });
+    nameInput(el).value = 'GITHUB_TOKEN';
+    valueInput(el).value = 'ghp_x';
+    saveBtn(el).click();
+    await expect(pending).resolves.toMatchObject({
+      domains: ['api.github.com', 'uploads.github.com'],
+    });
+  });
+
+  it('resolves open() with the submitted detail and never reflects the value', async () => {
+    const el = mount();
+    const pending = el.open();
+    fill(el);
+    persistBox(el).checked = true;
+    saveBtn(el).click();
+
+    await expect(pending).resolves.toEqual({
+      name: 'GITHUB_TOKEN',
+      value: 'ghp_realtoken',
+      domains: ['api.github.com', '*.github.com'],
+      persist: true,
+    } satisfies SecretDialogSubmitDetail);
+    // The credential is not recoverable from the DOM after the dialog closes.
+    expect(el.outerHTML).not.toContain('ghp_realtoken');
+    expect(valueInput(el).value).toBe('');
+  });
+
+  it('emits a composed, bubbling slicc-secret-submit', async () => {
+    const el = mount();
+    const seen: SecretDialogSubmitDetail[] = [];
+    // Listened for on `document`, not the element: that only passes if the event
+    // is composed AND bubbling, which is the contract under test.
+    document.addEventListener(
+      'slicc-secret-submit',
+      (e) => seen.push((e as CustomEvent<SecretDialogSubmitDetail>).detail),
+      { once: true }
+    );
+    const pending = el.open();
+    fill(el);
+    saveBtn(el).click();
+    await pending;
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].name).toBe('GITHUB_TOKEN');
+    expect(seen[0].persist).toBe(false);
+  });
+
+  it('resolves null and emits slicc-secret-cancel on Cancel', async () => {
+    const el = mount();
+    const cancelled = vi.fn();
+    el.addEventListener('slicc-secret-cancel', cancelled);
+    const pending = el.open();
+    fill(el);
+    cancelBtn(el).click();
+
+    await expect(pending).resolves.toBeNull();
+    expect(cancelled).toHaveBeenCalledTimes(1);
+    expect(valueInput(el).value).toBe('');
+  });
+
+  it('resolves null when the modal shell dismisses (Escape / ✕)', async () => {
+    const el = mount();
+    const pending = el.open();
+    innerDialog(el).dispatchEvent(
+      new CustomEvent('slicc-dialog-close', { detail: { reason: 'escape' }, bubbles: true })
+    );
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it('is persistent — a stray backdrop click cannot discard a typed credential', () => {
+    const el = mount();
+    expect(innerDialog(el).hasAttribute('persistent')).toBe(true);
+  });
+
+  it('blocks submit on an empty name, empty value, or empty scope', async () => {
+    const el = mount();
+    void el.open();
+
+    saveBtn(el).click();
+    expect(errorLine(el).textContent).toContain('name');
+
+    nameInput(el).value = 'TOKEN';
+    saveBtn(el).click();
+    expect(errorLine(el).textContent).toContain('value');
+
+    valueInput(el).value = 'abc';
+    domainInput(el).value = '  ';
+    saveBtn(el).click();
+    expect(errorLine(el).textContent).toContain('allowed domain');
+    // Blanking the one row is the only way to reach that state — the − button
+    // stays disabled precisely so a scope-less secret cannot be submitted.
+    expect(removeBtns(el)[0].disabled).toBe(true);
+  });
+
+  // The input joins pasted line breaks itself, so the mangling is invisible
+  // without this warning — a pasted PEM key would look stored and be truncated.
+  it('warns when a pasted value spanned multiple lines', () => {
+    const el = mount();
+    void el.open();
+    const data = new DataTransfer();
+    data.setData('text', '-----BEGIN KEY-----\nabc\n-----END KEY-----');
+    valueInput(el).dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: data, bubbles: true })
+    );
+    expect(errorLine(el).textContent).toContain('single-line');
+  });
+
+  it('warns that a non-POSIX name will not be available as $NAME', async () => {
+    const el = mount();
+    void el.open({ name: 's3.r2.secret_access_key', domains: ['*.r2.cloudflarestorage.com'] });
+    await flush();
+    const hint = el.querySelector('.slicc-secret__hint:not([hidden])') as HTMLElement;
+    expect(hint.textContent).toContain('$s3.r2.secret_access_key');
+  });
+
+  it('prefills a request and opens the options drawer for a suggested scope', async () => {
+    const el = mount();
+    void el.open({
+      name: 'STAGING_TOKEN',
+      domains: ['api.staging.example.com'],
+      requester: 'Cone',
+      reason: 'the deploy script needs a bearer token',
+    });
+    await flush();
+
+    expect(nameInput(el).value).toBe('STAGING_TOKEN');
+    expect(domainInput(el).value).toBe('api.staging.example.com');
+    expect((el.querySelector('details') as HTMLDetailsElement).open).toBe(true);
+    // The unpunctuated reason gets a full stop, so it does not run into the
+    // secrecy promise that follows it.
+    expect(innerDialog(el).getAttribute('description')).toBe(
+      'Cone: the deploy script needs a bearer token. Secure secrets cannot be read by the model, ' +
+        'and work only on the domains you specify.'
+    );
+  });
+
+  it('keeps the dialog open with the value intact when the store step fails', async () => {
+    const el = mount();
+    el.submitHandler = () => 'Keychain did not respond within 10s';
+    void el.open();
+    fill(el);
+    saveBtn(el).click();
+    await flush();
+
+    expect(errorLine(el).textContent).toContain('Keychain');
+    expect(valueInput(el).value).toBe('ghp_realtoken');
+    expect(innerDialog(el).hasAttribute('open')).toBe(true);
+    expect(saveBtn(el).disabled).toBe(false);
+  });
+
+  it('closes once the store step succeeds', async () => {
+    const el = mount();
+    const handler = vi.fn().mockResolvedValue(null);
+    el.submitHandler = handler;
+    const pending = el.open();
+    fill(el);
+    saveBtn(el).click();
+
+    await expect(pending).resolves.toMatchObject({ name: 'GITHUB_TOKEN' });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(innerDialog(el).hasAttribute('open')).toBe(false);
+  });
+
+  it('submits on Enter in the value field', async () => {
+    const el = mount();
+    const pending = el.open();
+    fill(el);
+    valueInput(el).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await expect(pending).resolves.toMatchObject({ name: 'GITHUB_TOKEN' });
+  });
+
+  it('rejects a name the secret stores cannot key on', () => {
+    const el = mount();
+    void el.open();
+    nameInput(el).value = 'has spaces!';
+    valueInput(el).value = 'abc';
+    saveBtn(el).click();
+    expect(errorLine(el).textContent).toContain('letters, digits');
+  });
+
+  it('updates both hints live as the human types', () => {
+    const el = mount();
+    void el.open();
+
+    nameInput(el).value = 'oauth.adobe.token';
+    nameInput(el).dispatchEvent(new Event('input'));
+    expect(visibleHints(el)).toContain('$oauth.adobe.token');
+
+    domainInput(el).value = 'api.adobe.io';
+    domainInput(el).dispatchEvent(new Event('input'));
+    expect(visibleHints(el)).not.toContain('any domain');
+  });
+
+  it('shows a throwing store handler as the error and stays open', async () => {
+    const el = mount();
+    el.submitHandler = () => {
+      throw new Error('bridge closed');
+    };
+    void el.open();
+    fill(el);
+    saveBtn(el).click();
+    await flush();
+
+    expect(errorLine(el).textContent).toContain('bridge closed');
+    expect(innerDialog(el).hasAttribute('open')).toBe(true);
+  });
+
+  it('applies prefill attributes live, before and after the first open', () => {
+    const el = mount();
+    el.setAttribute('secret-name', 'FROM_ATTR');
+    el.setAttribute('domain', 'api.example.com');
+    el.setAttribute('persist-default', '');
+    el.heading = 'Give me a token';
+
+    expect(nameInput(el).value).toBe('FROM_ATTR');
+    expect(domainInput(el).value).toBe('api.example.com');
+    expect(persistBox(el).checked).toBe(true);
+    expect(innerDialog(el).getAttribute('heading')).toBe('Give me a token');
+
+    // Removal falls back to the documented defaults, not to an empty dialog.
+    el.removeAttribute('domain');
+    el.persistDefault = false;
+    el.heading = null;
+    expect(domainInput(el).value).toBe('*');
+    expect(persistBox(el).checked).toBe(false);
+    expect(innerDialog(el).getAttribute('heading')).toBe('Share a secret securely');
+  });
+
+  it('lets a request override the heading', async () => {
+    const el = mount();
+    void el.open({ heading: 'Adobe needs a key' });
+    await flush();
+    expect(innerDialog(el).getAttribute('heading')).toBe('Adobe needs a key');
+  });
+
+  it('surfaces a host-side failure through setError', () => {
+    const el = mount();
+    void el.open();
+    el.setError('Keychain is locked');
+    expect(errorLine(el).textContent).toBe('Keychain is locked');
+    expect(saveBtn(el).disabled).toBe(false);
+  });
+
+  it('starts every open() from a cleared, masked value field', async () => {
+    const el = mount();
+    const first = el.open();
+    fill(el);
+    cancelBtn(el).click();
+    await first;
+
+    void el.open({ name: 'OTHER' });
+    expect(valueInput(el).value).toBe('');
+    expect(valueInput(el).type).toBe('password');
+  });
+});

--- a/packages/webcomponents/tests/overlay/slicc-secret-dialog.test.ts
+++ b/packages/webcomponents/tests/overlay/slicc-secret-dialog.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type SecretDialogSubmitDetail,
+  type SecretDialogSubmitSummary,
   SliccSecretDialog,
 } from '../../src/overlay/slicc-secret-dialog.js';
 import { ensureGlobalTokens } from '../../src/theme/tokens.js';
@@ -89,11 +90,22 @@ describe('slicc-secret-dialog', () => {
     expect(valueInput(el).type).toBe('password');
   });
 
-  it('defaults the scope to a single wildcard row and warns what it means', async () => {
+  // A default scope is a scope nobody read. With nothing suggested the human has
+  // to name one, and the drawer holding it is never collapsed out of sight.
+  it('starts with one empty scope row, visible, and no wildcard default', async () => {
     const el = mount();
     void el.open();
     await flush();
-    expect(domainInputs(el).map((i) => i.value)).toEqual(['*']);
+    expect(domainInputs(el).map((i) => i.value)).toEqual(['']);
+    expect(visibleHints(el)).not.toContain('any domain');
+    expect((el.querySelector('details') as HTMLDetailsElement).open).toBe(true);
+  });
+
+  it('warns only once a wildcard is typed deliberately', () => {
+    const el = mount();
+    void el.open();
+    domainInput(el).value = '*';
+    domainInput(el).dispatchEvent(new Event('input'));
     expect(visibleHints(el)).toContain('any domain');
   });
 
@@ -167,14 +179,14 @@ describe('slicc-secret-dialog', () => {
     expect(valueInput(el).value).toBe('');
   });
 
-  it('emits a composed, bubbling slicc-secret-submit', async () => {
+  it('emits a composed, bubbling slicc-secret-submit that carries no value', async () => {
     const el = mount();
-    const seen: SecretDialogSubmitDetail[] = [];
+    const seen: SecretDialogSubmitSummary[] = [];
     // Listened for on `document`, not the element: that only passes if the event
     // is composed AND bubbling, which is the contract under test.
     document.addEventListener(
       'slicc-secret-submit',
-      (e) => seen.push((e as CustomEvent<SecretDialogSubmitDetail>).detail),
+      (e) => seen.push((e as CustomEvent<SecretDialogSubmitSummary>).detail),
       { once: true }
     );
     const pending = el.open();
@@ -183,8 +195,15 @@ describe('slicc-secret-dialog', () => {
     await pending;
 
     expect(seen).toHaveLength(1);
-    expect(seen[0].name).toBe('GITHUB_TOKEN');
-    expect(seen[0].persist).toBe(false);
+    // Exact equality, not a property check: this event escapes the component into
+    // the page, so ANY extra key on it would be a leak. The credential must not be
+    // reachable from the detail under any name.
+    expect(seen[0]).toEqual({
+      name: 'GITHUB_TOKEN',
+      domains: ['api.github.com', '*.github.com'],
+      persist: false,
+    } satisfies SecretDialogSubmitSummary);
+    expect(JSON.stringify(seen[0])).not.toContain('ghp_realtoken');
   });
 
   it('resolves null and emits slicc-secret-cancel on Cancel', async () => {
@@ -303,6 +322,32 @@ describe('slicc-secret-dialog', () => {
     expect(innerDialog(el).hasAttribute('open')).toBe(false);
   });
 
+  // A store write cannot be recalled, so "cancelled" must not be answerable over
+  // one that is still in flight — it would report no secret where one landed.
+  it('refuses every dismissal while the store write is pending', async () => {
+    const el = mount();
+    let release: (v: null) => void = () => {};
+    el.submitHandler = () => new Promise<null>((r) => (release = r));
+    const pending = el.open();
+    fill(el);
+    saveBtn(el).click();
+    await flush();
+
+    expect(saveBtn(el).disabled).toBe(true);
+    expect(cancelBtn(el).disabled).toBe(true);
+    cancelBtn(el).click();
+    innerDialog(el).dispatchEvent(
+      new CustomEvent('slicc-dialog-close', { detail: { reason: 'escape' }, bubbles: true })
+    );
+    await flush();
+    expect(innerDialog(el).hasAttribute('open')).toBe(true);
+
+    release(null);
+    // The submit path, not the dismissal, is what resolves it — with the detail.
+    await expect(pending).resolves.toMatchObject({ name: 'GITHUB_TOKEN' });
+    expect(cancelBtn(el).disabled).toBe(false);
+  });
+
   it('submits on Enter in the value field', async () => {
     const el = mount();
     const pending = el.open();
@@ -359,11 +404,12 @@ describe('slicc-secret-dialog', () => {
     expect(persistBox(el).checked).toBe(true);
     expect(innerDialog(el).getAttribute('heading')).toBe('Give me a token');
 
-    // Removal falls back to the documented defaults, not to an empty dialog.
+    // Removal falls back to the documented defaults: an EMPTY scope row (there is
+    // no default scope) and a session-only secret.
     el.removeAttribute('domain');
     el.persistDefault = false;
     el.heading = null;
-    expect(domainInput(el).value).toBe('*');
+    expect(domainInput(el).value).toBe('');
     expect(persistBox(el).checked).toBe(false);
     expect(innerDialog(el).getAttribute('heading')).toBe('Share a secret securely');
   });


### PR DESCRIPTION
Two ways a human can hand SLICC a credential, both landing on the same surface:

1. **Share secret securely** in the composer's `+` menu, below file upload and screen sharing.
2. **`request_secret`**, an agent-invokable tool for when the model needs a credential it must not read.

## The plaintext never enters the agent realm

`ui/wc/wc-secret-request.ts` runs in the page realm, writes what the human typed straight to the trusted-realm store through the existing `SecretBackend`, and returns only `{ name, maskedValue, domains, persisted }`. The mask reaches the agent's shell as `$NAME` via a new `AlmostBashShellHeadless.setMaskedEnvVar` seam, exactly like `secret set` already does.

The tool-UI/sandboxed-iframe pattern was the obvious route and the wrong one here: the value would have crossed the iframe, the registry, and the agent realm just to be typed. A kernel-worker caller reaches the page surface over a new `secret-request` panel-RPC op, and a float with no surface installed answers `{ stored: false, reason: 'unavailable' }` rather than rejecting — capability fails open, secrecy fails closed.

## The dialog

`<slicc-secret-dialog>` (`@slicc/webcomponents`, `Overlay/SecretDialog` in Storybook) mounts through `mountTrusted`, because it is precisely the fake "enter your API key" form that `trusted-layer.ts` exists to defend against; a float without that layer falls back to `document.body` with a loud warning.

- Password by default with a reveal toggle. The value lives only in the input: never reflected to an attribute, never emitted except in the submit detail, cleared on every close.
- `persistent`, so a stray backdrop click cannot discard a half-typed credential.
- The store's verdict decides whether it closes — `submitHandler` returning a message keeps the dialog open with the value intact, so a stalled Keychain costs a click rather than a re-paste.
- **Additional options** holds one row per allowed domain with − / + trailing each row, plus "Keep after this session ends" (off = session-only in-memory store, on = persisted like `--persist`). The last row's − stays disabled because the stores reject a scope-less secret.
- The description names the provider the value is kept from ("Secure secrets cannot be read by Anthropic, and work only on the domains you specify"), derived from the selected model.
- Warnings that do not block: a non-POSIX name (no `$NAME` in the shell), a wildcard scope, and a multi-line paste — the single-line input joins the breaks itself, silently mangling a PEM key.

## The tool

`request_secret` takes `{ name, reason, domains?, persist? }`, resolves the page-realm surface first and panel-RPC second (5-minute budget), and reports the mask, scope, and lifetime. A decline is returned as `isError` so the model stops rather than proceeding with a value it invented.

## Screenshots

Storybook: `Overlay/SecretDialog` (8 stories, light + dark) and `AddMenu/AddMenu → SecretAction`.

## Tests

New: 27 dialog tests, 11 surface tests, 13 tool tests. Extended: add-menu (5), `wc-attach` routing + menu gating (4), `panel-rpc-handlers` (3), `scoop-context.tools` wiring, and the `setMaskedEnvVar` seam end-to-end through a real shell in `almost-bash-shell-secret.integration.test.ts`.

Four sibling `scoop-context.*` suites had their `src/tools/index.js` mocks extended for the new tool.

## Docs

`docs/secrets.md` (a third way to add a secret), `docs/tools-reference.md` (`request_secret` + the availability table), `docs/webcomponents-details.md` (the component's load-bearing decisions), `packages/webcomponents/CLAUDE.md`.

## Verification

lint, typecheck, `npm test` (21k+), webcomponents browser suite (2,372), coverage above every floor for both packages, both builds, and the touched-file debt gate.
