### PR TITLE
fix(sprinkles): restore current theme and state after iframe remounts

### DIFF
--- a/docs/panel-system-design.md
+++ b/docs/panel-system-design.md
@@ -432,3 +432,9 @@ The init payload reads the latest saved bridge state. A sprinkle should restore
 its state when it receives `sprinkle-init`, before persisting startup defaults.
 Theme registration immediately sends the active theme and custom overrides;
 subsequent changes continue through the same broadcaster.
+
+Theme tokens are sanitized before broadcast using the same validation as the
+parent theme engine. Sanitized `.sprinkle-*` and `.fill` rules travel with the
+update instead of being frozen into the initial document. Sprinkles and dips
+share a receiver that accepts theme messages only from their parent and replaces
+or clears both tokens and custom rules when a preset changes or resets.

--- a/docs/panel-system-design.md
+++ b/docs/panel-system-design.md
@@ -423,3 +423,12 @@ Behavioral change to call out: `sessions-rail` (the freezer) is `position: fixed
 today, reserving space via `--rail-w` on `.wcui-appcol`. As a real docked panel
 it moves into flow, and its expand/collapse becomes a size change rather than an
 overlay + padding transition.
+
+### Sprinkle reloads after layout changes
+
+Full-document sprinkles receive the current `slicc-theme` message followed by
+`sprinkle-init` on every iframe load, including loads caused by rail reparenting.
+The init payload reads the latest saved bridge state. A sprinkle should restore
+its state when it receives `sprinkle-init`, before persisting startup defaults.
+Theme registration immediately sends the active theme and custom overrides;
+subsequent changes continue through the same broadcaster.

--- a/packages/webapp/src/ui/dip.ts
+++ b/packages/webapp/src/ui/dip.ts
@@ -35,6 +35,7 @@ import {
 } from '../kernel/usb-device-registry.js';
 import * as usbOps from '../kernel/usb-operations.js';
 import { isNestedInAnotherFrame, nudgeIframeRepaint } from './iframe-repaint.js';
+import { iframeThemeBridgeSource } from './iframe-theme.js';
 import {
   runJshOp,
   type SprinkleAgentOptions,
@@ -321,10 +322,11 @@ function buildBridgeScript(includeExec: boolean): string {
     parent.postMessage({ type: 'dip-height',
       height: document.documentElement.scrollHeight }, '*');
   }
+  ${iframeThemeBridgeSource}
   window.addEventListener('message', function(e) {
     if (!e.data || typeof e.data.type !== 'string') return;
     if (e.data.type === 'slicc-theme') {
-      document.documentElement.classList.toggle('theme-light', !!e.data.isLight);
+      applyIframeTheme(e);
       return;
     }
     /* Pushed device events (currently 'hid:inputreport'). The host

--- a/packages/webapp/src/ui/iframe-theme.ts
+++ b/packages/webapp/src/ui/iframe-theme.ts
@@ -1,0 +1,30 @@
+/** Shared receiver for parent-sanitized theme updates in sprinkles and dips. */
+export const iframeThemeBridgeSource = `
+  var _themeOverrideKeys = [];
+  var _themeCssStyle = null;
+  function applyIframeTheme(event) {
+    if (event.source !== parent) return;
+    var msg = event.data;
+    document.documentElement.classList.toggle('theme-light', !!msg.isLight);
+    var rootStyle = document.documentElement.style;
+    _themeOverrideKeys.forEach(function(key) { rootStyle.removeProperty(key); });
+    _themeOverrideKeys = [];
+    Object.entries(msg.overrides || {}).forEach(function(entry) {
+      if (entry[0].startsWith('--') && typeof entry[1] === 'string') {
+        rootStyle.setProperty(entry[0], entry[1]);
+        _themeOverrideKeys.push(entry[0]);
+      }
+    });
+    if (typeof msg.css === 'string' && msg.css) {
+      if (!_themeCssStyle) {
+        _themeCssStyle = document.createElement('style');
+        _themeCssStyle.id = 'slicc-iframe-theme-overrides';
+        document.head.appendChild(_themeCssStyle);
+      }
+      _themeCssStyle.textContent = msg.css;
+    } else if (_themeCssStyle) {
+      _themeCssStyle.remove();
+      _themeCssStyle = null;
+    }
+  }
+`;

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -427,6 +427,8 @@ export class SprinkleRenderer {
   private bridge: SprinkleBridgeAPI;
   private scripts: HTMLScriptElement[] = [];
   private iframe: HTMLIFrameElement | null = null;
+  private iframeLoadHandler: (() => void) | null = null;
+  private registeredWindow: Window | null = null;
   private messageHandler: ((event: MessageEvent) => void) | null = null;
   private visibilityObserver: IntersectionObserver | null = null;
   private bridgeLifecycleReady = false;
@@ -496,6 +498,7 @@ export class SprinkleRenderer {
   var _hidInputReportListeners = new Set();
   var _sprinkleName = '';
   var _state = null;
+  var _themeOverrideKeys = [];
   var _cbId = 0;
   var _callbacks = {};
 
@@ -516,6 +519,15 @@ export class SprinkleRenderer {
       }
     } else if (msg.type === 'slicc-theme') {
       document.documentElement.classList.toggle('theme-light', !!msg.isLight);
+      var rootStyle = document.documentElement.style;
+      _themeOverrideKeys.forEach(function(key) { rootStyle.removeProperty(key); });
+      _themeOverrideKeys = [];
+      Object.entries(msg.overrides || {}).forEach(function(entry) {
+        if (entry[0].startsWith('--') && typeof entry[1] === 'string') {
+          rootStyle.setProperty(entry[0], entry[1]);
+          _themeOverrideKeys.push(entry[0]);
+        }
+      });
     } else if (msg.id && _callbacks[msg.id]) {
       var cb = _callbacks[msg.id];
       delete _callbacks[msg.id];
@@ -847,14 +859,21 @@ export class SprinkleRenderer {
     this.messageHandler = createIframeMessageListener(iframe, handlers);
     window.addEventListener('message', this.messageHandler);
 
-    const loaded = waitForIframeLoad(iframe, () => {
-      // Register with theme broadcaster so prefers-color-scheme changes flip CSS vars live
-      registerSprinkleWindow(iframe.contentWindow);
+    // Reparenting a srcdoc iframe creates a new document. Hydrate from the
+    // current bridge state and theme on every load, not just the first one.
+    this.iframeLoadHandler = () => {
+      unregisterSprinkleWindow(this.registeredWindow);
+      this.registeredWindow = iframe.contentWindow;
+      registerSprinkleWindow(this.registeredWindow);
       const savedState = this.bridge.getState();
       iframe.contentWindow?.postMessage(
         { type: 'sprinkle-init', name: sprinkleName, savedState },
         '*'
       );
+    };
+    iframe.addEventListener('load', this.iframeLoadHandler);
+
+    const loaded = waitForIframeLoad(iframe, () => {
       // Force a layout read while the pin (or the used 100% box) is in
       // effect, then restore percentage sizing so later panel resizes
       // still flow into the frame.
@@ -946,7 +965,12 @@ export class SprinkleRenderer {
       this.messageHandler = null;
     }
     if (this.iframe) {
-      unregisterSprinkleWindow(this.iframe.contentWindow);
+      if (this.iframeLoadHandler) {
+        this.iframe.removeEventListener('load', this.iframeLoadHandler);
+        this.iframeLoadHandler = null;
+      }
+      unregisterSprinkleWindow(this.registeredWindow);
+      this.registeredWindow = null;
       this.iframe.remove();
       this.iframe = null;
     }
@@ -1003,6 +1027,9 @@ export function collectThemeCSS(): string {
       );
     });
   for (const sheet of document.styleSheets) {
+    // Dynamic overrides arrive through slicc-theme; freezing them here would
+    // leave old preset colors behind after a theme switch or reset.
+    if ((sheet.ownerNode as HTMLElement | null)?.id === 'slicc-theme-overrides') continue;
     try {
       for (const rule of sheet.cssRules) {
         if (rule instanceof CSSFontFaceRule) {

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -10,6 +10,7 @@
 
 import { isNestedInAnotherFrame, nudgeIframeRepaint } from '@slicc/shared-ts';
 import type { EntryType } from '../fs/index.js';
+import { iframeThemeBridgeSource } from './iframe-theme.js';
 import {
   iframeFetchResponseSource,
   type SprinkleAgentOptions,
@@ -498,9 +499,9 @@ export class SprinkleRenderer {
   var _hidInputReportListeners = new Set();
   var _sprinkleName = '';
   var _state = null;
-  var _themeOverrideKeys = [];
   var _cbId = 0;
   var _callbacks = {};
+  ${iframeThemeBridgeSource}
 
   window.addEventListener('message', function(event) {
     var msg = event.data;
@@ -518,16 +519,7 @@ export class SprinkleRenderer {
         });
       }
     } else if (msg.type === 'slicc-theme') {
-      document.documentElement.classList.toggle('theme-light', !!msg.isLight);
-      var rootStyle = document.documentElement.style;
-      _themeOverrideKeys.forEach(function(key) { rootStyle.removeProperty(key); });
-      _themeOverrideKeys = [];
-      Object.entries(msg.overrides || {}).forEach(function(entry) {
-        if (entry[0].startsWith('--') && typeof entry[1] === 'string') {
-          rootStyle.setProperty(entry[0], entry[1]);
-          _themeOverrideKeys.push(entry[0]);
-        }
-      });
+      applyIframeTheme(event);
     } else if (msg.id && _callbacks[msg.id]) {
       var cb = _callbacks[msg.id];
       delete _callbacks[msg.id];

--- a/packages/webapp/src/ui/theme-engine.ts
+++ b/packages/webapp/src/ui/theme-engine.ts
@@ -129,7 +129,7 @@ function sanitizeCustomCss(css: string | undefined): string | undefined {
 }
 
 /** Sanitize a full theme in place (returns a new object; input is untouched). */
-function sanitizeTheme(theme: SliccTheme): SliccTheme {
+export function sanitizeTheme(theme: SliccTheme): SliccTheme {
   return {
     ...theme,
     tokens: sanitizeTokens(theme.tokens),

--- a/packages/webapp/src/ui/theme.ts
+++ b/packages/webapp/src/ui/theme.ts
@@ -60,7 +60,10 @@ export function isThemeLight(): boolean {
 const sprinkleWindows = new Set<Window>();
 
 export function registerSprinkleWindow(w: Window | null | undefined): void {
-  if (w) sprinkleWindows.add(w);
+  if (!w) return;
+  sprinkleWindows.add(w);
+  // A newly loaded/reparented document missed earlier broadcasts.
+  syncSprinkleTheme(w);
 }
 
 export function unregisterSprinkleWindow(w: Window | null | undefined): void {
@@ -74,17 +77,20 @@ function getActiveOverrides(): Record<string, string> | null {
   return theme?.tokens ?? null;
 }
 
-function broadcastTheme(): void {
-  const isLight = isThemeLight();
-  const overrides = getActiveOverrides();
-  for (const w of sprinkleWindows) {
-    try {
-      w.postMessage({ type: 'slicc-theme', isLight, overrides }, '*');
-    } catch {
-      // Window likely detached — drop silently.
-      sprinkleWindows.delete(w);
-    }
+function syncSprinkleTheme(w: Window): void {
+  try {
+    w.postMessage(
+      { type: 'slicc-theme', isLight: isThemeLight(), overrides: getActiveOverrides() },
+      '*'
+    );
+  } catch {
+    // Window likely detached — drop silently.
+    sprinkleWindows.delete(w);
   }
+}
+
+function broadcastTheme(): void {
+  for (const w of sprinkleWindows) syncSprinkleTheme(w);
 }
 
 export function applyTheme(): void {

--- a/packages/webapp/src/ui/theme.ts
+++ b/packages/webapp/src/ui/theme.ts
@@ -3,7 +3,12 @@
  * and applies .theme-light class on <html> for CSS variable switching.
  */
 
-import { applyThemeOverrides, getActiveThemeId, getCustomThemes } from './theme-engine.js';
+import {
+  applyThemeOverrides,
+  getActiveThemeId,
+  getCustomThemes,
+  sanitizeTheme,
+} from './theme-engine.js';
 import { PRESETS } from './theme-presets.js';
 
 export type ThemePreference = 'dark' | 'light' | 'system';
@@ -74,13 +79,35 @@ function getActiveOverrides(): Record<string, string> | null {
   const id = getActiveThemeId();
   if (!id) return null;
   const theme = PRESETS.find((p) => p.id === id) ?? getCustomThemes().find((t) => t.id === id);
-  return theme?.tokens ?? null;
+  // Stored/imported theme JSON is untrusted, just as it is in buildThemeCss().
+  return theme ? sanitizeTheme(theme).tokens : null;
+}
+
+/** Preserve the sprinkle rules from the already-sanitized preset stylesheet. */
+function getSprinkleOverrideCss(): string {
+  const style = document.getElementById?.('slicc-theme-overrides') as HTMLStyleElement | null;
+  const rules: string[] = [];
+  for (const rule of style?.sheet?.cssRules ?? []) {
+    if (
+      'selectorText' in rule &&
+      typeof rule.selectorText === 'string' &&
+      (rule.selectorText.includes('.sprinkle-') || rule.selectorText.includes('.fill'))
+    ) {
+      rules.push(rule.cssText);
+    }
+  }
+  return rules.join('\n');
 }
 
 function syncSprinkleTheme(w: Window): void {
   try {
     w.postMessage(
-      { type: 'slicc-theme', isLight: isThemeLight(), overrides: getActiveOverrides() },
+      {
+        type: 'slicc-theme',
+        isLight: isThemeLight(),
+        overrides: getActiveOverrides(),
+        css: getSprinkleOverrideCss(),
+      },
       '*'
     );
   } catch {

--- a/packages/webapp/tests/ui/dip.test.ts
+++ b/packages/webapp/tests/ui/dip.test.ts
@@ -399,6 +399,8 @@ describe('mountDraftDip', () => {
     });
 
     iframe.dispatchEvent(new Event('load'));
+    // Registration now hydrates the theme; count only subsequent content updates.
+    postSpy.mockClear();
 
     draft.update('<div>same</div>');
     draft.update('<div>same</div>');

--- a/packages/webapp/tests/ui/iframe-theme.test.ts
+++ b/packages/webapp/tests/ui/iframe-theme.test.ts
@@ -1,0 +1,189 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mountDip } from '../../src/ui/dip.js';
+import type { SprinkleBridgeAPI } from '../../src/ui/sprinkle-bridge.js';
+import { SprinkleRenderer } from '../../src/ui/sprinkle-renderer.js';
+import {
+  applyTheme,
+  registerSprinkleWindow,
+  unregisterSprinkleWindow,
+} from '../../src/ui/theme.js';
+import { clearActiveTheme, saveCustomTheme, setActiveTheme } from '../../src/ui/theme-engine.js';
+import type { SliccTheme } from '../../src/ui/theme-types.js';
+
+interface ThemeMessage {
+  type: 'slicc-theme';
+  isLight: boolean;
+  overrides: Record<string, string> | null;
+  css: string;
+}
+
+describe.each(['sprinkle', 'dip'] as const)('%s iframe theme integration', (kind) => {
+  let host: JSDOM;
+  let frame: JSDOM;
+  let dispose: () => void;
+  let receiver: Window;
+  let posts: ThemeMessage[];
+
+  beforeEach(() => {
+    host = new JSDOM('<!doctype html><html><head></head><body></body></html>', {
+      url: 'http://localhost',
+    });
+    for (const key of [
+      'window',
+      'document',
+      'localStorage',
+      'location',
+      'getComputedStyle',
+      'CSSStyleRule',
+      'CSSFontFaceRule',
+    ] as const) {
+      vi.stubGlobal(key, host.window[key]);
+    }
+    posts = [];
+  });
+
+  afterEach(() => {
+    unregisterSprinkleWindow(receiver);
+    dispose?.();
+    frame?.window.close();
+    host.window.close();
+    vi.unstubAllGlobals();
+  });
+
+  function selectTheme(theme: Pick<SliccTheme, 'tokens' | 'css'>): void {
+    saveCustomTheme({ id: 'imported', name: 'Imported', base: 'dark', ...theme });
+    setActiveTheme('imported');
+    applyTheme();
+    // jsdom omits CSSStyleSheet.ownerNode; supply the browser's association so
+    // the collector really exercises the dynamic stylesheet exclusion.
+    const style = document.getElementById('slicc-theme-overrides') as HTMLStyleElement | null;
+    if (style?.sheet) {
+      Object.defineProperty(style.sheet, 'ownerNode', { configurable: true, value: style });
+    }
+  }
+
+  async function mount(): Promise<void> {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const content =
+      '<!doctype html><html><body><div class="sprinkle-card fill">Card</div></body></html>';
+    if (kind === 'sprinkle') {
+      // Only the theme/load lifecycle is used by this document.
+      const bridge = { name: 'theme-test', getState: () => null } as SprinkleBridgeAPI;
+      const renderer = new SprinkleRenderer(container, bridge);
+      dispose = () => renderer.dispose();
+      await renderer.render(content, 'theme-test');
+    } else {
+      const dip = mountDip(container, content, vi.fn());
+      dispose = () => dip.dispose();
+    }
+    const srcdoc = container.querySelector('iframe')!.srcdoc;
+    expect(srcdoc).not.toContain('outline: 3px');
+    // Execute the actual generated document; jsdom does not load srcdoc itself.
+    frame = new JSDOM(srcdoc, {
+      url: 'http://localhost',
+      runScripts: 'dangerously',
+      pretendToBeVisual: true,
+      beforeParse(win) {
+        Object.defineProperty(win, 'parent', { value: host.window });
+        win.ResizeObserver = class {
+          observe() {}
+          unobserve() {}
+          disconnect() {}
+        };
+      },
+    });
+    receiver = {
+      postMessage(message: ThemeMessage) {
+        posts.push(message);
+        frame.window.dispatchEvent(
+          new frame.window.MessageEvent('message', {
+            data: message,
+            source: host.window as unknown as Window,
+          })
+        );
+      },
+    } as unknown as Window;
+    registerSprinkleWindow(receiver);
+  }
+
+  it('sanitizes imported tokens on initial registration and subsequent updates', async () => {
+    const tokens = {
+      '--s2-gray-25': 'url(https://example.invalid/pixel)',
+      '--expression': 'expression(alert(1))',
+      '--injection': 'red; background: blue',
+      '--safe': '#abcdef',
+      's2-accent': 'rgba(10, 20, 30, 0.5)',
+      '--reference': 'var(--safe)',
+    };
+    selectTheme({ tokens });
+    await mount();
+    const safe = {
+      '--safe': '#abcdef',
+      '--s2-accent': 'rgba(10, 20, 30, 0.5)',
+      '--reference': 'var(--safe)',
+    };
+    expect(posts.at(-1)?.overrides).toEqual(safe);
+    const rootStyle = frame.window.document.documentElement.style;
+    expect(rootStyle.getPropertyValue('--s2-gray-25')).toBe('');
+    expect(rootStyle.getPropertyValue('--safe')).toBe('#abcdef');
+
+    selectTheme({ tokens: { ...tokens, '--safe': '#123456' } });
+    expect(posts.at(-1)?.overrides).toEqual({ ...safe, '--safe': '#123456' });
+    expect(rootStyle.getPropertyValue('--safe')).toBe('#123456');
+    expect(rootStyle.cssText).not.toMatch(/url\(|expression\(|background:/);
+  });
+
+  it('preserves sanitized sprinkle CSS, replaces it on a switch, and clears it on reset', async () => {
+    selectTheme({
+      tokens: { '--accent': '#abcdef' },
+      css: '.sprinkle-card { outline: 3px solid red; } .fill { padding: 17px; } .wcui-card { color: blue; }',
+    });
+    await mount();
+    const doc = frame.window.document;
+    const card = doc.querySelector('.sprinkle-card')!;
+    const getStyle = () => doc.getElementById('slicc-iframe-theme-overrides');
+    expect(posts.at(-1)?.css).toContain('.sprinkle-card');
+    expect(posts.at(-1)?.css).toContain('.fill');
+    expect(posts.at(-1)?.css).not.toContain('.wcui-card');
+    expect(getStyle()?.textContent).toContain('outline: 3px solid red');
+    expect(frame.window.getComputedStyle(card).padding).toBe('17px');
+
+    selectTheme({ tokens: { '--other': '#123456' }, css: '.fill { padding: 23px; }' });
+    expect(doc.querySelectorAll('#slicc-iframe-theme-overrides')).toHaveLength(1);
+    expect(getStyle()?.textContent).not.toContain('outline');
+    expect(frame.window.getComputedStyle(card).padding).toBe('23px');
+    expect(doc.documentElement.style.getPropertyValue('--accent')).toBe('');
+
+    clearActiveTheme();
+    applyTheme();
+    expect(posts.at(-1)).toMatchObject({ overrides: null, css: '' });
+    expect(getStyle()).toBeNull();
+    expect(frame.window.getComputedStyle(card).padding).not.toBe('23px');
+    expect(doc.documentElement.style.getPropertyValue('--other')).toBe('');
+  });
+
+  it('drops unsafe custom CSS and rejects theme messages from other windows', async () => {
+    selectTheme({
+      tokens: { '--safe': '#abcdef' },
+      css: '.sprinkle-card { background: url(https://example.invalid/pixel); }',
+    });
+    await mount();
+    expect(posts.at(-1)?.css).toBe('');
+    frame.window.dispatchEvent(
+      new frame.window.MessageEvent('message', {
+        source: frame.window as unknown as Window,
+        data: {
+          type: 'slicc-theme',
+          isLight: true,
+          overrides: { '--unsafe': 'url(https://example.invalid/pixel)' },
+          css: '.fill { padding: 99px; }',
+        },
+      })
+    );
+    expect(frame.window.document.documentElement.classList.contains('theme-light')).toBe(false);
+    expect(frame.window.document.documentElement.style.getPropertyValue('--unsafe')).toBe('');
+    expect(frame.window.document.getElementById('slicc-iframe-theme-overrides')).toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -495,6 +495,7 @@ describe('full document rendering', () => {
       frameDom.window.dispatchEvent(
         new frameDom.window.MessageEvent('message', {
           data: { type: 'slicc-theme', isLight, overrides },
+          source: frameDom.window.parent,
         })
       );
     };
@@ -526,7 +527,10 @@ describe('full document rendering', () => {
     getState.mockReturnValue({ items: ['first', 'second'] });
     dom.window.document.body.setAttribute('data-theme', 'light');
     iframe.dispatchEvent(new dom.window.Event('load'));
-    expect(post).toHaveBeenCalledWith({ type: 'slicc-theme', isLight: true, overrides: null }, '*');
+    expect(post).toHaveBeenCalledWith(
+      { type: 'slicc-theme', isLight: true, overrides: null, css: '' },
+      '*'
+    );
     expect(post).toHaveBeenCalledWith(
       { type: 'sprinkle-init', name: 'work-list', savedState: { items: ['first', 'second'] } },
       '*'
@@ -536,7 +540,7 @@ describe('full document rendering', () => {
     dom.window.document.body.setAttribute('data-theme', 'dark');
     iframe.dispatchEvent(new dom.window.Event('load'));
     expect(post).toHaveBeenCalledWith(
-      { type: 'slicc-theme', isLight: false, overrides: null },
+      { type: 'slicc-theme', isLight: false, overrides: null, css: '' },
       '*'
     );
     renderer.dispose();

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -482,6 +482,69 @@ describe('full document rendering', () => {
     expect(bridge.readFile).not.toHaveBeenCalled();
   });
 
+  it('updates and clears preset overrides in the iframe bridge', async () => {
+    const renderer = new SprinkleRenderer(container, makeBridge('theme-test'));
+    await renderer.render(
+      '<!DOCTYPE html><html><head></head><body>Theme</body></html>',
+      'theme-test'
+    );
+    const srcdoc = container.querySelector('iframe')!.srcdoc;
+    const frameDom = new JSDOM(srcdoc, { runScripts: 'dangerously' });
+    const root = frameDom.window.document.documentElement;
+    const theme = (isLight: boolean, overrides: object | null) => {
+      frameDom.window.dispatchEvent(
+        new frameDom.window.MessageEvent('message', {
+          data: { type: 'slicc-theme', isLight, overrides },
+        })
+      );
+    };
+    theme(false, { '--s2-accent': '#abcdef', '--s2-bg-base': '#101010' });
+    expect(root.classList.contains('theme-light')).toBe(false);
+    expect(root.style.getPropertyValue('--s2-accent')).toBe('#abcdef');
+    theme(true, { '--s2-accent': '#123456' });
+    expect(root.classList.contains('theme-light')).toBe(true);
+    expect(root.style.getPropertyValue('--s2-accent')).toBe('#123456');
+    expect(root.style.getPropertyValue('--s2-bg-base')).toBe('');
+    theme(true, null);
+    expect(root.style.getPropertyValue('--s2-accent')).toBe('');
+    frameDom.window.close();
+    renderer.dispose();
+  });
+
+  it('rehydrates the current state and theme after an iframe reload', async () => {
+    const bridge = makeBridge('work-list');
+    const getState = vi.mocked(bridge.getState);
+    getState.mockReturnValue({ items: ['first'] });
+    const renderer = new SprinkleRenderer(container, bridge);
+    await renderer.render(
+      '<!DOCTYPE html><html><head></head><body>Queue</body></html>',
+      'work-list'
+    );
+    const iframe = container.querySelector('iframe')!;
+    const post = vi.spyOn(iframe.contentWindow!, 'postMessage');
+
+    getState.mockReturnValue({ items: ['first', 'second'] });
+    dom.window.document.body.setAttribute('data-theme', 'light');
+    iframe.dispatchEvent(new dom.window.Event('load'));
+    expect(post).toHaveBeenCalledWith({ type: 'slicc-theme', isLight: true, overrides: null }, '*');
+    expect(post).toHaveBeenCalledWith(
+      { type: 'sprinkle-init', name: 'work-list', savedState: { items: ['first', 'second'] } },
+      '*'
+    );
+
+    post.mockClear();
+    dom.window.document.body.setAttribute('data-theme', 'dark');
+    iframe.dispatchEvent(new dom.window.Event('load'));
+    expect(post).toHaveBeenCalledWith(
+      { type: 'slicc-theme', isLight: false, overrides: null },
+      '*'
+    );
+    renderer.dispose();
+    post.mockClear();
+    iframe.dispatchEvent(new dom.window.Event('load'));
+    expect(post).not.toHaveBeenCalled();
+  });
+
   it('dispose removes full-doc iframe', async () => {
     const bridge = makeBridge('full-doc');
     const renderer = new SprinkleRenderer(container, bridge);

--- a/packages/webapp/tests/ui/theme-wc.test.ts
+++ b/packages/webapp/tests/ui/theme-wc.test.ts
@@ -65,6 +65,7 @@ describe('watchSprinkleThemeBroadcast', () => {
         posts.push(msg),
     } as unknown as Window;
     registerSprinkleWindow(fakeWindow);
+    expect(posts.at(-1)).toMatchObject({ type: 'slicc-theme', isLight: isThemeLight() });
     watchSprinkleThemeBroadcast();
 
     document.body.setAttribute('data-theme', 'light');
@@ -149,7 +150,7 @@ describeWithStorage('theme override broadcast to sprinkles', () => {
     setActiveTheme('bc-test');
     applyTheme();
 
-    const msg = posts.find((p: any) => p.type === 'slicc-theme') as any;
+    const msg = posts.filter((p: any) => p.type === 'slicc-theme').at(-1) as any;
     expect(msg).toBeDefined();
     expect(msg.overrides).toBeDefined();
     expect(msg.overrides['--s2-accent']).toBe('#abcdef');
@@ -164,7 +165,7 @@ describeWithStorage('theme override broadcast to sprinkles', () => {
 
     applyTheme();
 
-    const msg = posts.find((p: any) => p.type === 'slicc-theme') as any;
+    const msg = posts.filter((p: any) => p.type === 'slicc-theme').at(-1) as any;
     expect(msg).toBeDefined();
     expect(msg.overrides).toBeNull();
   });


### PR DESCRIPTION
## Summary

Full-document sprinkles now receive the current theme and saved state on every iframe load. Moving or resizing a panel can recreate its `srcdoc` document; previously the one-time initialization left the new document with stale colors or an empty queue. Switching and resetting presets now also updates and clears CSS overrides in already-open panels.

## Why

1. Open a populated full-document sprinkle such as Review.
2. Change the app theme or preset.
3. Reparent the panel between rail sizes.

The panel should retain the current theme and saved queue. Its original load-time theme and state should not return after reparenting.

## Approach / Implementation notes

A renderer-owned load listener hydrates each document and is removed on disposal. Theme registration immediately sends the current class, tokens sanitized by the parent theme engine, and matching `.sprinkle-*` / `.fill` rules from the sanitized preset stylesheet. A shared sprinkle/dip receiver accepts theme updates only from its parent, replaces the previous token and CSS overrides, and clears them on reset. The dynamic preset stylesheet stays out of the initial document so reset cannot leave frozen colors behind. Existing host-size pinning and first-load repaint handling are preserved.

## Cross-cutting impact

Dips use the same registration helper and iframe receiver, so imported presets and custom sprinkle CSS follow the same sanitization, update, and reset behavior in both surfaces. This changes the shared standalone/hosted rendering path used by CLI and thin extension sprinkles. No persisted schema or state migration is introduced. The physical extension, Electron and native follower surfaces were not exercised manually.

## Verification

- `npm run verify`: all eight checks pass, including the touched-file debt check.
- `npm run typecheck`: pass.
- `npm run test -- --maxWorkers=4`: 21,071 passing; 61 skipped.
- `npm run test:coverage -- --maxWorkers=4`: pass; 80.97% statements, 72.87% branches, 79.87% functions, 83% lines. The first run hit the existing cloud-status socket-reuse flake (404 instead of 400); the isolated test and full rerun passed.
- `npm run build`: pass, including native builds.
- `npm run build -w @slicc/chrome-extension` and `npm run bundle-size`: pass.
- Webcomponent Chromium suite: 2,340 passing; Spoon Chromium suite: 158 passing.
- Regression tests cover rehydration using the latest saved state, immediate theme registration, listener disposal, and applying/replacing/clearing preset overrides. Six additional integration cases execute the generated sprinkle and dip documents to check token sanitization, custom CSS preservation/switch/reset, and rejection of theme messages from other windows.
- Fresh-build browser checks confirm sanitized imported tokens, custom CSS on initial load and iframe remounts at measured 320px / 640px rail widths, live preset switching, and reset.
- UI recording and screenshot attached. Six updated skill panels also have four-mode capture/interaction evidence in their companion skills PRs. Data is synthetic; no provider requests completed, and no publication, live audio or physical USB workflows were exercised. Loose Ends automatically requested hydration while the shell bridge warmed up; those requests produced missing-provider notices in the empty test session.

## Documentation

`docs/panel-system-design.md` documents the per-load theme/state contract and the shared sanitized CSS update path.

## Risk & rollback

The main risk is initialization order for third-party full-document sprinkles: they must restore `sprinkle-init` state before persisting startup defaults. Existing fragment rendering is unaffected. Reverting this PR requires no data migration.

![Midnight Scoop preset with the saved Review queue](https://github.com/user-attachments/assets/35bf14f5-7a97-48cd-b55d-f891ae2c7524)