### PR TITLE
fix(webapp): fall back to legacy MCP initialize when discovery is rejected for a missing session id

### DIFF
--- a/packages/webapp/src/shell/mcp/client.ts
+++ b/packages/webapp/src/shell/mcp/client.ts
@@ -185,9 +185,11 @@ function rpcFailure(error: McpRpcError): Error {
 
 function rpcErrorFromFrame(
   frame: JsonRpcResponseFrame,
-  expectedId: number
+  expectedId: number,
+  opts?: { allowNullId?: boolean }
 ): McpRpcError | undefined {
-  if (frame.jsonrpc !== '2.0' || frame.id !== expectedId || Object.hasOwn(frame, 'result')) {
+  const idMatches = frame.id === expectedId || (opts?.allowNullId === true && frame.id === null);
+  if (frame.jsonrpc !== '2.0' || !idMatches || Object.hasOwn(frame, 'result')) {
     return undefined;
   }
   const error = frame.error;
@@ -196,10 +198,19 @@ function rpcErrorFromFrame(
     : undefined;
 }
 
+/**
+ * Parse the JSON-RPC error envelope out of an HTTP >= 400 body.
+ *
+ * A transport-level rejection is often raised before the server has attributed
+ * the payload to a request, and JSON-RPC 2.0 requires `id: null` in exactly
+ * that case (Cloudflare's `agents` SDK does this for its missing-session
+ * rejection). A null id is therefore accepted here, unlike on the success
+ * path, where the id is what associates a frame with its request.
+ */
 function parseRpcError(text: string, expectedId: number): McpRpcError | undefined {
   try {
     const frame = JSON.parse(text) as JsonRpcResponseFrame;
-    return rpcErrorFromFrame(frame, expectedId);
+    return rpcErrorFromFrame(frame, expectedId, { allowNullId: true });
   } catch {
     return undefined;
   }

--- a/packages/webapp/src/shell/mcp/client.ts
+++ b/packages/webapp/src/shell/mcp/client.ts
@@ -205,6 +205,30 @@ function parseRpcError(text: string, expectedId: number): McpRpcError | undefine
   }
 }
 
+/**
+ * True when a `server/discover` rejection means "this server wants the legacy
+ * `initialize` handshake first" rather than a genuine failure.
+ *
+ * Two shapes qualify:
+ * - `-32601` Method not found — the server has no `server/discover` route.
+ * - `-32000` + HTTP 400 + a missing-session message — servers built on
+ *   Cloudflare's `agents` SDK reject any non-initialization request that
+ *   carries no `Mcp-Session-Id`. `-32000` is the JSON-RPC catch-all, so the
+ *   message and status are both required to keep the signal narrow.
+ */
+function isLegacyHandshakeSignal(err: unknown, rpcError: McpRpcError | undefined): boolean {
+  if (!rpcError) return false;
+  const httpStatus = err instanceof McpHttpError ? err.status : undefined;
+  if (rpcError.code === -32601) {
+    return httpStatus === 400 || err instanceof McpRpcFailure;
+  }
+  return (
+    rpcError.code === -32000 &&
+    httpStatus === 400 &&
+    rpcError.message.toLowerCase().includes('mcp-session-id')
+  );
+}
+
 function advertisedVersions(error: McpRpcError): string[] {
   if (!error.data || typeof error.data !== 'object') return [];
   const supported = (error.data as { supported?: unknown }).supported;
@@ -287,12 +311,9 @@ export class McpClient {
         }
         return this.discoverModern(retryVersion);
       }
-      const isValidatedLegacySignal =
-        rpcError?.code === -32601 &&
-        ((err instanceof McpHttpError && err.status === 400) || err instanceof McpRpcFailure);
-      if (isValidatedLegacySignal) {
+      if (isLegacyHandshakeSignal(err, rpcError)) {
         log.debug('server/discover identified a legacy server; using initialize', {
-          error: err.message,
+          error: err instanceof Error ? err.message : String(err),
         });
         return this.initializeLegacy();
       }

--- a/packages/webapp/tests/shell/mcp/client.test.ts
+++ b/packages/webapp/tests/shell/mcp/client.test.ts
@@ -221,7 +221,13 @@ describe('McpClient: protocol negotiation', () => {
         ? {
             status: 400,
             statusText: 'Bad Request',
-            body: jsonRpcError(sent.id, -32000, 'Bad Request: Mcp-Session-Id header is required'),
+            // Verbatim wire payload from Cloudflare's `agents` SDK: the
+            // rejection is not attributable to a request, so `id` is null.
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: null,
+              error: { code: -32000, message: 'Bad Request: Mcp-Session-Id header is required' },
+            }),
           }
         : {
             headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'minted-session' },
@@ -366,6 +372,15 @@ describe('McpClient: protocol negotiation', () => {
     [
       'invalid JSON-RPC envelope',
       JSON.stringify({ error: { code: -32601, message: 'Method not found' } }),
+    ],
+    // A null id is tolerated on the error path; a wrong non-null id is not.
+    [
+      'mismatched non-null request id',
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 99,
+        error: { code: -32000, message: 'Bad Request: Mcp-Session-Id header is required' },
+      }),
     ],
   ])('does not fall back on an %s HTTP 400 response', async (_label, body) => {
     const { fetchImpl, calls } = stubFetch(() => ({

--- a/packages/webapp/tests/shell/mcp/client.test.ts
+++ b/packages/webapp/tests/shell/mcp/client.test.ts
@@ -214,6 +214,49 @@ describe('McpClient: protocol negotiation', () => {
     expect(c.getSessionId()).toBe('legacy-session');
   });
 
+  it('falls back to legacy initialize when discovery is rejected for a missing session id', async () => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number; method: string };
+      return sent.method === 'server/discover'
+        ? {
+            status: 400,
+            statusText: 'Bad Request',
+            body: jsonRpcError(sent.id, -32000, 'Bad Request: Mcp-Session-Id header is required'),
+          }
+        : {
+            headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'minted-session' },
+            body: jsonRpc(sent.id, { protocolVersion: '2025-06-18' }),
+          };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await c.initialize();
+
+    expect(calls.map((call) => JSON.parse(call.init!.body!).method)).toEqual([
+      'server/discover',
+      'initialize',
+    ]);
+    expect(JSON.parse(calls[1].init!.body!).params.protocolVersion).toBe('2025-06-18');
+    expect(calls[1].init!.headers!['Mcp-Session-Id']).toBeUndefined();
+    expect(c.getNegotiatedProtocolVersion()).toBe('2025-06-18');
+    expect(c.getSessionId()).toBe('minted-session');
+  });
+
+  it('does not fall back on an unrelated -32000 server error', async () => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number };
+      return {
+        status: 400,
+        statusText: 'Bad Request',
+        body: jsonRpcError(sent.id, -32000, 'Bad Request: malformed params'),
+      };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await expect(c.initialize()).rejects.toThrow(/MCP HTTP 400/);
+    expect(calls).toHaveLength(1);
+  });
+
   it('falls back on a validated HTTP 200 method-not-found response', async () => {
     const { fetchImpl, calls } = stubFetch((_url, init) => {
       const sent = JSON.parse(init?.body ?? '{}') as { id: number; method: string };


### PR DESCRIPTION
## Summary

`mcp add` against any MCP server built on Cloudflare's `agents` SDK failed with a raw session error and never registered the server. It now falls back to the legacy `initialize` handshake and registers, as it already did for servers that answer `server/discover` with `-32601`.

## Why

Repro:

```
mcp add https://mcpecrets.minivelos.workers.dev/mcp mcpecrets
```

- Expected: registration (via the legacy `initialize` handshake), then OAuth if required.
- Actual: `mcp add: MCP HTTP 400 Bad Request for server/discover: {"error":{"code":-32000,"message":"Bad Request: Mcp-Session-Id header is required"},"id":null,"jsonrpc":"2.0"}` — no registration, no OAuth attempt.

**The server is spec-compliant.** The `agents` streamable-HTTP handler (`node_modules/agents/dist/mcp/index.js`) rejects a request with no session id only when it is *not* an initialization request:

```js
if (!isInitializationRequest && !sessionId) {
  // JSON-RPC -32000, "Bad Request: Mcp-Session-Id header is required", HTTP 400
}
```

A spec-correct `initialize` carrying no session id is accepted, and the server then mints a session and returns it in the `Mcp-Session-Id` response header. Our stateless `server/discover` probe is not an initialization request, so it trips that guard — which is exactly the situation the legacy fallback exists for. No server-side change is needed, and none is made.

**The defect is error-class over-narrowness, not missing protocol support.** `McpClient.initialize()` fell back only on JSON-RPC `-32601`:

```ts
const isValidatedLegacySignal =
  rpcError?.code === -32601 &&
  ((err instanceof McpHttpError && err.status === 400) || err instanceof McpRpcFailure);
```

`agents` answers `-32000`, so the gate was false, control reached `throw err`, and the session error surfaced to the user. Both protocol revisions were already supported; `MCP_SUPPORTED_PROTOCOL_VERSIONS` and `LEGACY_PROTOCOL_VERSION` are untouched.

This affects **every** MCP server built on Cloudflare's `agents` SDK — including every Cloudflare-hosted MCP Worker — not one deployment.

## Approach / Implementation notes

- Classification moved out of `initialize()` into a documented `isLegacyHandshakeSignal(err, rpcError)` helper in the same file, so the two accepted shapes read side by side.
- The new case is deliberately narrow: `-32000` is the JSON-RPC "server error" catch-all, so it qualifies only with **HTTP 400 AND** a message containing `mcp-session-id` (case-insensitive). Treating all `-32000` as a legacy signal would swallow genuine server errors behind a second handshake.
- The `-32601` branch is preserved verbatim (HTTP 400 `McpHttpError` **or** `McpRpcFailure`), and the fallback still logs through the existing `log.debug` path.
- Since the helper breaks TS narrowing on the `unknown` catch binding, the `log.debug` payload now uses `err instanceof Error ? err.message : String(err)`.

**Second commit (068b717f2), from [Codex review feedback](https://github.com/ai-ecoverse/slicc/pull/3001#discussion_r3970287308):** the classifier above could never have fired against the real server. `agents` raises the rejection before attributing the payload to a request, so the body carries `"id": null` — and `parseRpcError()` discarded any frame whose id did not equal the outgoing request id, leaving `McpHttpError.rpcError` as `undefined`. The first version of the regression test masked this by echoing `sent.id`.

`parseRpcError()` now passes `{ allowNullId: true }` to `rpcErrorFromFrame()`, scoped to the HTTP >= 400 body path only — that is where JSON-RPC 2.0 mandates `id: null`. The HTTP 200 path is untouched, since there the id is what associates a frame with its request, and a **wrong non-null** id on an error body is still rejected.

## Cross-cutting impact

- **Floats exercised**: the MCP client is float-agnostic shell code; the change is inside `initialize()` and affects CLI, extension, Electron and worker floats identically. No float-specific branches touched.
- **Other callers of the changed contract**: `isLegacyHandshakeSignal` is private to `client.ts` and called from exactly one site. `rpcErrorFromFrame()` gained an opt-in `allowNullId` flag whose only caller is `parseRpcError()`; the other call site (the HTTP 200 `frame.error` path) passes no options and keeps strict id association. The error shapes (`McpHttpError`, `McpRpcFailure`, `McpAuthRequiredError`, `McpTimeoutError`) are unchanged, so `mcp` shell-command exit-code mapping (including 124 on timeout) is unaffected. Callers of `toolsList()` / `toolsCall()` / `appsList()` see no behavior change: the new branch is reachable only from the `server/discover` probe inside `initialize()`.
- **401 / OAuth path**: unchanged. A 401 still short-circuits to `McpAuthRequiredError` before any of this runs; the fix means Cloudflare-hosted servers now reach that path at all instead of dying on discovery.
- **Persisted state**: none. No new keys, no schema change.
- **Security**: no new logging of headers or tokens; the debug line logs only the error message, as before.

## Test plan

- [x] `npm run verify` — 8/8 checks pass (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — clean
- [x] `npm run typecheck`
- [x] `npm run test` — 21111 passing / 61 skipped, no new failures
- [x] `npm run build -w @slicc/webapp`
- [x] **New behavior is covered by a unit test** in `packages/webapp/tests/shell/mcp/client.test.ts`, mirroring `packages/webapp/src/shell/mcp/client.ts` (`npx vitest run packages/webapp/tests/shell/mcp/client.test.ts` — 38 passing)
- [x] No UI change, so no screencast

**Red-then-green verification, twice.** The regression test carries the SDK's verbatim wire payload, including `id: null`. Run against the **unfixed** client it fails for the right reason — the `-32000` rejection propagating instead of triggering a fallback:

```
FAIL packages/webapp/tests/shell/mcp/client.test.ts > McpClient: protocol negotiation >
  falls back to legacy initialize when discovery is rejected for a missing session id
McpHttpError: MCP HTTP 400 Bad Request for server/discover: {"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":"Bad Request: Mcp-Session-Id header is required"}}
 ❯ McpClient.request packages/webapp/src/shell/mcp/client.ts:443:13
 ❯ McpClient.discoverModern packages/webapp/src/shell/mcp/client.ts:325:21
 ❯ McpClient.initialize packages/webapp/src/shell/mcp/client.ts:299:14

Tests  1 failed | 36 passed (37)
```

That same assertion also failed against the **first** commit of this PR with only the `id: null` payload substituted, which is how the Codex finding was confirmed: the classifier alone was not enough, because `McpHttpError.rpcError` was `undefined` and there was no code to classify. With both commits applied, all 38 pass.

The test asserts the client then issues `initialize` with `protocolVersion: 2025-06-18`, sends **no** `Mcp-Session-Id` on that request, and captures the minted id from the response headers.

Two negative tests keep the widening honest:

- `does not fall back on an unrelated -32000 server error` — `-32000` + HTTP 400 with an unrelated message still rejects with `MCP HTTP 400` after a single call, so this is not a blanket `-32000` catch.
- `does not fall back on a mismatched non-null request id HTTP 400 response` — the missing-session message with id `99` is still discarded, so tolerating `id: null` did not become "ignore ids".

Neighbouring cases confirmed unregressed by running the whole file: the existing `-32601` HTTP 400 fallback, the HTTP 200 `-32601` fallback, `selects 2026-07-28 from server/discover without a legacy initialize`, `does not fall back on an HTTP 200 mismatched request id` (the success-path id association), and the generic `-32601` rejection from `toolsList()`.

**Pre-existing failures**: none.

## Documentation

- [x] No documentation changes needed — this restores the documented fallback behavior rather than changing a contract; no user-facing flag, command or protocol surface changed.

## Risk & rollback

- Blast radius: one error-classification branch on the `server/discover` failure path. Servers that answer discovery successfully never reach it; servers that answer `-32601` behave exactly as before.
- Worst case for a scoped miss: a server that returns `-32000` + HTTP 400 + a `mcp-session-id` message for some *other* reason would get one extra `initialize` attempt before failing, instead of failing immediately.
- No flags, no persisted-state migration. Reverting this PR is clean.
- Not covered by CI: the live `mcp add` round-trip against a real Cloudflare-hosted Worker, including the subsequent OAuth flow.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (none changed)
- [x] If this changes a contract used by other floats, I checked the followers/leader/offscreen paths — the MCP client is shared and float-agnostic; no float-specific branch touched

