### PR TITLE
feat(webapp): report the rolling Grok usage window as a provider budget

### DIFF
--- a/docs/webapp-details.md
+++ b/docs/webapp-details.md
@@ -171,20 +171,36 @@ One roster, three renderings, one vocabulary — `ui/follower-presentation.ts` o
 - Parse with `isFeatureEnabled`/`coerceFeatureFlagValue` (trimmed, case-insensitive `on`/`true`/`1`). With `overridableFloats`, precedence is local → remote → bundled. `experimental-settings` is worker-controlled (`userToggleable: false`).
 - `setupFeatureFlagsForPage` loads the isolated cache synchronously, then non-blocking `/api/flags?float=<float>` refresh; later config needs reload.
 
-## Budget-mode cost surfaces (`/v1/usage`)
+## Budget-mode cost surfaces
 
 A provider that bills against a **rolling allowance** rather than per token makes session
 dollars the wrong headline: a family-priced model can bill $0.00 while the shared window burns
-down. Adobe's LLM proxy is the first case, reporting one 7-day window over `GET /v1/usage`
-(OpenCode Go's public shape, same IMS token as `/v1/messages`).
+down. Two providers report one:
+
+- **Adobe** — one 7-day window over `GET /v1/usage` on the LLM proxy (OpenCode Go's public
+  shape, same IMS token as `/v1/messages`).
+- **xAI Grok** — the rolling SuperGrok allowance behind the grok.com Settings > Usage tab, over
+  `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` with the OAuth access token.
+  The route is **unofficial and undocumented** (it is the JSON transcoding of the gRPC-web
+  `GetGrokCreditsConfig` the web app calls, and `api.x.ai` has no usage route at all), so
+  `providers/xai-grok-usage.ts` caps the body before parsing, clamps the percent, and degrades
+  to "no window" on any shape it does not recognise. Dropping `?format=credits` silently returns
+  the monthly RPC's shape instead.
 
 - **Provider hook** — `ProviderConfig.getBudgetUsage?()` (`providers/types.ts`). Its contract is
   a three-way answer, and the distinction is load-bearing for the cache: `null` = "this provider
   has no budget concept / the proxy lacks the endpoint" (re-probed in 30 min), **throw** = "the
   call failed" (retried in 5 min, previous reading stays on screen), a window = a reading.
-  Adobe's implementation is `providers/adobe-usage.ts` (pure + injectable `fetch`, so it is
-  testable — `providers/adobe.ts` itself cannot be imported under vitest); a 404/501 is an
-  answer, every other non-OK status is a failure.
+  Both implementations are pure modules with an injectable `fetch`, so they are testable
+  without network (`providers/adobe.ts` itself cannot be imported under vitest):
+  `providers/adobe-usage.ts` and `providers/xai-grok-usage.ts`. A 404/501 is an answer — and the
+  likeliest way an undocumented route retires — while every other non-OK status is a failure;
+  Grok's 401/403 throws a "re-login required" message rather than reaching a render path.
+- **OAuth token masking (`oauthTokenDomains`)** — a budget endpoint on a host the provider does
+  not declare in `oauthTokenDomains` has its token **masked**, and the fetch proxy then drops
+  the request CLIENT-SIDE: no HTTP status, no body, which reads like a network outage rather
+  than an auth problem. `cli-chat-proxy.grok.com` is in xai-grok's list for exactly this reason.
+  At runtime the same fix is `oauth-domain add <provider> <host>` then `oauth-token --renew`.
 - **Cache** — `providers/budget-window-cache.ts`: success 60 s, failure 5 min, unsupported
   30 min, one shared in-flight probe, keyed by provider id so a switched account never inherits
   the previous one's allowance. `providers/budget-usage-source.ts` is the singleton over it.

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -13,7 +13,7 @@
       "name": "webapp: total JS payload",
       "path": "../../dist/ui/**/*.js",
       "brotli": false,
-      "limit": "25.1 MB"
+      "limit": "25.2 MB"
     }
   ],
   "dependencies": {

--- a/packages/webapp/providers/xai-grok.ts
+++ b/packages/webapp/providers/xai-grok.ts
@@ -36,11 +36,13 @@ import {
   streamSimpleOpenAIResponses,
 } from '@earendil-works/pi-ai/compat';
 import { deriveCodeChallenge, generateCodeVerifier, randomState } from '../src/providers/pkce.js';
+import type { ProviderBudgetWindow } from '../src/providers/provider-budget.js';
 import type {
   InterceptingOAuthLauncher,
   OAuthLoginOptions,
   ProviderConfig,
 } from '../src/providers/types.js';
+import { fetchXaiGrokUsage } from '../src/providers/xai-grok-usage.js';
 import { getAccounts, saveOAuthAccount } from '../src/ui/provider-settings.js';
 import { XaiErrorCode, XaiOAuthError } from './xai-grok-errors.js';
 
@@ -219,6 +221,26 @@ async function getValidAccessToken(): Promise<string> {
   return account.accessToken; // best-effort; xAI will 401 if revoked
 }
 
+/**
+ * The account's rolling SuperGrok allowance, or `null` when this account does
+ * not report one.
+ *
+ * Grok bills a subscription window rather than per token, so the session's
+ * dollars are a footnote — the window is what decides whether the next turn
+ * runs. The endpoint is undocumented; `xai-grok-usage.ts` carries the full
+ * account of it and the defensive posture that follows.
+ *
+ * Never logs in and never renews interactively — a decorative counter must not
+ * pop an auth window. Being signed out THROWS rather than returning `null`:
+ * `null` files the account under "this provider has no budget" for half an
+ * hour, so signing back in would keep showing dollars long after the session
+ * was valid again.
+ */
+async function getBudgetUsage(): Promise<ProviderBudgetWindow | null> {
+  if (!getXaiAccount()?.accessToken) throw new Error('xAI Grok budget: not signed in');
+  return fetchXaiGrokUsage(await getValidAccessToken(), fetch);
+}
+
 // ── Stream functions ───────────────────────────────────────────────
 
 function makeErrorOutput(model: Model<Api>, error: unknown): AssistantMessageEvent {
@@ -346,8 +368,21 @@ export const config: ProviderConfig = {
   requiresBaseUrl: false,
   isOAuth: true,
   defaultModelId: XAI_DEFAULT_MODEL_ID,
-  oauthTokenDomains: ['api.x.ai', '*.x.ai', 'auth.x.ai', 'accounts.x.ai'],
+  // A host absent from this list has its OAuth token MASKED by the fetch
+  // proxy — the request is then dropped CLIENT-SIDE, so curl exits non-zero
+  // with an empty body and NO http status. That reads like a network outage,
+  // not an auth problem, which is exactly the wrong place to start debugging.
+  // `cli-chat-proxy.grok.com` is here because the billing window lives there
+  // (see `src/providers/xai-grok-usage.ts`); `api.x.ai` has no usage route.
+  oauthTokenDomains: [
+    'api.x.ai',
+    '*.x.ai',
+    'auth.x.ai',
+    'accounts.x.ai',
+    'cli-chat-proxy.grok.com',
+  ],
   getModelIds: () => getNativeXaiModels().map(toModelMetadata),
+  getBudgetUsage,
 
   onOAuthLoginIntercepted: async (
     launcher: InterceptingOAuthLauncher,

--- a/packages/webapp/src/providers/xai-grok-usage.ts
+++ b/packages/webapp/src/providers/xai-grok-usage.ts
@@ -95,26 +95,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * `USAGE_PERIOD_TYPE_WEEKLY` → `weekly`.
- *
- * The enum is spelled out in full by the JSON transcoding. Unknown members are
- * lowercased rather than rejected, so a future `USAGE_PERIOD_TYPE_DAILY` reads
- * as `daily` without a code change; a type we cannot name at all falls back to
- * `billing`, which is true of every window this route reports.
- */
-function periodName(type: unknown): string {
-  if (typeof type !== 'string') return 'billing';
-  const suffix = type.replace(/^USAGE_PERIOD_TYPE_/, '').toLowerCase();
-  return suffix && suffix !== 'unspecified' ? suffix : 'billing';
-}
-
-/** An instant we can actually render, or nothing. Never a half-parsed date. */
-function isoInstant(value: unknown): string | undefined {
-  if (typeof value !== 'string' || !value) return undefined;
-  return Number.isFinite(Date.parse(value)) ? value : undefined;
-}
-
-/**
  * Parse a `?format=credits` body into a window, or `null` when it carries
  * none.
  *
@@ -131,17 +111,27 @@ export function parseXaiUsage(payload: unknown): ProviderBudgetWindow | null {
   const percent = Math.min(MAX_PERCENT, Math.max(0, raw));
 
   const period = isRecord(config.currentPeriod) ? config.currentPeriod : {};
+  // `USAGE_PERIOD_TYPE_WEEKLY` → `weekly`. The enum is spelled out in full by
+  // the JSON transcoding. Unknown members are lowercased rather than rejected,
+  // so a future `..._DAILY` reads as `daily` without a code change; a type we
+  // cannot name falls back to `billing`, true of every window this route
+  // reports.
+  const type = period.type;
+  const named =
+    typeof type === 'string' ? type.replace('USAGE_PERIOD_TYPE_', '').toLowerCase() : '';
   // `currentPeriod.end` is the credits window; `billingPeriodEnd` is the same
   // instant in the payloads we have seen, and the fallback for one where the
-  // period block is absent.
-  const resetsAt = isoInstant(period.end) ?? isoInstant(config.billingPeriodEnd);
+  // period block is absent. Anything we cannot turn into an instant is dropped
+  // rather than rendered half-parsed.
+  const end = period.end ?? config.billingPeriodEnd;
+  const resetsAt = typeof end === 'string' && Number.isFinite(Date.parse(end)) ? end : undefined;
   return {
     percent,
     // The route reports consumption, never refusal — there is no
     // `rate-limited` signal in the payload to map. A window at or past its
     // critical threshold is what the surfaces tint on.
     status: 'ok',
-    window: periodName(period.type),
+    window: named && named !== 'unspecified' ? named : 'billing',
     ...(resetsAt ? { resetsAt } : {}),
   };
 }
@@ -164,36 +154,35 @@ export async function fetchXaiGrokUsage(
   fetchImpl: XaiUsageFetch,
   opts: { timeoutMs?: number } = {}
 ): Promise<ProviderBudgetWindow | null> {
-  const controller = typeof AbortController === 'function' ? new AbortController() : null;
-  const timer = controller
-    ? setTimeout(() => controller.abort(), opts.timeoutMs ?? USAGE_TIMEOUT_MS)
-    : null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? USAGE_TIMEOUT_MS);
   try {
     const res = await fetchImpl(XAI_USAGE_URL, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      ...(controller ? { signal: controller.signal } : {}),
+      signal: controller.signal,
     });
+    const { status } = res;
     // 404/501 is the route saying it does not exist — an answer, not a
     // failure, and the likeliest way an undocumented endpoint retires.
-    if (res.status === 404 || res.status === 501) return null;
-    if (res.status === 401 || res.status === 403) {
-      throw new Error(
-        `xAI Grok usage: re-login required (${res.status}) — run \`oauth-token --renew xai-grok\``
-      );
+    if (status === 404 || status === 501) return null;
+    if (!res.ok) {
+      // 401/403 is the one failure a user can act on, so it says so; the rest
+      // are the cache's business, not the reader's.
+      const why = status === 401 || status === 403 ? 're-login required' : 'failed';
+      throw new Error(`xAI Grok usage: ${why} (${status})`);
     }
-    if (!res.ok) throw new Error(`xAI Grok usage returned ${res.status}`);
     const body = await res.text();
     // Cap before parsing, not after: the point is to never hand an unbounded
-    // third-party string to `JSON.parse`.
+    // third-party string to `JSON.parse`. A 200 that is oversized or is not
+    // JSON at all is an interstitial or a login wall, not an outage — "no
+    // window" backs the probe off instead of spinning the retry clock.
     if (body.length > MAX_BODY_BYTES) return null;
     try {
       return parseXaiUsage(JSON.parse(body));
     } catch {
-      // A 200 that is not JSON is an interstitial or a login wall, not an
-      // outage. Treat it as "no window" so the probe backs off.
       return null;
     }
   } finally {
-    if (timer) clearTimeout(timer);
+    clearTimeout(timer);
   }
 }

--- a/packages/webapp/src/providers/xai-grok-usage.ts
+++ b/packages/webapp/src/providers/xai-grok-usage.ts
@@ -1,0 +1,199 @@
+/**
+ * Pure xAI Grok billing client — the rolling SuperGrok allowance.
+ *
+ * Grok does not meter this account per token: a SuperGrok / SuperGrok Heavy
+ * subscription hands out a rolling window, and the number the grok.com
+ * Settings → Usage tab shows ("23% used · Weekly SuperGrok Heavy Limit") is
+ * the one that actually decides whether the next turn runs. So the provider
+ * reports it as a {@link ProviderBudgetWindow} and every cost surface —
+ * floatbar pill, cost overlay, monitor, `cost` — headlines the window.
+ *
+ * ## The endpoint
+ *
+ * ```
+ * GET https://cli-chat-proxy.grok.com/v1/billing?format=credits
+ * Authorization: Bearer <xai-grok OAuth access token>
+ * ```
+ *
+ * Response (real, redacted):
+ *
+ * ```json
+ * { "config": {
+ *     "currentPeriod": { "type": "USAGE_PERIOD_TYPE_WEEKLY",
+ *                        "start": "2026-09-04T19:03:46.999237+00:00",
+ *                        "end":   "2026-09-11T19:03:46.999237+00:00" },
+ *     "creditUsagePercent": 23.0,
+ *     "productUsage": [{ "product": "GrokBuild", "usagePercent": 23.0 }],
+ *     "billingPeriodEnd": "2026-09-11T19:03:46.999237+00:00" } }
+ * ```
+ *
+ * This is the JSON transcoding of the same backend RPC the grok.com web app
+ * calls over gRPC-web (`grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig`),
+ * which is binary protobuf and cookie-authenticated — unusable from here. The
+ * CLI proxy takes the OAuth token we already hold and needs nothing else: a
+ * single GET with only `Authorization` is sufficient (no `x-userid`, no
+ * `x-grok-client-*`), and slicc's existing narrower scope set is accepted.
+ * Dropping `?format=credits` returns the MONTHLY view instead.
+ *
+ * `api.x.ai` has no usage endpoint at all (`/v1/usage`, `/v1/billing/usage`
+ * and `/v1/rate-limits` all 404 while `/v1/models` answers), so the CLI proxy
+ * host is genuinely required rather than a convenience.
+ *
+ * ## UNOFFICIAL AND UNDOCUMENTED
+ *
+ * xAI publishes nothing about this route and owes us no stability. Everything
+ * below is therefore defensive: the body is size-capped before it is parsed,
+ * every field is optional, every number is clamped, and an unrecognised shape
+ * degrades to "no window" rather than to a wrong one. A usage lookup must
+ * never break a chat turn — see the `getBudgetUsage` contract in `types.ts`,
+ * whose cache swallows the throw and keeps the last good reading on screen.
+ *
+ * Prior art: https://github.com/stnly/pi-grok (`usage.ts`, `safe-fetch.ts`,
+ * `bounded-json.ts`), a pi-ai xAI provider that ships this same lookup with
+ * the same posture. It resolves `/v1/user` first to forward `x-userid`; we
+ * measured that as unnecessary and do not.
+ */
+
+import type { ProviderBudgetWindow } from './provider-budget.js';
+
+/** Minimal `fetch` surface, injected so tests need no network. */
+export type XaiUsageFetch = (
+  input: string,
+  init?: { headers?: Record<string, string>; signal?: AbortSignal }
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+/** The credits (rolling-allowance) view. Without the param the route reports months. */
+export const XAI_USAGE_URL = 'https://cli-chat-proxy.grok.com/v1/billing?format=credits';
+
+/** A proxy this slow is not answering; the reading is not worth a stalled poll. */
+const USAGE_TIMEOUT_MS = 8_000;
+
+/**
+ * Hard cap on the body we will parse. The real payload is a few hundred
+ * bytes; anything at this scale is an error page or an interstitial, and
+ * `JSON.parse` on an unbounded third-party body is how a decorative counter
+ * stalls the worker.
+ */
+const MAX_BODY_BYTES = 64 * 1024;
+
+/**
+ * Percent is a protobuf `float` from a route we do not control. Negatives are
+ * nonsense and a garbage float must not render as an astronomical pill, so the
+ * reading is clamped into a band that still lets a genuine overage (a window
+ * legitimately past 100%) through intact.
+ */
+const MAX_PERCENT = 1_000;
+
+/**
+ * The proxy names its own period types and may add more; there is no shape to
+ * name until a window has been read out of the body, which is what
+ * {@link parseXaiUsage} does.
+ */
+// biome-ignore lint/plugin: parsed third-party JSON — the proxy owns these field names, narrowed structurally below.
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * `USAGE_PERIOD_TYPE_WEEKLY` → `weekly`.
+ *
+ * The enum is spelled out in full by the JSON transcoding. Unknown members are
+ * lowercased rather than rejected, so a future `USAGE_PERIOD_TYPE_DAILY` reads
+ * as `daily` without a code change; a type we cannot name at all falls back to
+ * `billing`, which is true of every window this route reports.
+ */
+function periodName(type: unknown): string {
+  if (typeof type !== 'string') return 'billing';
+  const suffix = type.replace(/^USAGE_PERIOD_TYPE_/, '').toLowerCase();
+  return suffix && suffix !== 'unspecified' ? suffix : 'billing';
+}
+
+/** An instant we can actually render, or nothing. Never a half-parsed date. */
+function isoInstant(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value) return undefined;
+  return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+
+/**
+ * Parse a `?format=credits` body into a window, or `null` when it carries
+ * none.
+ *
+ * A body without a usable `creditUsagePercent` is not a window: reporting it
+ * as 0% would say "nothing used" about a route that said nothing at all, and
+ * "we don't know" must not look like "you have your whole week left".
+ */
+export function parseXaiUsage(payload: unknown): ProviderBudgetWindow | null {
+  if (!isRecord(payload)) return null;
+  // Tolerate both the documented envelope and a future unwrapped body.
+  const config = isRecord(payload.config) ? payload.config : payload;
+  const raw = config.creditUsagePercent;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return null;
+  const percent = Math.min(MAX_PERCENT, Math.max(0, raw));
+
+  const period = isRecord(config.currentPeriod) ? config.currentPeriod : {};
+  // `currentPeriod.end` is the credits window; `billingPeriodEnd` is the same
+  // instant in the payloads we have seen, and the fallback for one where the
+  // period block is absent.
+  const resetsAt = isoInstant(period.end) ?? isoInstant(config.billingPeriodEnd);
+  return {
+    percent,
+    // The route reports consumption, never refusal — there is no
+    // `rate-limited` signal in the payload to map. A window at or past its
+    // critical threshold is what the surfaces tint on.
+    status: 'ok',
+    window: periodName(period.type),
+    ...(resetsAt ? { resetsAt } : {}),
+  };
+}
+
+/**
+ * Fetch the account's rolling SuperGrok window.
+ *
+ * Returns `null` for "this account has no such window" — a 404/501 from a
+ * route that has moved (this one is unofficial, so plan on it), or a 200
+ * carrying nothing parseable. THROWS for a call that failed: the two get
+ * different retry clocks upstream, and a proxy that is briefly unreachable
+ * must not be written off as budget-less for the next half hour.
+ *
+ * A 401/403 throws with a re-login message rather than crashing a render
+ * path; `budget-window-cache.ts` catches it, keeps the previous reading, and
+ * retries in five minutes.
+ */
+export async function fetchXaiGrokUsage(
+  accessToken: string,
+  fetchImpl: XaiUsageFetch,
+  opts: { timeoutMs?: number } = {}
+): Promise<ProviderBudgetWindow | null> {
+  const controller = typeof AbortController === 'function' ? new AbortController() : null;
+  const timer = controller
+    ? setTimeout(() => controller.abort(), opts.timeoutMs ?? USAGE_TIMEOUT_MS)
+    : null;
+  try {
+    const res = await fetchImpl(XAI_USAGE_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      ...(controller ? { signal: controller.signal } : {}),
+    });
+    // 404/501 is the route saying it does not exist — an answer, not a
+    // failure, and the likeliest way an undocumented endpoint retires.
+    if (res.status === 404 || res.status === 501) return null;
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(
+        `xAI Grok usage: re-login required (${res.status}) — run \`oauth-token --renew xai-grok\``
+      );
+    }
+    if (!res.ok) throw new Error(`xAI Grok usage returned ${res.status}`);
+    const body = await res.text();
+    // Cap before parsing, not after: the point is to never hand an unbounded
+    // third-party string to `JSON.parse`.
+    if (body.length > MAX_BODY_BYTES) return null;
+    try {
+      return parseXaiUsage(JSON.parse(body));
+    } catch {
+      // A 200 that is not JSON is an interstitial or a login wall, not an
+      // outage. Treat it as "no window" so the probe backs off.
+      return null;
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/webapp/tests/providers/xai-grok-usage.test.ts
+++ b/packages/webapp/tests/providers/xai-grok-usage.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchXaiGrokUsage,
+  parseXaiUsage,
+  XAI_USAGE_URL,
+  type XaiUsageFetch,
+} from '../../src/providers/xai-grok-usage.js';
+
+/**
+ * The real `?format=credits` body, captured from a live logged-in account and
+ * redacted of nothing (it carries no identity — no user id, no email, no
+ * token). Kept verbatim so the parser is pinned against the wire shape rather
+ * than against our idea of it: camelCase names, the enum spelled out in full,
+ * protobuf `Cent` rendered as `{val}`, and 6-digit fractional seconds.
+ */
+const LIVE_BODY = {
+  config: {
+    currentPeriod: {
+      type: 'USAGE_PERIOD_TYPE_WEEKLY',
+      start: '2026-09-04T19:03:46.999237+00:00',
+      end: '2026-09-11T19:03:46.999237+00:00',
+    },
+    creditUsagePercent: 23.0,
+    onDemandCap: { val: 0 },
+    onDemandUsed: { val: 0 },
+    productUsage: [{ product: 'GrokBuild', usagePercent: 23.0 }, { product: 'GrokChat' }],
+    isUnifiedBillingUser: true,
+    prepaidBalance: { val: 0 },
+    topUpMethod: 'TOP_UP_METHOD_SAVED_PAYMENT_METHOD',
+    billingPeriodStart: '2026-09-04T19:03:46.999237+00:00',
+    billingPeriodEnd: '2026-09-11T19:03:46.999237+00:00',
+  },
+};
+
+function respond(status: number, body: unknown = {}): XaiUsageFetch {
+  return vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  }));
+}
+
+describe('parseXaiUsage', () => {
+  it('reads the live credits body into a weekly window', () => {
+    expect(parseXaiUsage(LIVE_BODY)).toEqual({
+      percent: 23,
+      status: 'ok',
+      window: 'weekly',
+      resetsAt: '2026-09-11T19:03:46.999237+00:00',
+    });
+  });
+
+  it('keeps the reset instant parseable despite 6-digit fractional seconds', () => {
+    // The proxy emits microseconds and a `+00:00` offset; if `Date.parse`
+    // choked on either, the window would silently lose its reset line.
+    const window = parseXaiUsage(LIVE_BODY);
+    expect(Number.isFinite(Date.parse(window?.resetsAt ?? ''))).toBe(true);
+  });
+
+  it('names an unknown period type instead of rejecting the window', () => {
+    // A future USAGE_PERIOD_TYPE_DAILY must read without a code change.
+    const daily = {
+      config: { creditUsagePercent: 4, currentPeriod: { type: 'USAGE_PERIOD_TYPE_DAILY' } },
+    };
+    expect(parseXaiUsage(daily)).toMatchObject({ window: 'daily' });
+  });
+
+  it('falls back to `billing` for a missing, unspecified or non-string type', () => {
+    for (const currentPeriod of [{}, { type: 'USAGE_PERIOD_TYPE_UNSPECIFIED' }, { type: 7 }]) {
+      expect(parseXaiUsage({ config: { creditUsagePercent: 1, currentPeriod } })).toMatchObject({
+        window: 'billing',
+      });
+    }
+  });
+
+  it('falls back to billingPeriodEnd when the period block is absent', () => {
+    const window = parseXaiUsage({
+      config: { creditUsagePercent: 5, billingPeriodEnd: '2026-09-11T19:03:46Z' },
+    });
+    expect(window).toMatchObject({ resetsAt: '2026-09-11T19:03:46Z', window: 'billing' });
+  });
+
+  it('omits resetsAt entirely rather than reporting an unparseable date', () => {
+    const window = parseXaiUsage({
+      config: { creditUsagePercent: 5, currentPeriod: { end: 'not-a-date' } },
+    });
+    expect(window).not.toHaveProperty('resetsAt');
+  });
+
+  it('tolerates an unwrapped body without the `config` envelope', () => {
+    expect(parseXaiUsage({ creditUsagePercent: 12 })).toMatchObject({ percent: 12 });
+  });
+
+  it('reports NO WINDOW rather than 0% when the percent is missing or unusable', () => {
+    // "We don't know" and "you have your whole week left" must not look alike.
+    expect(parseXaiUsage({ config: {} })).toBeNull();
+    expect(parseXaiUsage({ config: { creditUsagePercent: null } })).toBeNull();
+    expect(parseXaiUsage({ config: { creditUsagePercent: '23' } })).toBeNull();
+    expect(parseXaiUsage({ config: { creditUsagePercent: Number.NaN } })).toBeNull();
+    expect(parseXaiUsage({ config: { creditUsagePercent: Number.POSITIVE_INFINITY } })).toBeNull();
+    expect(parseXaiUsage(null)).toBeNull();
+    expect(parseXaiUsage('nope')).toBeNull();
+  });
+
+  it('clamps a nonsensical percent instead of rendering it', () => {
+    expect(parseXaiUsage({ config: { creditUsagePercent: -5 } })).toMatchObject({ percent: 0 });
+    expect(parseXaiUsage({ config: { creditUsagePercent: 1e12 } })).toMatchObject({
+      percent: 1000,
+    });
+  });
+
+  it('lets a genuine overage through intact', () => {
+    // 104% is a fact about a burnt window, not a parse error.
+    expect(parseXaiUsage({ config: { creditUsagePercent: 104 } })).toMatchObject({ percent: 104 });
+  });
+});
+
+describe('fetchXaiGrokUsage', () => {
+  it('sends ONE GET to the credits route carrying only the bearer token', async () => {
+    // The minimum viable request, established by removing headers until it
+    // broke: no x-userid, no x-grok-client-*, no X-XAI-Token-Auth.
+    const fetchImpl = respond(200, LIVE_BODY);
+    const window = await fetchXaiGrokUsage('tok', fetchImpl);
+
+    expect(window).toMatchObject({ percent: 23, window: 'weekly' });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      XAI_USAGE_URL,
+      expect.objectContaining({ headers: { Authorization: 'Bearer tok' } })
+    );
+  });
+
+  it('asks for the credits view, not the monthly one', () => {
+    // Dropping `?format=credits` silently returns a different RPC's shape.
+    expect(XAI_USAGE_URL).toContain('format=credits');
+    expect(XAI_USAGE_URL).toContain('cli-chat-proxy.grok.com');
+  });
+
+  it('reports NO WINDOW when the undocumented route has moved', async () => {
+    // 404/501 is the route answering, not failing: the caller writes the
+    // provider off for half an hour rather than retrying in five minutes.
+    await expect(fetchXaiGrokUsage('t', respond(404))).resolves.toBeNull();
+    await expect(fetchXaiGrokUsage('t', respond(501))).resolves.toBeNull();
+  });
+
+  it('says RE-LOGIN on 401/403 rather than crashing a render path', async () => {
+    await expect(fetchXaiGrokUsage('t', respond(401))).rejects.toThrow(/re-login required \(401\)/);
+    await expect(fetchXaiGrokUsage('t', respond(403))).rejects.toThrow(/re-login required \(403\)/);
+  });
+
+  it('THROWS on a broken call so the retry clock stays short', async () => {
+    await expect(fetchXaiGrokUsage('t', respond(500))).rejects.toThrow('500');
+    await expect(fetchXaiGrokUsage('t', respond(503))).rejects.toThrow('503');
+  });
+
+  it('treats a 200 that is not JSON as no window, not an outage', async () => {
+    // A login wall or interstitial answers 200 with HTML.
+    await expect(fetchXaiGrokUsage('t', respond(200, '<html>sign in</html>'))).resolves.toBeNull();
+  });
+
+  it('refuses to parse an oversized body', async () => {
+    // Never hand an unbounded third-party string to JSON.parse.
+    const huge = `{"config":{"creditUsagePercent":23,"pad":"${'x'.repeat(70 * 1024)}"}}`;
+    await expect(fetchXaiGrokUsage('t', respond(200, huge))).resolves.toBeNull();
+  });
+
+  it('aborts a stalled proxy instead of hanging the poll', async () => {
+    const fetchImpl: XaiUsageFetch = (_input, init) =>
+      new Promise<never>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    await expect(fetchXaiGrokUsage('t', fetchImpl, { timeoutMs: 1 })).rejects.toThrow('aborted');
+  });
+});

--- a/packages/webapp/tests/providers/xai-grok.test.ts
+++ b/packages/webapp/tests/providers/xai-grok.test.ts
@@ -361,3 +361,60 @@ describe('xai-grok provider', () => {
     expect(mocks.streamOpenAICompletions.mock.calls[0][2]).not.toHaveProperty('onPayload');
   });
 });
+
+describe('xai-grok budget window', () => {
+  const creditsBody = {
+    config: {
+      currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end: '2026-09-11T19:03:46Z' },
+      creditUsagePercent: 23,
+    },
+  };
+
+  function stubFetch(status: number, body: unknown) {
+    const fetchImpl = vi.fn(async () => ({
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => JSON.stringify(body),
+    }));
+    vi.stubGlobal('fetch', fetchImpl);
+    return fetchImpl;
+  }
+
+  it('lists the billing proxy in oauthTokenDomains', () => {
+    // A host missing from this list has its token MASKED and the request
+    // dropped client-side — no status, no body, looks like a network outage.
+    // The budget probe is unreachable without this entry.
+    expect(config.oauthTokenDomains).toContain('cli-chat-proxy.grok.com');
+    expect(config.oauthTokenDomains).toContain('api.x.ai');
+  });
+
+  it('reports the rolling SuperGrok window through the generic hook', async () => {
+    const fetchImpl = stubFetch(200, creditsBody);
+
+    await expect(config.getBudgetUsage?.()).resolves.toMatchObject({
+      percent: 23,
+      window: 'weekly',
+      status: 'ok',
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringContaining('cli-chat-proxy.grok.com'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer oauth-token' } })
+    );
+  });
+
+  it('THROWS when signed out instead of reporting "no budget"', async () => {
+    // `null` would file the account under "this provider has no budget" for
+    // half an hour, so signing back in would keep showing dollars. This costs
+    // no network — the check is local.
+    providerSettingsMocks.accounts = [];
+    const fetchImpl = stubFetch(200, creditsBody);
+
+    await expect(config.getBudgetUsage?.()).rejects.toThrow('not signed in');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('never lets a retired endpoint look like a failure', async () => {
+    stubFetch(404, {});
+    await expect(config.getBudgetUsage?.()).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Grok bills a SuperGrok subscription against a **rolling allowance**, not per token — the number on grok.com's *Settings > Usage* tab ("23% used · Weekly SuperGrok Heavy Limit · Resets September 11") is what actually decides whether the next turn runs. This teaches the `xai-grok` provider to report that window, so every cost surface headlines it instead of `$`.

## Scope: neither option in the brief — the hook and the UI already exist

The brief asked me to choose between (a) a self-contained `fetchUsage` + shell command, or (b) building a general `getUsage?()` hook on `ProviderConfig` with new UI. **Both premises turned out to be stale.** `ProviderConfig.getBudgetUsage?()` already exists (`src/providers/types.ts:341`), and it is already consumed generically end to end:

```
getBudgetUsage()  →  budget-usage-source.ts  →  budget-window-cache.ts
                  →  facade.ts (SessionStatsMsg.budget)
                  →  floatbar pill · cost overlay · wc-monitor · `cost` command
```

Adobe is simply its first implementer (`src/providers/adobe-usage.ts`) — the `adobe_credits` server-side tool mentioned in the brief is a *different*, older thing. So the smallest useful change is also the one that gets the full UI for free: **implement the existing hook**. No new hook, no new UI, no new shell command. That is what this PR does.

The one genuinely new thing is the `oauthTokenDomains` entry, without which the endpoint is unreachable.

## Endpoint

```
GET https://cli-chat-proxy.grok.com/v1/billing?format=credits
Authorization: Bearer <xai-grok OAuth access token>
```

Response (real, from a live account; it carries no identity — no user id, email or token):

```json
{ "config": {
    "currentPeriod": { "type": "USAGE_PERIOD_TYPE_WEEKLY",
                       "start": "2026-09-04T19:03:46.999237+00:00",
                       "end":   "2026-09-11T19:03:46.999237+00:00" },
    "creditUsagePercent": 23.0,
    "onDemandCap": { "val": 0 }, "onDemandUsed": { "val": 0 },
    "productUsage": [{ "product": "GrokBuild", "usagePercent": 23.0 },
                     { "product": "GrokChat" }],
    "isUnifiedBillingUser": true, "prepaidBalance": { "val": 0 },
    "topUpMethod": "TOP_UP_METHOD_SAVED_PAYMENT_METHOD",
    "billingPeriodStart": "2026-09-04T19:03:46.999237+00:00",
    "billingPeriodEnd":   "2026-09-11T19:03:46.999237+00:00" } }
```

This is the JSON transcoding of the same backend RPC the grok.com web app calls over gRPC-web (`grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig`) — that one is binary protobuf authenticated by the httpOnly grok.com session cookie, so it is unusable from a provider. The CLI proxy takes the OAuth token we already hold.

Minimum viable request, established by removing headers until it broke: **one GET with only `Authorization`**. Not required: `x-userid`, `x-grok-client-identifier`, `x-grok-client-version`, `x-grok-client-mode`, `X-XAI-Token-Auth`, `x-authenticateresponse`. The extra scopes pi-grok requests (`conversations:read/write`) are also not needed — it answers 200 under slicc's existing narrower set. Dropping `?format=credits` silently returns the *monthly* RPC's shape instead.

`api.x.ai` has **no** usage route (`/v1/usage`, `/v1/billing/usage`, `/v1/rate-limits` all 404 while `/v1/models` answers), so the CLI-proxy host is genuinely required rather than a convenience.

## ⚠️ The `oauthTokenDomains` masking pitfall

slicc's fetch proxy **masks** OAuth tokens, substituting the real one only for hosts a provider lists in `oauthTokenDomains`. `cli-chat-proxy.grok.com` was not listed, so the request was dropped **client-side**: curl exits non-zero with an empty response and **no HTTP status**. That looks like a network failure, not an auth problem, and it is a genuinely expensive hour to lose. There is now a comment at the declaration saying so.

The runtime equivalent of this fix, for anyone debugging a similar host:

```
oauth-domain add xai-grok cli-chat-proxy.grok.com
oauth-token --renew xai-grok        # re-pushes the merged domain list
```

## Unofficial endpoint — the defensive posture

**xAI documents none of this and owes us no stability; the route may move or change shape.** So `xai-grok-usage.ts` is written to fail silently and never break a chat turn:

- body **size-capped at 64 KB before** `JSON.parse` ever sees it;
- percent **clamped** to `[0, 1000]` (a real 104% overage still passes through intact);
- every field optional — a missing/non-numeric percent yields `null` ("we don't know"), never `0%` ("your whole week is left");
- unknown period enums degrade (`USAGE_PERIOD_TYPE_DAILY` → `daily`, unknown → `billing`);
- **404/501 → `null`** (the route answering that it is gone — the likeliest way an undocumented endpoint retires; re-probed in 30 min);
- **401/403 → throws "re-login required"**, caught by `budget-window-cache.ts`, which keeps the last good reading on screen and retries in 5 min;
- a 200 that is oversized or not JSON → `null`, not an outage;
- 8 s abort so a stalled proxy never hangs the poll.

Prior art, and the source of this posture: **https://github.com/stnly/pi-grok** (`usage.ts`, `safe-fetch.ts`, `bounded-json.ts`). It resolves `/v1/user` first to forward `x-userid`; we measured that as unnecessary and do not.

## Bundle budget — please review this bit

The second commit raises the **total-JS-payload backstop from 25.1 → 25.2 MB**, and I want it seen rather than buried:

- The feature is ~2.4 kB minified, emitted **twice** (the provider ships in both the page and kernel-worker builds).
- `main` had only **2.3 kB** of headroom under the 25.1 MB cap, so this landed **43 B** over.
- I trimmed the module hard first (unconditional `AbortController`, one merged non-OK throw, date/enum helpers folded into their call sites) — that recovered ~460 B. Getting the last 43 B would have meant degrading the error messages and enum handling, i.e. exactly the defensiveness above.
- **`check-first-load-size.mjs` reports `+0.0 kB`** — the gate that actually guards cold boot is unmoved, because the provider chunk is lazily loaded. The 25.1 MB cap is a backstop that counts every emitted file, lazy ones included.

Happy to revert the raise and shave the module instead if a reviewer prefers, but note the cap has historically only been *lowered*, and main was already within 2.3 kB of it — the next feature hits this regardless.

## Tests

No network. The real captured payload above is the fixture.

- `tests/providers/xai-grok-usage.test.ts` (new, 18 tests) — the live body, microsecond timestamps, unknown/unspecified enums, `billingPeriodEnd` fallback, unparseable dates, missing/`NaN`/`Infinity`/string percents, clamping, genuine overage, the bearer-only request, 404/501, 401/403, 5xx, non-JSON 200, oversized body, abort.
- `tests/providers/xai-grok.test.ts` (+4) — the `oauthTokenDomains` entry, the hook reporting a window through `config.getBudgetUsage()`, signed-out throwing (with no network call), and 404 → `null`.

## Verification

`verify` · `check-touched-exemptions` · `typecheck` · `test` (21133 passed) · `test:coverage` (floors held, none lowered) · `build` · `build -w @slicc/chrome-extension` · `bundle-size` — all green.

## Follow-ups (not in this PR)

- `adobe-usage.ts` and `xai-grok-usage.ts` now duplicate the same timeout/abort/status-classification scaffolding; a shared helper would pay for itself in bytes across both.
- The route has a monthly view (no `?format=credits`) and `productUsage` per-product breakdowns (`GrokBuild` vs `GrokChat`) that this PR ignores — `ProviderBudgetWindow` models exactly one window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
