### PR TITLE
fix(pr-fix-dispatcher): do not skip when lint failed because of ci aggregator

### DIFF
--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -198,7 +198,12 @@ The `CI / ci` aggregator (`if: always()` over `needs: [everything]`) fails
 alongside whichever job actually broke, and its own log says only "One or more
 jobs failed" (plus the job env dump). It is forced to `unknown` and cannot
 outrank a sibling: verdicts fold in `blocked` → `code` → `infra` order, with
-`unknown` used only when nothing else matched. A bare `dns` substring must never
+`unknown` used only when nothing else matched. The unknown fallback must not
+pick the aggregator either — GitHub lists `ci` first, so `classified[0]` used
+to skip with the aggregator's sentence while `lint` had also failed (PR #3008).
+A failing well-known code job (`lint`, `typecheck`, `webapp`, `e2e`,
+`chrome-extension`, `node-matrix-tests`, `bundle-size`, `swift-*`) is `code`
+even with an empty excerpt. A bare `dns` substring must never
 appear in the network infra signature — every Actions job dumps
 `NODE_OPTIONS: --dns-result-order=ipv4first`, and matching that classified PR
 #2320's real SPM pin conflict as a network flake. The flake hunter's

--- a/packages/dev-tools/pr-fix-dispatcher/README.md
+++ b/packages/dev-tools/pr-fix-dispatcher/README.md
@@ -52,6 +52,35 @@ signature now requires an explicit DNS-failure phrase (`getaddrinfo`,
 `ENOTFOUND`, `dns resolution`, …), and the aggregator job is forced to
 `unknown` so a sibling that named a real cause can win.
 
+### The aggregator must not own the skip reason
+
+Forcing the aggregator to `unknown` is not enough if the unknown _fallback_
+then picks it. GitHub's check-runs API lists `ci` before the child that
+actually failed (PR #3008: `lint` FAILURE + `ci` FAILURE). `classifyFailures`
+walks blocked → code → infra, and when nothing matches it used to return
+`classified[0]`. That made the skip comment `"ci" is the CI aggregator and
+does not name a failure cause` even though `lint` had also failed.
+
+Two compounding traps:
+
+- **`CODE_SIGNATURES.lint` does not match the job name `lint`.** The pattern
+  wants `biome (found|check)|eslint|prettier|lint(ing)? (error|failed)`. An
+  empty or truncated log excerpt (log fetch 403/410, or `MAX_LOGS_PER_PR`
+  spent on the aggregator first) classified the real job as unknown too
+  (`no plausible cause`).
+- **Log fetches followed `checks.failing` order.** With `ci` first, the
+  bounded log budget could starve the sibling.
+
+The unknown fallback never picks an aggregator-unknown. A failing well-known
+code job (`lint`, `typecheck`, `webapp`, `e2e`, `chrome-extension`,
+`node-matrix-tests`, `bundle-size`, `swift-*`) is `code` even with an empty
+excerpt, so the PR dispatches. `lint` / `typecheck` are also job-name
+signatures on the single-failure path (after infra, so a network flake on
+the lint job is still a re-run). Log fetches prefer non-`ci` jobs.
+
+Same class as the #2215 debt-gate + aggregator miss and the #2320
+NODE_OPTIONS false positive: aggregator noise dominating a named child.
+
 ### The debt boy-scout gate is the likeliest dispatch of all
 
 `check-touched-exemptions.mjs` (the `lint` job's "Debt boy-scout gate" step) fails

--- a/packages/dev-tools/pr-fix-dispatcher/lib.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/lib.mjs
@@ -344,6 +344,30 @@ function matchSignature(table, text) {
 }
 
 /**
+ * Bare check-run name. GitHub reports this repo's jobs as `lint` / `ci`; some
+ * UIs and required-check titles use the `CI / lint` form.
+ * @param {string} jobName
+ * @returns {string}
+ */
+function bareCheckName(jobName) {
+  return String(jobName ?? '')
+    .trim()
+    .replace(/^ci\s*\/\s*/i, '')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * The `CI / ci` aggregator job (`if: always()` over `needs: [*]`). Its log
+ * never names a cause — it only echoes that a sibling failed.
+ * @param {string} jobName
+ * @returns {boolean}
+ */
+export function isCiAggregatorJob(jobName) {
+  return bareCheckName(jobName) === 'ci';
+}
+
+/**
  * The `CI / ci` aggregator (`if: always()` over `needs: [*]`) always fails
  * whenever any child does; its own log only echoes that fact (plus the job
  * env dump). Classifying it from its log would let boilerplate — or a false
@@ -353,8 +377,76 @@ function matchSignature(table, text) {
  * @returns {boolean}
  */
 function isCiAggregatorNoise(jobName, logExcerpt) {
-  if (String(jobName).toLowerCase() !== 'ci') return false;
+  if (!isCiAggregatorJob(jobName)) return false;
   return /one or more jobs failed or were cancelled/i.test(String(logExcerpt));
+}
+
+/**
+ * Jobs whose name alone is a code-failure signature: the log may be empty or
+ * truncated (MAX_LOGS_PER_PR, a 403/410 log fetch) and still not say "biome"
+ * / "lint error". Checked after log-based CODE_SIGNATURES (so a debt-gate
+ * excerpt still wins) and after INFRA_SIGNATURES (so a network flake on the
+ * lint job is still a re-run).
+ */
+const JOB_NAME_CODE_CATEGORIES = {
+  lint: 'lint',
+  typecheck: 'types',
+};
+
+/**
+ * Failing jobs that evaluate this repo's code. Used when every per-job
+ * classification is `unknown` (empty excerpt, aggregator noise) so a named
+ * child still dispatches instead of skipping with the aggregator's sentence.
+ * `swift-*` covers swift-server / swift-optel / swift-launcher / …
+ */
+const WELL_KNOWN_CODE_JOBS = new Set([
+  'lint',
+  'typecheck',
+  'webapp',
+  'e2e',
+  'chrome-extension',
+  'node-matrix-tests',
+  'bundle-size',
+]);
+
+/**
+ * Category for a well-known code job, or null. `lint` / `typecheck` map onto
+ * the existing CODE_SIGNATURES categories; other names stay as themselves so
+ * the dispatch reason names the job.
+ * @param {string} jobName
+ * @returns {string|null}
+ */
+export function wellKnownCodeCategory(jobName) {
+  const bare = bareCheckName(jobName);
+  if (JOB_NAME_CODE_CATEGORIES[bare]) return JOB_NAME_CODE_CATEGORIES[bare];
+  if (WELL_KNOWN_CODE_JOBS.has(bare)) return bare;
+  if (bare.startsWith('swift-')) return 'build';
+  return null;
+}
+
+/** @param {string} name @param {string} category */
+function codeVerdict(name, category) {
+  return {
+    kind: 'code',
+    category,
+    reason: `"${name}" failed in the code (${category}).`,
+  };
+}
+
+/**
+ * Spend the per-PR log budget on jobs that can name a cause. The `ci`
+ * aggregator is last: its log is boilerplate (`One or more jobs failed…` plus
+ * the env dump) and fetching it first used to starve a sibling (PR #3008).
+ * @param {Array<{name?: string, jobName?: string}>} failing
+ * @returns {Array<{name?: string, jobName?: string}>}
+ */
+export function prioritizeLogFetch(failing = []) {
+  const list = Array.isArray(failing) ? [...failing] : [];
+  return list.sort((a, b) => {
+    const aAgg = isCiAggregatorJob(a.name ?? a.jobName);
+    const bAgg = isCiAggregatorJob(b.name ?? b.jobName);
+    return Number(aAgg) - Number(bAgg);
+  });
 }
 
 /**
@@ -393,13 +485,7 @@ export function classifyFailure({ jobName = '', logExcerpt = '' } = {}) {
     };
   }
   const code = matchSignature(CODE_SIGNATURES, text);
-  if (code) {
-    return {
-      kind: 'code',
-      category: code,
-      reason: `"${name}" failed in the code (${code}).`,
-    };
-  }
+  if (code) return codeVerdict(name, code);
   const infra = matchSignature(INFRA_SIGNATURES, text);
   if (infra) {
     return {
@@ -408,6 +494,12 @@ export function classifyFailure({ jobName = '', logExcerpt = '' } = {}) {
       reason: `"${name}" failed in CI plumbing (${infra}) without evaluating the code.`,
     };
   }
+  // Job name `lint` / `typecheck` does not match CODE_SIGNATURES.lint (that
+  // pattern wants "biome" / "lint error"), so an empty excerpt used to land
+  // here as unknown. After infra, so a network flake on the lint job is still
+  // a re-run.
+  const named = JOB_NAME_CODE_CATEGORIES[bareCheckName(name)];
+  if (named) return codeVerdict(name, named);
   return {
     kind: 'unknown',
     category: null,
@@ -419,21 +511,45 @@ export function classifyFailure({ jobName = '', logExcerpt = '' } = {}) {
  * Fold per-failure classifications into one verdict for the PR. `blocked`
  * dominates, then `code` (fix it), then `infra` (re-run it); `unknown` only
  * when nothing else matched.
+ *
+ * The unknown fallback must not pick the `ci` aggregator. GitHub lists that
+ * check first (PR #3008), `isCiAggregatorNoise` correctly forces it to
+ * `unknown`, and returning `classified[0]` then skipped with the aggregator's
+ * sentence even when a sibling (`lint`) had also failed. Prefer a
+ * non-aggregator unknown; if any remaining job is a well-known code job,
+ * promote it to `code` so the PR dispatches.
  * @param {Array<{name?: string, jobName?: string, logExcerpt?: string}>} failures
  * @returns {{kind: 'blocked'|'code'|'infra'|'unknown', category: string|null, reason: string}}
  */
 export function classifyFailures(failures = []) {
-  const classified = (Array.isArray(failures) ? failures : []).map((f) =>
-    classifyFailure({
-      jobName: f.jobName ?? f.name,
-      logExcerpt: f.logExcerpt ?? f.description ?? '',
-    })
-  );
+  const list = Array.isArray(failures) ? failures : [];
+  const classified = list.map((f) => {
+    const jobName = f.jobName ?? f.name;
+    return {
+      jobName,
+      ...classifyFailure({
+        jobName,
+        logExcerpt: f.logExcerpt ?? f.description ?? '',
+      }),
+    };
+  });
   for (const kind of ['blocked', 'code', 'infra']) {
     const hit = classified.find((c) => c.kind === kind);
     if (hit) return hit;
   }
+  return pickUnknownFallback(classified);
+}
+
+/**
+ * Last-resort unknown fold: never let aggregator noise own the skip reason.
+ * @param {Array<{jobName?: string, kind: string, category: string|null, reason: string}>} classified
+ */
+function pickUnknownFallback(classified) {
+  const named = classified.find((c) => wellKnownCodeCategory(c.jobName));
+  if (named) return codeVerdict(named.jobName, wellKnownCodeCategory(named.jobName));
+  const nonAggregator = classified.find((c) => !isCiAggregatorJob(c.jobName));
   return (
+    nonAggregator ??
     classified[0] ?? {
       kind: 'unknown',
       category: null,

--- a/packages/dev-tools/pr-fix-dispatcher/lib.test.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/lib.test.mjs
@@ -11,9 +11,12 @@ import {
   formatFailuresForMatrix,
   hasRerunForSha,
   isAutomationPr,
+  isCiAggregatorJob,
   parseMarkers,
+  prioritizeLogFetch,
   screenPr,
   summarizeChecks,
+  wellKnownCodeCategory,
 } from './lib.mjs';
 
 const NOW = new Date('2025-01-15T12:00:00Z');
@@ -344,6 +347,38 @@ describe('classifyFailure', () => {
     expect(out.reason).toMatch(/no plausible cause/i);
   });
 
+  // Job name `lint` does not match CODE_SIGNATURES.lint (that pattern wants
+  // "biome" / "lint error"). An empty or truncated excerpt must still be
+  // code, or the aggregator-first fallback skips a mechanically fixable PR.
+  it('classifies a failing lint/typecheck job as code even with an empty excerpt', () => {
+    expect(classifyFailure({ jobName: 'lint', logExcerpt: '' })).toMatchObject({
+      kind: 'code',
+      category: 'lint',
+    });
+    expect(classifyFailure({ jobName: 'typecheck', logExcerpt: '' })).toMatchObject({
+      kind: 'code',
+      category: 'types',
+    });
+    expect(classifyFailure({ jobName: 'CI / lint', logExcerpt: '' })).toMatchObject({
+      kind: 'code',
+      category: 'lint',
+    });
+  });
+
+  it('still prefers a log-based code signature over the lint job-name fallback', () => {
+    expect(classifyFailure({ jobName: 'lint', logExcerpt: DEBT_GATE_EXCERPT })).toMatchObject({
+      kind: 'code',
+      category: 'debt-gate',
+    });
+  });
+
+  it('still classifies a network flake on the lint job as infra', () => {
+    expect(
+      classifyFailure({ jobName: 'lint', logExcerpt: 'getaddrinfo ENOTFOUND registry.npmjs.org' })
+        .kind
+    ).toBe('infra');
+  });
+
   it('tolerates missing input', () => {
     expect(classifyFailure().kind).toBe('unknown');
   });
@@ -409,6 +444,71 @@ describe('classifyFailures', () => {
   it('reports unknown for an empty list', () => {
     expect(classifyFailures([]).kind).toBe('unknown');
     expect(classifyFailures().kind).toBe('unknown');
+  });
+
+  // PR #3008: GitHub listed `ci` before `lint`. Both classified as unknown
+  // (aggregator noise; empty lint excerpt), and `classified[0]` made the skip
+  // reason the aggregator's sentence.
+  it('does not pick the aggregator unknown as the fallback (PR #3008)', () => {
+    const out = classifyFailures([
+      { name: 'ci', logExcerpt: AGGREGATOR_EXCERPT },
+      { name: 'lint', logExcerpt: '' },
+    ]);
+    expect(out.kind).toBe('code');
+    expect(out.category).toBe('lint');
+    expect(out.reason).toMatch(/lint/);
+    expect(out.reason).not.toMatch(/aggregator/i);
+  });
+
+  it('prefers a non-aggregator unknown over the aggregator sentence', () => {
+    const out = classifyFailures([
+      { name: 'ci', logExcerpt: AGGREGATOR_EXCERPT },
+      { name: 'mystery', logExcerpt: 'exit 7' },
+    ]);
+    expect(out.kind).toBe('unknown');
+    expect(out.reason).toMatch(/mystery/);
+    expect(out.reason).not.toMatch(/aggregator/i);
+  });
+
+  it('promotes a well-known code job with an empty excerpt to dispatch', () => {
+    for (const name of ['webapp', 'e2e', 'chrome-extension', 'node-matrix-tests', 'bundle-size']) {
+      expect(
+        classifyFailures([
+          { name: 'ci', logExcerpt: AGGREGATOR_EXCERPT },
+          { name, logExcerpt: '' },
+        ]),
+        name
+      ).toMatchObject({ kind: 'code' });
+    }
+    expect(
+      classifyFailures([
+        { name: 'ci', logExcerpt: AGGREGATOR_EXCERPT },
+        { name: 'swift-server', logExcerpt: '' },
+      ])
+    ).toMatchObject({ kind: 'code', category: 'build' });
+  });
+});
+
+describe('aggregator job helpers', () => {
+  it('recognises the ci aggregator under both check-run names', () => {
+    expect(isCiAggregatorJob('ci')).toBe(true);
+    expect(isCiAggregatorJob('CI')).toBe(true);
+    expect(isCiAggregatorJob('CI / ci')).toBe(true);
+    expect(isCiAggregatorJob('lint')).toBe(false);
+    expect(isCiAggregatorJob('CI / lint')).toBe(false);
+  });
+
+  it('maps well-known code jobs, including swift-*', () => {
+    expect(wellKnownCodeCategory('lint')).toBe('lint');
+    expect(wellKnownCodeCategory('typecheck')).toBe('types');
+    expect(wellKnownCodeCategory('webapp')).toBe('webapp');
+    expect(wellKnownCodeCategory('swift-optel')).toBe('build');
+    expect(wellKnownCodeCategory('mystery')).toBeNull();
+  });
+
+  it('fetches non-aggregator jobs before the ci aggregator', () => {
+    const ordered = prioritizeLogFetch([{ name: 'ci' }, { name: 'lint' }, { name: 'mystery' }]);
+    expect(ordered.map((f) => f.name)).toEqual(['lint', 'mystery', 'ci']);
   });
 });
 
@@ -815,5 +915,42 @@ describe('regression: PR #2215 — a debt-gate-only automation PR', () => {
     expect(out.category).toBe('debt-gate');
     expect(out.reason).toMatch(/debt-gate/);
     expect(out.reason).not.toMatch(/no plausible cause/i);
+  });
+});
+
+// PR #3008 (`renovate/ghosttyterminal-1.x`) failed `lint` and the `CI / ci`
+// aggregator. GitHub listed `ci` first; the lint excerpt was empty, so both
+// classified as unknown and the skip comment said `"ci" is the CI aggregator
+// and does not name a failure cause` — stranding a mechanically fixable
+// automation PR. Lint is a well-known code job even with no log.
+describe('regression: PR #3008 — lint + aggregator, empty lint excerpt', () => {
+  const failing = [
+    { name: 'ci', conclusion: 'failure', logExcerpt: AGGREGATOR_EXCERPT },
+    { name: 'lint', conclusion: 'failure', logExcerpt: '' },
+  ];
+  const input = candidate({
+    pr: {
+      number: 3008,
+      title: 'chore(deps): update dependency ghosttyterminal to v1.5.2',
+      headRef: 'renovate/ghosttyterminal-1.x',
+      headSha: SHA,
+      labels: [],
+      user: { type: 'Bot', login: 'renovate[bot]' },
+    },
+    failing,
+    checks: { failing, pending: false, newestFailureAt: minutesAgo(90) },
+  });
+
+  it('reaches the rubric rather than being screened out', () => {
+    expect(screenPr(input)).toBeNull();
+  });
+
+  it('dispatches a fixer naming lint, not the aggregator', () => {
+    const out = decidePrAction(input);
+    expect(out.action).toBe('dispatch');
+    expect(out.category).toBe('lint');
+    expect(out.reason).toMatch(/lint/);
+    expect(out.reason).not.toMatch(/aggregator/i);
+    expect(out.reason).not.toMatch(/"ci" is the CI aggregator/i);
   });
 });

--- a/packages/dev-tools/pr-fix-dispatcher/scan-failing-prs.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/scan-failing-prs.mjs
@@ -48,6 +48,7 @@ import {
   isAutomationPr,
   LABELS,
   parseMarkers,
+  prioritizeLogFetch,
   screenPr,
   summarizeChecks,
 } from './lib.mjs';
@@ -201,8 +202,11 @@ function jobIdFromDetailsUrl(url) {
 
 /** Attach a bounded log excerpt to each failing check that has a fetchable job log. */
 async function attachLogExcerpts(failing) {
+  // Non-aggregator jobs first so MAX_LOGS_PER_PR is not spent on the `ci`
+  // aggregator's boilerplate when a sibling (`lint`, …) named the cause.
+  const ordered = prioritizeLogFetch(failing);
   let fetched = 0;
-  for (const failure of failing) {
+  for (const failure of ordered) {
     if (failure.kind === 'status') {
       failure.logExcerpt = String(failure.description ?? '');
       continue;
@@ -219,7 +223,7 @@ async function attachLogExcerpts(failing) {
     });
     failure.logExcerpt = log ? extractLogExcerpt(log) : '';
   }
-  return failing;
+  return ordered;
 }
 
 /**


### PR DESCRIPTION
## Summary

The PR Fix Dispatcher no longer skips a mechanically fixable automation PR because GitHub listed the `CI / ci` aggregator first. A failing `lint` job (even with an empty log excerpt) now dispatches a fixer, and the skip reason no longer quotes the aggregator sentence.

## Why

Wrong skip on [#3008](https://github.com/ai-ecoverse/slicc/pull/3008#issuecomment-5613076692):

```
🧊 **PR Fix Dispatcher — skipping this one.** `"ci" is the CI aggregator and does not name a failure cause.`
```

PR #3008 (`ghosttyterminal` bump) had **lint FAILURE** and **ci FAILURE**. Lint is a real, fixable job. The skip is wrong.

**Repro:**
1. Automation PR fails `lint` and the `CI / ci` aggregator.
2. GitHub's check-runs API lists `ci` first.
3. `isCiAggregatorNoise` correctly forces the aggregator to `unknown`.
4. `classifyFailures` walks blocked → code → infra, then returned `classified[0]`.
5. Expected: dispatch naming lint. Actual: skip with the aggregator sentence.

Two compounding traps:
- `CODE_SIGNATURES.lint` does not match the job name `lint` (it wants `biome` / `lint error`). An empty or truncated excerpt classified the real job as unknown too.
- Log fetches followed `checks.failing` order, so `MAX_LOGS_PER_PR` could be spent on the aggregator first.

Same class as [#2215](https://github.com/ai-ecoverse/slicc/pull/2215) (debt-gate + aggregator) and [#2320](https://github.com/ai-ecoverse/slicc/pull/2320) (NODE_OPTIONS/dns aggregator false positive).

This PR does **not** land #3008 / #2989 / #3003 / #3004 — sibling threads own those.

## Approach / Implementation notes

- `classifyFailures` never picks aggregator-unknown as the fallback. Prefer a non-aggregator unknown. If any failing job is a well-known code job (`lint`, `typecheck`, `webapp`, `e2e`, `chrome-extension`, `node-matrix-tests`, `bundle-size`, `swift-*`), treat it as **code** and **dispatch**.
- Job-name-only signatures: a failing check named `lint` / `typecheck` is `code` even with an empty excerpt (after infra, so a network flake on the lint job is still a re-run).
- `prioritizeLogFetch` fetches logs for non-`ci` jobs before the aggregator.

## Cross-cutting impact

- **Floats exercised:** none (scheduled CI dispatcher only).
- No runtime, shell, persisted-state, or security surface changes.
- Does not change fixer behaviour, dispatch budget, markers, or the re-run path.

## Test plan

- [x] `npx vitest run --project dev-tools packages/dev-tools/pr-fix-dispatcher/lib.test.mjs` — 79 passing, including:
  - PR #3008 fixture: `lint` empty excerpt + `ci` aggregator → `decidePrAction` is **dispatch**, reason names lint, not `"ci" is the CI aggregator`
  - PR #2215 debt-gate regression still green
  - aggregator-unknown is never the skip-reason fallback when a sibling failed
- [x] `npm run verify` — 8/8
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [ ] `npm run test` — running after push (`.mjs` dispatcher only; no app code)
- [ ] N/A — no UI / bundle-size change; no coverage floor for this package

## Documentation

- [x] `packages/dev-tools/pr-fix-dispatcher/README.md` — skip-reason trap
- [x] `docs/dev-tools-details.md` — same class as #2215 / #2320

## Risk & rollback

- Blast radius: scheduled PR Fix Dispatcher classification only. False negatives still skip (safe). False positives could over-dispatch well-known jobs with empty logs (budget-capped at 3/tick, 5 in flight).
- Rollback: revert this PR.
- Nothing CI cannot catch that a reviewer must verify by hand beyond the unit tests.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (N/A — none)
- [x] No float contract changes