### PR TITLE
fix(webapp): keep cone-error cards across a reload

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -220,6 +220,15 @@ so a `discarded` round deletes it); `toChatMessages` folds them back by
 rendering side is unchanged: the row is a `ChatMessage` carrying `compaction`,
 and `messageEls` keys on that field.
 
+**Error cards are ordinary assistant-role rows, not markers.** A cone-error
+card (`ChatMessage.error` → `<slicc-error-card>`) is something the conversation
+showed, not something that happened TO it. The kernel appends it to the
+message buffer (`Bridge.recordErrorCard`) so it rides persist + replay, and a
+Pi-history rebuild folds the persisted `error: true` rows back in — Pi never
+held them, and they must not become a `ConversationEntry` (the model would see
+its own failure as a prior turn). `toBufferedChatMessages` projects `error`
+explicitly, the same way it projects `compaction`.
+
 **Only a SETTLED round is durable.** The kernel writes nothing on the opening
 phase and `interleaveMarkers` restores `summarized` / `fallback` only. The
 compaction phase stream does not replay, so a `summarizing` marker left behind

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -59,7 +59,10 @@ Invariants a reviewer must catch; mechanism in the linked docs.
   `record.markers` entry, NEVER a `ConversationEntry` — compaction replaces entries wholesale and
   would erase the row announcing it. Only a SETTLED round is written down (the phase stream does
   not replay, so a persisted in-flight seam could never be settled), under the row id the KERNEL
-  minted and the wire carried. **Users never
+  minted and the wire carried. A cone-error card (`ChatMessage.error`) is an ordinary
+  assistant-role row: the kernel appends it to the message buffer so it rides persist + replay;
+  it is not a marker (it does not have to survive a wholesale entry replace) and must never
+  become a Pi message. **Users never
   talk to a scoop**: a selected scoop is READ-ONLY (`isReadOnlyUnit`); asks go to the OWNING
   cone. Layout from `workspaceFor` ALONE (never hardcode `/workspace`); memory per cone.
   Privileged-float detection via `CapabilityBroker`, not `isExtensionRealm`, in scoops.

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -153,6 +153,13 @@ interface BufferedChatMessage {
    * store — the view renders on this field alone (`messageEls`).
    */
   compaction?: ChatMessage['compaction'];
+  /**
+   * Cone-error card: an ordinary assistant-role row the view renders as
+   * `<slicc-error-card>`. Carried so a reload's persist/reseed keeps the card
+   * (`messageEls` keys on this field). Distinct from `lickState` / `lickId`,
+   * which are a sibling projection (#3004).
+   */
+  error?: boolean;
 }
 
 export class Bridge implements KernelFacade {
@@ -387,6 +394,10 @@ export class Bridge implements KernelFacade {
       },
 
       onError: (scoopJid, error) => {
+        // Persist before the panel-facing emit: `#handleError` only appends
+        // in-memory, and a reload reseeds from Pi history which never held
+        // this row. The buffer + UI store is the durability path (#3003).
+        bridge.recordErrorCard(scoopJid, error);
         bridge.emit({
           type: 'error',
           scoopJid,
@@ -995,8 +1006,11 @@ export class Bridge implements KernelFacade {
     // Without this a rebuild from live agent state (every boot seed) would be
     // the transcript MINUS its seams, and persist that over the UI store.
     const { interleaveMarkers } = await import('../work-unit/conversation/derive.js');
-    return toBufferedChatMessages(
-      interleaveMarkers(chatMessages, await this.loadConversationMarkers(scoop))
+    return this.withPersistedErrorCards(
+      scoop,
+      toBufferedChatMessages(
+        interleaveMarkers(chatMessages, await this.loadConversationMarkers(scoop))
+      )
     );
   }
 
@@ -1039,7 +1053,7 @@ export class Bridge implements KernelFacade {
     const { toChatMessages } = await import('../work-unit/conversation/derive.js');
     const chatMessages = await toChatMessages(record, { source: sourceLabelFor(scoop) });
     if (chatMessages.length === 0) return null;
-    return toBufferedChatMessages(chatMessages);
+    return this.withPersistedErrorCards(scoop, toBufferedChatMessages(chatMessages));
   }
 
   /**
@@ -1639,6 +1653,52 @@ export class Bridge implements KernelFacade {
     }
     if (stuck.length === 0) this.pendingMarkers.delete(scoopJid);
     else this.pendingMarkers.set(scoopJid, stuck);
+  }
+
+  /**
+   * Append a cone-error card to the unit's message buffer and persist it.
+   *
+   * Unlike a compaction marker, this is an ordinary assistant-role row: it
+   * can ride the existing buffer + `browser-coding-agent` persist path, and
+   * it must never become a Pi `ConversationEntry` (the model would see its
+   * own failure as a prior turn). Boot reseed rebuilds from Pi history, so
+   * {@link withPersistedErrorCards} folds these rows back in from the UI
+   * store — the same store this write just updated (#3003).
+   */
+  private recordErrorCard(scoopJid: string, error: string): void {
+    this.getBuffer(scoopJid).push({
+      id: uid(),
+      role: 'assistant',
+      content: error,
+      timestamp: Date.now(),
+      error: true,
+    });
+    this.persistScoop(scoopJid);
+  }
+
+  /**
+   * Fold cone-error cards out of the UI store back into a Pi-history rebuild.
+   *
+   * `seedBuffersFromAgentState` / a remount rebuild from agent messages,
+   * which never held an `error` row, then persist that over the UI store.
+   * Without this fold the card `recordErrorCard` just wrote would be
+   * overwritten by the transcript minus its errors. Compaction seams are
+   * restored separately via `record.markers` + `interleaveMarkers`.
+   *
+   * Missing / unread store is a no-op — a missing card costs the retry
+   * affordance, not the transcript.
+   */
+  private async withPersistedErrorCards(
+    scoop: RegisteredScoop,
+    rebuilt: BufferedChatMessage[]
+  ): Promise<BufferedChatMessage[]> {
+    if (!this.sessionStore) return rebuilt;
+    try {
+      const session = await this.sessionStore.load(chatSessionIdFor(scoop));
+      return foldPersistedErrorCards(rebuilt, session?.messages);
+    } catch {
+      return rebuilt;
+    }
   }
 
   /**
@@ -2424,5 +2484,53 @@ function toBufferedChatMessages(chatMessages: readonly ChatMessage[]): BufferedC
     usage: m.usage,
     isStreaming: false,
     compaction: m.compaction,
+    error: m.error,
   }));
+}
+
+/**
+ * Re-insert `error: true` rows a Pi-history rebuild cannot reconstruct.
+ * Dedupes by id so a row already in `rebuilt` (same-session buffer) is not
+ * doubled, and orders extras by timestamp so a card that landed between
+ * two turns stays between them after a reload.
+ */
+function foldPersistedErrorCards(
+  rebuilt: BufferedChatMessage[],
+  persisted: readonly ChatMessage[] | undefined
+): BufferedChatMessage[] {
+  if (!persisted || persisted.length === 0) return rebuilt;
+  const extras = persisted.filter((m) => m.error === true);
+  if (extras.length === 0) return rebuilt;
+  const seen = new Set(rebuilt.map((m) => m.id));
+  const fresh = extras.filter((m) => !seen.has(m.id));
+  if (fresh.length === 0) return rebuilt;
+  return interleaveBufferedByTimestamp(rebuilt, toBufferedChatMessages(fresh));
+}
+
+function interleaveBufferedByTimestamp(
+  base: BufferedChatMessage[],
+  extra: BufferedChatMessage[]
+): BufferedChatMessage[] {
+  const sorted = [...extra].sort((a, b) => bufferedTime(a) - bufferedTime(b));
+  const out: BufferedChatMessage[] = [];
+  let next = 0;
+  for (const message of base) {
+    const at = bufferedTime(message);
+    while (next < sorted.length && bufferedTime(sorted[next]) <= at) {
+      out.push(sorted[next++]);
+    }
+    out.push(message);
+  }
+  while (next < sorted.length) out.push(sorted[next++]);
+  return out;
+}
+
+function bufferedTime(message: { timestamp: number }): number {
+  const raw: unknown = message.timestamp;
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string') {
+    const parsed = Date.parse(raw);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return Number.NEGATIVE_INFINITY;
 }

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -864,24 +864,12 @@ export class Bridge implements KernelFacade {
     if (!this.orchestrator) return;
     const cone = rootsOf(this.orchestrator.getScoops())[0];
     if (!cone) return;
-    const buf = messages.map((m) => ({
-      id: m.id,
-      role: m.role,
-      content: m.content,
-      attachments: m.attachments,
-      timestamp: m.timestamp,
-      source: m.source,
-      channel: m.channel,
-      toolCalls: m.toolCalls?.map((tc) => ({
-        id: tc.id,
-        name: tc.name,
-        input: tc.input,
-        result: tc.result,
-        isError: tc.isError,
-      })),
-      isStreaming: m.isStreaming,
-      model: m.model,
-      usage: m.usage,
+    // Same projector as the leader rebuild so `error` / `compaction` cannot
+    // silently drop here when they are added there. Streaming is the one
+    // field a live leader snapshot may still carry, so it is restored after.
+    const buf = toBufferedChatMessages(messages).map((row, i) => ({
+      ...row,
+      isStreaming: messages[i]?.isStreaming,
     }));
     this.messageBuffers.set(cone.jid, buf);
     this.currentMessageId.delete(cone.jid);

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -1264,6 +1264,12 @@ export interface ScoopMessagesReplacedMsg {
      * remounted panel or a follower — no agent event replays it.
      */
     compaction?: ChatMessage['compaction'];
+    /**
+     * Cone-error card (#3003): an ordinary assistant-role row. On the wire
+     * so a remounted panel and a tray follower render `<slicc-error-card>`
+     * from the replay instead of losing the live `error` event.
+     */
+    error?: boolean;
   }>;
   /**
    * Ids of the messages still pending in the orchestrator's queue for this

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -315,6 +315,14 @@ describe('Bridge createCallbacks', () => {
     expect(emitted.payload.type).toBe('error');
     expect(emitted.payload.scoopJid).toBe(scoopJid);
     expect(emitted.payload.error).toBe('Something went wrong');
+    // The card also lands in the kernel buffer so persist/reseed can keep it
+    // (`#handleError` on the page is in-memory only).
+    const buf = (bridge as any).getBuffer(scoopJid);
+    expect(buf.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: 'Something went wrong',
+      error: true,
+    });
   });
 
   it('onSendMessage buffers, persists, and emits text_delta + response_done', () => {
@@ -2641,8 +2649,10 @@ describe('Bridge handlePanelMessage dispatch', () => {
       (m: any) => m.payload?.type === 'scoop-messages-replaced' && m.payload.scoopJid === 'cone_2'
     ) as any;
     expect(replaced?.payload.messages.map((m: any) => m.content)).toEqual(['restore me']);
-    // The legacy UI store is never consulted once the record answered.
-    expect(uiLoad).not.toHaveBeenCalled();
+    // The record is still the transcript source. The UI store is consulted
+    // only to fold persisted cone-error cards back in (#3003); an empty
+    // load leaves the derived messages untouched.
+    expect(uiLoad).toHaveBeenCalledWith('session-cone-two');
   });
 
   it('request-scoop-messages falls back to the legacy UI store when there is no canonical record', async () => {

--- a/packages/webapp/tests/kernel/error-card-persistence.test.ts
+++ b/packages/webapp/tests/kernel/error-card-persistence.test.ts
@@ -214,4 +214,32 @@ describe('kernel error-card persistence', () => {
     const rebuilt = (await rebuild()) as ChatMessage[];
     expect(rebuilt.filter((m) => m.error === true)).toHaveLength(1);
   });
+
+  it('keeps error: true through a follower snapshot projection', () => {
+    sentMessages.length = 0;
+    bridge.applyFollowerSnapshot([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 100 },
+      {
+        id: 'err-snap',
+        role: 'assistant',
+        content: 'rate limited',
+        timestamp: 200,
+        error: true,
+      },
+    ]);
+
+    const buf = (bridge as unknown as { getBuffer: (jid: string) => ChatMessage[] }).getBuffer(
+      'cone_1'
+    );
+    expect(buf.find((m) => m.id === 'err-snap')).toMatchObject({
+      role: 'assistant',
+      content: 'rate limited',
+      error: true,
+    });
+
+    const replaced = sentMessages.find(
+      (m) => (m as { payload?: { type?: string } }).payload?.type === 'scoop-messages-replaced'
+    ) as { payload: { messages: ChatMessage[] } } | undefined;
+    expect(replaced?.payload.messages.find((m) => m.id === 'err-snap')?.error).toBe(true);
+  });
 });

--- a/packages/webapp/tests/kernel/error-card-persistence.test.ts
+++ b/packages/webapp/tests/kernel/error-card-persistence.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Durable cone-error cards (#3003).
+ *
+ * `#handleError` appends an `error: true` row to the page chat controller
+ * only. Pi history never held it, and `toBufferedChatMessages` used to strip
+ * `error` even if the row reached the kernel. These tests pin the writes that
+ * make the card survive a reload: the message buffer, the
+ * `browser-coding-agent` store, and the rebuild that folds a persisted card
+ * back in next to the compaction seam (#2992).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '../../src/scoops/chat-types.js';
+import type { ConversationMarker } from '../../src/work-unit/conversation/types.js';
+
+const messageListeners: Array<(message: unknown) => void> = [];
+const sentMessages: unknown[] = [];
+
+(globalThis as unknown as { chrome: unknown }).chrome = {
+  runtime: {
+    id: 'test-extension-id',
+    lastError: undefined,
+    sendMessage: vi.fn(async (msg: unknown) => {
+      sentMessages.push(msg);
+    }),
+    onMessage: {
+      addListener: vi.fn((cb: (message: unknown) => void) => void messageListeners.push(cb)),
+      removeListener: vi.fn(),
+    },
+  },
+};
+
+const { mockSessionStore, sessions, saved } = vi.hoisted(() => {
+  const sessions = new Map<string, ChatMessage[]>();
+  const saved: Array<{ sessionId: string; messages: ChatMessage[] }> = [];
+  return {
+    sessions,
+    saved,
+    mockSessionStore: vi.fn(function (this: Record<string, unknown>) {
+      this.init = vi.fn().mockResolvedValue(undefined);
+      this.saveMessages = vi.fn(async (sessionId: string, messages: ChatMessage[]) => {
+        const copy = structuredClone(messages);
+        sessions.set(sessionId, copy);
+        saved.push({ sessionId, messages: copy });
+      });
+      this.load = vi.fn(async (sessionId: string) => {
+        const messages = sessions.get(sessionId);
+        return messages ? { id: sessionId, messages, createdAt: 0, updatedAt: 0 } : null;
+      });
+      this.delete = vi.fn().mockResolvedValue(undefined);
+    }),
+  };
+});
+
+vi.mock('../../src/scoops/chat-session-store.js', () => ({ SessionStore: mockSessionStore }));
+
+const { Bridge } = await import('../../src/kernel/facade.js');
+
+const CONE = {
+  jid: 'cone_1',
+  name: 'Cone',
+  folder: 'cone',
+  parentJid: null,
+  requiresTrigger: false,
+  assistantLabel: 'sliccy',
+  addedAt: '2026-01-04T10:00:00.000Z',
+};
+
+function makeConversationStore(markers: ConversationMarker[] = []) {
+  return {
+    markers,
+    load: vi.fn(async () => ({ markers })),
+    putMarker: vi.fn(async (_key: string, marker: ConversationMarker) => {
+      const at = markers.findIndex((m) => m.id === marker.id);
+      if (at >= 0) markers[at] = marker;
+      else markers.push(marker);
+      return true;
+    }),
+    deleteMarker: vi.fn(async (_key: string, id: string) => {
+      const at = markers.findIndex((m) => m.id === id);
+      if (at >= 0) markers.splice(at, 1);
+      return at >= 0;
+    }),
+  };
+}
+
+describe('kernel error-card persistence', () => {
+  let bridge: InstanceType<typeof Bridge>;
+  let callbacks: ReturnType<typeof Bridge.createCallbacks>;
+  let conversationStore: ReturnType<typeof makeConversationStore>;
+  let agentMessages: unknown[];
+
+  const persisted = () => saved[saved.length - 1]?.messages ?? [];
+
+  const rebuild = () =>
+    (
+      bridge as unknown as {
+        buildBufferFromAgentMessages: (scoop: unknown) => Promise<ChatMessage[] | null>;
+      }
+    ).buildBufferFromAgentMessages(CONE);
+
+  beforeEach(async () => {
+    sentMessages.length = 0;
+    saved.length = 0;
+    sessions.clear();
+    vi.clearAllMocks();
+    agentMessages = [
+      { role: 'user', content: [{ type: 'text', text: 'ship it' }], timestamp: 1000 },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'shipped' }],
+        timestamp: 2000,
+        model: 'claude-opus-4-6',
+      },
+    ];
+    conversationStore = makeConversationStore();
+
+    bridge = new Bridge();
+    await bridge.bind({
+      getScoops: () => [CONE],
+      getScoopContext: () => ({ getAgentMessages: () => agentMessages }),
+      getConversationStore: () => conversationStore,
+      getQueuedMessageIds: () => [],
+    } as never);
+    callbacks = Bridge.createCallbacks(bridge);
+  });
+
+  it('appends an error card to the buffer and the UI store', async () => {
+    callbacks.onError?.('cone_1', 'rate limited');
+    await vi.waitFor(() => expect(persisted().some((m) => m.error === true)).toBe(true));
+
+    const card = persisted().find((m) => m.error);
+    expect(card).toMatchObject({
+      role: 'assistant',
+      content: 'rate limited',
+      error: true,
+    });
+    const buf = (bridge as unknown as { getBuffer: (jid: string) => ChatMessage[] }).getBuffer(
+      'cone_1'
+    );
+    expect(buf.at(-1)).toMatchObject({ content: 'rate limited', error: true });
+  });
+
+  it('keeps error: true across persist/reseed from Pi history', async () => {
+    callbacks.onError?.('cone_1', 'provider exploded');
+    await vi.waitFor(() => expect(persisted().some((m) => m.error === true)).toBe(true));
+    const cardId = persisted().find((m) => m.error)?.id;
+    expect(cardId).toBeTruthy();
+
+    // Full reload: buffers start empty, seed rebuilds from Pi (no error row)
+    // and would overwrite the UI store without the fold.
+    (bridge as unknown as { messageBuffers: Map<string, unknown> }).messageBuffers.clear();
+    await bridge.seedBuffersFromAgentState();
+
+    const buf = (bridge as unknown as { getBuffer: (jid: string) => ChatMessage[] }).getBuffer(
+      'cone_1'
+    );
+    const card = buf.find((m) => m.error === true);
+    expect(card).toMatchObject({
+      id: cardId,
+      role: 'assistant',
+      content: 'provider exploded',
+      error: true,
+    });
+    expect(persisted().find((m) => m.id === cardId)?.error).toBe(true);
+  });
+
+  it('keeps the compaction seam when an error card is folded back in', async () => {
+    conversationStore.markers.push({
+      id: 'compaction-cone_1-stored',
+      kind: 'compaction',
+      timestamp: 1500,
+      compaction: { trigger: 'threshold', state: 'summarized' },
+    });
+    callbacks.onError?.('cone_1', 'rate limited');
+    await vi.waitFor(() => expect(persisted().some((m) => m.error === true)).toBe(true));
+
+    (bridge as unknown as { messageBuffers: Map<string, unknown> }).messageBuffers.clear();
+    const rebuilt = (await rebuild()) as ChatMessage[];
+
+    expect(rebuilt.map((m) => (m.compaction ? 'seam' : m.error ? 'error' : m.role))).toEqual([
+      'user',
+      'seam',
+      'assistant',
+      'error',
+    ]);
+    expect(rebuilt.find((m) => m.error)?.error).toBe(true);
+    expect(rebuilt.find((m) => m.compaction)?.compaction).toMatchObject({ state: 'summarized' });
+  });
+
+  it('places a persisted error card on the timestamp seam', async () => {
+    sessions.set('session-cone', [
+      {
+        id: 'err-mid',
+        role: 'assistant',
+        content: 'boom',
+        timestamp: 1500,
+        error: true,
+      },
+    ]);
+
+    const rebuilt = (await rebuild()) as ChatMessage[];
+    expect(rebuilt.map((m) => (m.error ? 'error' : m.role))).toEqual([
+      'user',
+      'error',
+      'assistant',
+    ]);
+  });
+
+  it('folds a persisted error card in once', async () => {
+    callbacks.onError?.('cone_1', 'rate limited');
+    await vi.waitFor(() => expect(persisted().some((m) => m.error === true)).toBe(true));
+
+    const rebuilt = (await rebuild()) as ChatMessage[];
+    expect(rebuilt.filter((m) => m.error === true)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #3003.

## Summary

A cone-error card (`ChatMessage.error` → `<slicc-error-card>` with Try again) vanished on a leader-tab reload. The card now survives, because the kernel appends it to the message buffer and a Pi-history reseed folds the persisted `error: true` row back in.

## Why

Named out of scope in PR #2992: the same page-only path that dropped compaction seams also dropped error cards.

**Repro**

1. Trigger a cone error (LLM/tool failure) — a `<slicc-error-card>` appears in the thread.
2. Reload the leader tab.

Expected: the card is still there, with `error: true`.
Actual: it is gone, and nothing carrying it exists in `browser-coding-agent` IDB.

Three layers were missing it at once:

1. `WcChatController.#handleError` appends the row to its in-memory array and the DOM, and nothing else.
2. The only writer of chat rows to IDB is the kernel bridge, from `messageBuffers` — which never held an error row — and `toBufferedChatMessages` enumerates fields explicitly, omitting `error`.
3. Even with the row in IDB, boot re-seeds the buffer from Pi's history (`buildBufferFromAgentMessages`) and overwrites the store. Pi never held an error row.

Unlike a compaction marker (which must not be a `ConversationEntry` because compaction rewrites entries wholesale), an error card is an ordinary assistant-role row and can ride the existing buffer + persist path once emitted through the kernel.

## Approach / Implementation notes

- **Kernel `onError` appends** an assistant-role row with `error: true` to the unit's message buffer and `persistScoop`s it (`Bridge.recordErrorCard`). The live panel still renders from the `error` event; durability is the buffer + UI store.
- **`toBufferedChatMessages` projects `error`.** Same explicit field list that gained `compaction` in #2992. `lickId` / `lickState` are left for #3004.
- **Reseed fold.** Boot rebuilds from Pi history, which still cannot reconstruct the card, so `withPersistedErrorCards` reads the UI store and interleaves persisted `error: true` rows by timestamp. Compaction seams still come from `record.markers` + `interleaveMarkers`.
- **Replay wire.** `ScoopMessagesReplacedMsg` carries `error` so a remounted panel and a tray follower render the card from the snapshot. iOS `ErrorCard` already keys on `message.error`.
- **Not a `ConversationEntry`.** Putting the card in Pi history would show the model its own failure as a prior turn.

## Cross-cutting impact

- **Floats exercised**: standalone/CLI and extension share `Bridge` + `OffscreenClient`, so both get the persistence. A tray follower inherits the row on replay (`ScoopMessagesReplacedMsg.error`); the live `error` event is unchanged.
- **Other callers of the changed contract**: `toBufferedChatMessages` is shared by the live-agent rebuild and the canonical-record derivation. `lickId` / `lickState` are not projected (sibling #3004).
- **Persisted state side-effects**: `browser-coding-agent` sessions gain rows carrying `error: true`. No schema-version bump; older records read as "no error cards".
- **Rendering**: unchanged. The row is still a `ChatMessage` carrying `error`, and `messageEls` already routes that to `<slicc-error-card>`.

## Test plan

- [x] `npm run verify` — 8/8 checks
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 21144 passed; 2 pre-existing `check-touched-exemptions.test.mjs` timeouts under full-suite load (5 s budget; pass in isolation at ~1.9 s)
- [x] `npm run test:coverage:webapp` — floors met
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK (+0.9 kB worker, under 5 kB allowance), both apps under budget
- [x] **New behavior covered by unit tests**
  - `tests/kernel/error-card-persistence.test.ts` (new) — append + persist, persist/reseed keeps `error: true`, compaction seam still present, timestamp placement, no duplicate fold
  - `tests/kernel/bridge.test.ts` — `onError` lands in the kernel buffer; canonical-record rebuild still consults the UI store only to fold error cards

## Documentation

- [x] `packages/webapp/CLAUDE.md` — error cards ride the buffer, are not markers, must never become Pi messages
- [x] `docs/work-unit.md` — same rule next to the marker section
- [ ] `README.md` — no user-facing behavior change beyond the bug being gone

## Risk & rollback

- Blast radius: one transcript row on every float. Worst case is a duplicated or missing card; conversation content is never involved — error cards are not `ConversationEntry`s and `toAgentMessages` cannot see them.
- No feature flag. Reverting the PR is clean: a leftover `error: true` field on a buffered row is ignored by the previous reader.
- What CI cannot catch: the card on a **real tray follower** after a leader reload, and the card after a session freeze/thaw.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel change
- [x] Cross-float contract checked: replay shape (`ScoopMessagesReplacedMsg`), the kernel buffer, and the follower's renderer
- [x] Did not steal #3004 (lickState/lickId), #3008, #2989, or dispatcher work

## Not in scope

`lickState` / `lickId` on the same projection list (#3004). `toBufferedChatMessages` adds `error` only.