### PR TITLE
fix(renovate): group GhosttyTerminal with libghostty-spm dual pins

### DIFF
--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -218,9 +218,11 @@ Syncing those pins is mechanical; inventing a new dependency is still a hard
 skip. `renovate.json`'s regex `customManagers` entry covers `project.yml`, and
 each dual-pinned GitHub identity is grouped + labelled `swift-pin` so one PR
 moves both manifests. That still split (PRs #2320 / #2348: one PR on 151, the
-other on 150), so `renovate-swift-pin-reconcile.yml` raises the stale side the
-same way `renovate-format-reconcile.yml` reflows a formatter bump. `npm run
-lint:swift-pins` is the deterministic backstop. The dispatcher skips
+other on 150; PR #3008 opened as `GhosttyTerminal` because that is the xcodegen
+`packages:` key and missed the group), so `renovate-swift-pin-reconcile.yml`
+raises the stale side the same way `renovate-format-reconcile.yml` reflows a
+formatter bump. `npm run lint:swift-pins` is the deterministic backstop and
+requires the xcodegen key in `matchPackageNames` alongside `owner/repo`. The dispatcher skips
 `swift-pin` PRs so it does not race the reconciler; `pin-sync` remains the
 backup for an unlabeled leftover.
 

--- a/packages/dev-tools/swift-pin-reconcile/README.md
+++ b/packages/dev-tools/swift-pin-reconcile/README.md
@@ -11,7 +11,9 @@ failed with `depends on 'webrtc' 151 and root depends on 'webrtc' 150`.
 - **`lib.mjs`** — pure parse / compare / apply (unit-tested in `lib.test.mjs`).
 - **`check-swift-pins.mjs`** — the guard. `npm run lint:swift-pins`, wired into
   `lint` / `lint:ci`. Also asserts `renovate.json` labels every dual pin
-  `swift-pin` so the workflow below actually runs.
+  `swift-pin` and lists both the GitHub `owner/repo` and the xcodegen
+  `packages:` key (PR #3008 opened as `GhosttyTerminal` and missed the group)
+  so the workflow below actually runs.
 - **`reconcile.mjs`** — `--write` raises the stale side to the higher version
   already in the tree and, for exact pins, peels the git tag into
   `Package.resolved`. Consumed by

--- a/packages/dev-tools/swift-pin-reconcile/check-swift-pins.mjs
+++ b/packages/dev-tools/swift-pin-reconcile/check-swift-pins.mjs
@@ -14,8 +14,8 @@ import { fileURLToPath } from 'node:url';
 import { readPinFiles } from './files.mjs';
 import {
   checkRenovateSwiftPinSync,
+  collectDualPins,
   describeMismatch,
-  dualPinKeys,
   findMismatches,
 } from './lib.mjs';
 
@@ -24,15 +24,7 @@ const renovatePath = resolve(repoRoot, 'renovate.json');
 
 const { projectPins, swiftPins, resolvedPins } = readPinFiles(repoRoot);
 const mismatches = findMismatches({ projectPins, swiftPins, resolvedPins });
-
-const dualKeys = dualPinKeys({ projectPins, swiftPins });
-const seen = new Set();
-const dualPins = [];
-for (const pin of projectPins) {
-  if (!dualKeys.has(pin.key) || seen.has(pin.key)) continue;
-  seen.add(pin.key);
-  dualPins.push(pin);
-}
+const dualPins = collectDualPins({ projectPins, swiftPins });
 
 const renovate = existsSync(renovatePath) ? JSON.parse(readFileSync(renovatePath, 'utf8')) : null;
 const problems = [

--- a/packages/dev-tools/swift-pin-reconcile/lib.mjs
+++ b/packages/dev-tools/swift-pin-reconcile/lib.mjs
@@ -75,21 +75,22 @@ export function rangeContains(requirement, version) {
 }
 
 const PROJECT_PIN_RE =
-  /url:\s*(https:\/\/github\.com\/[^\s]+)\r?\n[ \t]+(exactVersion|minorVersion):\s*(\S+)/g;
+  /(?:^|\n)([ \t]*)([A-Za-z0-9._-]+):\r?\n\1[ \t]+url:\s*(https:\/\/github\.com\/[^\s]+)\r?\n\1[ \t]+(exactVersion|minorVersion):\s*(\S+)/g;
 
 /** Pins from a xcodegen `project.yml`. */
 export function parseProjectYmlPins(text, path = 'project.yml') {
   const pins = [];
   const src = String(text ?? '');
   for (const m of src.matchAll(PROJECT_PIN_RE)) {
-    const repo = githubRepoFromUrl(m[1]);
+    const repo = githubRepoFromUrl(m[3]);
     if (!repo) continue;
     pins.push({
       ...repo,
-      kind: m[2],
-      version: m[3],
+      ymlName: m[2],
+      kind: m[4],
+      version: m[5],
       path,
-      match: m[0],
+      match: m[0].replace(/^\n/, ''),
     });
   }
   return pins;
@@ -288,9 +289,19 @@ export function applyMismatches(fileContents, mismatches, revisionsByKey = {}) {
   return changed;
 }
 
-/** `owner/repo` as it appears in the GitHub URL — the name Renovate's regex manager uses. */
+/**
+ * Names the `swift-pin` packageRule must list so grouping + the reconcile
+ * workflow actually fire. `owner/repo` is what the swift manager uses;
+ * `ymlName` is the xcodegen `packages:` key (PR #3008 opened as
+ * `GhosttyTerminal` while the rule only listed `Lakr233/libghostty-spm`).
+ */
 export function requiredRenovateNames(pin) {
-  return [`${pin.owner}/${pin.repo}`];
+  const names = [`${pin.owner}/${pin.repo}`];
+  const ymlName = pin.ymlName?.trim();
+  if (ymlName && !names.some((n) => n.toLowerCase() === ymlName.toLowerCase())) {
+    names.push(ymlName);
+  }
+  return names;
 }
 
 /** Extra names github-releases may register the same pin under. */
@@ -333,8 +344,9 @@ export function checkRenovateSwiftPinSync({ dualPins, renovate }) {
   }
   const missing = [];
   for (const pin of pins) {
-    const required = `${pin.owner}/${pin.repo}`.toLowerCase();
-    if (!listed.has(required)) missing.push(`${pin.owner}/${pin.repo}`);
+    for (const name of requiredRenovateNames(pin)) {
+      if (!listed.has(name.toLowerCase())) missing.push(name);
+    }
   }
   if (missing.length > 0) {
     problems.push(

--- a/packages/dev-tools/swift-pin-reconcile/lib.mjs
+++ b/packages/dev-tools/swift-pin-reconcile/lib.mjs
@@ -74,8 +74,15 @@ export function rangeContains(requirement, version) {
   }
 }
 
-const PROJECT_PIN_RE =
-  /(?:^|\n)([ \t]*)([A-Za-z0-9._-]+):\r?\n\1[ \t]+url:\s*(https:\/\/github\.com\/[^\s]+)\r?\n\1[ \t]+(exactVersion|minorVersion):\s*(\S+)/g;
+// Comments, blank lines, merge keys, and anchors may sit between the xcodegen
+// `packages:` key and `url:` (and between `url:` and the version). Adjacent-
+// only matching dropped those pins while Renovate's url-first custom manager
+// still saw them (Codex review of PR #3014).
+const YML_SKIP_LINE = '(?:\\r?\\n(?:\\1[ \\t]+(?:#.*|<<:\\s*\\S+|&\\S.*)|\\1[ \\t]*))*';
+const PROJECT_PIN_RE = new RegExp(
+  `(?:^|\\n)([ \\t]*)([A-Za-z0-9._-]+):[^\\n]*${YML_SKIP_LINE}\\r?\\n\\1[ \\t]+url:\\s*(https://github\\.com/[^\\s]+)${YML_SKIP_LINE}\\r?\\n\\1[ \\t]+(exactVersion|minorVersion):\\s*(\\S+)`,
+  'g'
+);
 
 /** Pins from a xcodegen `project.yml`. */
 export function parseProjectYmlPins(text, path = 'project.yml') {
@@ -168,6 +175,26 @@ export function dualPinKeys({ projectPins, swiftPins }) {
     if (projectKeys.has(pin.key)) keys.add(pin.key);
   }
   return keys;
+}
+
+/**
+ * Dual-pinned project.yml entries, one per GitHub identity + xcodegen key.
+ * Deduping by identity alone (ios-app and swift-launcher both pin WebRTC)
+ * would drop a renamed `packages:` key and let lint:swift-pins pass while
+ * Renovate still opens an unlabeled PR under the leftover alias.
+ */
+export function collectDualPins({ projectPins, swiftPins }) {
+  const dualKeys = dualPinKeys({ projectPins, swiftPins });
+  const seen = new Set();
+  const dualPins = [];
+  for (const pin of projectPins ?? []) {
+    if (!dualKeys.has(pin.key)) continue;
+    const alias = `${pin.key}\0${(pin.ymlName ?? '').toLowerCase()}`;
+    if (seen.has(alias)) continue;
+    seen.add(alias);
+    dualPins.push(pin);
+  }
+  return dualPins;
 }
 
 /**
@@ -343,9 +370,13 @@ export function checkRenovateSwiftPinSync({ dualPins, renovate }) {
     }
   }
   const missing = [];
+  const missingSeen = new Set();
   for (const pin of pins) {
     for (const name of requiredRenovateNames(pin)) {
-      if (!listed.has(name.toLowerCase())) missing.push(name);
+      const lower = name.toLowerCase();
+      if (listed.has(lower) || missingSeen.has(lower)) continue;
+      missingSeen.add(lower);
+      missing.push(name);
     }
   }
   if (missing.length > 0) {

--- a/packages/dev-tools/swift-pin-reconcile/lib.test.mjs
+++ b/packages/dev-tools/swift-pin-reconcile/lib.test.mjs
@@ -3,6 +3,7 @@ import {
   applyMismatches,
   checkRenovateSwiftPinSync,
   cmpSemver,
+  collectDualPins,
   commitShaFromTagRef,
   describeMismatch,
   dualPinKeys,
@@ -127,6 +128,25 @@ describe('parsers', () => {
       'GhosttyTerminal:lakr233/libghostty-spm:exactVersion:1.3.2',
       'HuggingFace:huggingface/swift-huggingface:minorVersion:0.9.0',
       'WebRTC:stasel/webrtc:exactVersion:150.0.0',
+    ]);
+  });
+
+  it('keeps a pin when a comment or YAML anchor sits between the key and url', () => {
+    const pins = parseProjectYmlPins(`packages:
+  GhosttyTerminal: &ghostty # wrapper
+    # keep this exact
+    <<: *shared
+    url: https://github.com/Lakr233/libghostty-spm
+    # version
+    exactVersion: 1.5.2
+`);
+    expect(pins).toEqual([
+      expect.objectContaining({
+        ymlName: 'GhosttyTerminal',
+        key: 'lakr233/libghostty-spm',
+        kind: 'exactVersion',
+        version: '1.5.2',
+      }),
     ]);
   });
 
@@ -371,6 +391,40 @@ describe('checkRenovateSwiftPinSync', () => {
     expect(problems[0]).toMatch(/swift-huggingface/);
   });
 
+  it('fails when a second xcodegen alias for the same GitHub identity is missing', () => {
+    const projectPins = [
+      ...dualPins,
+      {
+        ...dualPins.find((p) => p.key === 'stasel/webrtc'),
+        ymlName: 'WebRTCKit',
+        path: 'other.yml',
+      },
+    ];
+    const problems = checkRenovateSwiftPinSync({
+      dualPins: collectDualPins({
+        projectPins,
+        swiftPins: parsePackageSwiftPins(PACKAGE_SWIFT),
+      }),
+      renovate: {
+        packageRules: [
+          {
+            addLabels: [SWIFT_PIN_LABEL],
+            matchPackageNames: [
+              'stasel/WebRTC',
+              'WebRTC',
+              'Lakr233/libghostty-spm',
+              'GhosttyTerminal',
+              'huggingface/swift-huggingface',
+              'HuggingFace',
+            ],
+          },
+        ],
+      },
+    });
+    expect(problems[0]).toMatch(/WebRTCKit/);
+    expect(problems[0]).not.toMatch(/GhosttyTerminal/);
+  });
+
   it('fails when the xcodegen package key is missing (PR #3008 GhosttyTerminal)', () => {
     const problems = checkRenovateSwiftPinSync({
       dualPins,
@@ -415,5 +469,25 @@ describe('renovate name helpers', () => {
       ymlName: 'GhosttyTerminal',
     };
     expect(requiredRenovateNames(ghostty)).toEqual(['Lakr233/libghostty-spm', 'GhosttyTerminal']);
+  });
+});
+
+describe('collectDualPins', () => {
+  it('keeps one entry per identity + xcodegen key, not per identity', () => {
+    const projectPins = [
+      ...parseProjectYmlPins(PROJECT_YML, 'packages/ios-app/project.yml'),
+      ...parseProjectYmlPins(
+        `packages:
+  WebRTCKit:
+    url: https://github.com/stasel/WebRTC.git
+    exactVersion: 150.0.0
+`,
+        'packages/swift-launcher/project.yml'
+      ),
+    ];
+    const swiftPins = parsePackageSwiftPins(PACKAGE_SWIFT);
+    const dual = collectDualPins({ projectPins, swiftPins });
+    const webrtc = dual.filter((p) => p.key === 'stasel/webrtc').map((p) => p.ymlName);
+    expect(webrtc.sort()).toEqual(['WebRTC', 'WebRTCKit']);
   });
 });

--- a/packages/dev-tools/swift-pin-reconcile/lib.test.mjs
+++ b/packages/dev-tools/swift-pin-reconcile/lib.test.mjs
@@ -123,10 +123,10 @@ describe('rangeContains', () => {
 describe('parsers', () => {
   it('reads exactVersion and minorVersion pins from project.yml', () => {
     const pins = parseProjectYmlPins(PROJECT_YML, 'packages/ios-app/project.yml');
-    expect(pins.map((p) => `${p.key}:${p.kind}:${p.version}`)).toEqual([
-      'lakr233/libghostty-spm:exactVersion:1.3.2',
-      'huggingface/swift-huggingface:minorVersion:0.9.0',
-      'stasel/webrtc:exactVersion:150.0.0',
+    expect(pins.map((p) => `${p.ymlName}:${p.key}:${p.kind}:${p.version}`)).toEqual([
+      'GhosttyTerminal:lakr233/libghostty-spm:exactVersion:1.3.2',
+      'HuggingFace:huggingface/swift-huggingface:minorVersion:0.9.0',
+      'WebRTC:stasel/webrtc:exactVersion:150.0.0',
     ]);
   });
 
@@ -335,7 +335,7 @@ describe('commitShaFromTagRef', () => {
 describe('checkRenovateSwiftPinSync', () => {
   const dualPins = parseProjectYmlPins(PROJECT_YML);
 
-  it('accepts a swift-pin rule that lists every owner/repo', () => {
+  it('accepts a swift-pin rule that lists every owner/repo and xcodegen key', () => {
     const renovate = {
       packageRules: [
         {
@@ -344,7 +344,9 @@ describe('checkRenovateSwiftPinSync', () => {
             'stasel/WebRTC',
             'WebRTC',
             'Lakr233/libghostty-spm',
+            'GhosttyTerminal',
             'huggingface/swift-huggingface',
+            'HuggingFace',
           ],
         },
       ],
@@ -369,6 +371,28 @@ describe('checkRenovateSwiftPinSync', () => {
     expect(problems[0]).toMatch(/swift-huggingface/);
   });
 
+  it('fails when the xcodegen package key is missing (PR #3008 GhosttyTerminal)', () => {
+    const problems = checkRenovateSwiftPinSync({
+      dualPins,
+      renovate: {
+        packageRules: [
+          {
+            addLabels: [SWIFT_PIN_LABEL],
+            matchPackageNames: [
+              'stasel/WebRTC',
+              'WebRTC',
+              'Lakr233/libghostty-spm',
+              'huggingface/swift-huggingface',
+            ],
+          },
+        ],
+      },
+    });
+    expect(problems[0]).toMatch(/GhosttyTerminal/);
+    expect(problems[0]).toMatch(/HuggingFace/);
+    expect(problems[0]).not.toMatch(/libghostty-spm/);
+  });
+
   it('fails when the rule exists but there are no dual pins', () => {
     const problems = checkRenovateSwiftPinSync({
       dualPins: [],
@@ -383,5 +407,13 @@ describe('renovate name helpers', () => {
   it('requires owner/repo and allows the repo-only github-releases alias', () => {
     expect(requiredRenovateNames(pin)).toEqual(['stasel/WebRTC']);
     expect(extraRenovateNames(pin)).toEqual(['WebRTC']);
+  });
+
+  it('also requires the xcodegen packages: key when it differs from owner/repo', () => {
+    const ghostty = {
+      ...githubRepoFromUrl('https://github.com/Lakr233/libghostty-spm'),
+      ymlName: 'GhosttyTerminal',
+    };
+    expect(requiredRenovateNames(ghostty)).toEqual(['Lakr233/libghostty-spm', 'GhosttyTerminal']);
   });
 });

--- a/renovate.json
+++ b/renovate.json
@@ -105,16 +105,16 @@
       "addLabels": ["swift-pin"]
     },
     {
-      "description": "Lakr233/libghostty-spm is dual-pinned (exact) in Package.swift and project.yml. Same split-PR failure mode as stasel/WebRTC; same group + swift-pin label. Keep in sync with lint:swift-pins.",
+      "description": "Lakr233/libghostty-spm is dual-pinned (exact) in Package.swift and project.yml. Same split-PR failure mode as stasel/WebRTC; same group + swift-pin label. Include the xcodegen packages: key (GhosttyTerminal) — PR #3008 opened under that name and missed the group, so only project.yml moved. Keep in sync with lint:swift-pins.",
       "matchManagers": ["swift", "custom.regex"],
-      "matchPackageNames": ["Lakr233/libghostty-spm", "libghostty-spm"],
+      "matchPackageNames": ["Lakr233/libghostty-spm", "libghostty-spm", "GhosttyTerminal"],
       "groupName": "Lakr233/libghostty-spm",
       "addLabels": ["swift-pin"]
     },
     {
-      "description": "huggingface/swift-huggingface is dual-pinned (minorVersion / upToNextMinor) in project.yml and Package.swift. Same split-PR failure mode as stasel/WebRTC; same group + swift-pin label. Keep in sync with lint:swift-pins.",
+      "description": "huggingface/swift-huggingface is dual-pinned (minorVersion / upToNextMinor) in project.yml and Package.swift. Same split-PR failure mode as stasel/WebRTC; same group + swift-pin label. Include the xcodegen packages: key (HuggingFace) the same way GhosttyTerminal is listed. Keep in sync with lint:swift-pins.",
       "matchManagers": ["swift", "custom.regex"],
-      "matchPackageNames": ["huggingface/swift-huggingface", "swift-huggingface"],
+      "matchPackageNames": ["huggingface/swift-huggingface", "swift-huggingface", "HuggingFace"],
       "groupName": "huggingface/swift-huggingface",
       "addLabels": ["swift-pin"]
     },


### PR DESCRIPTION
Follow-up to #3008.

## Summary

Renovate's `swift-pin` group for libghostty-spm listed `Lakr233/libghostty-spm` and `libghostty-spm`, but PR #3008 opened as **GhosttyTerminal** (the xcodegen `packages:` key). The group and label never applied, so only `project.yml` moved and `lint:swift-pins` went red.

This PR adds `GhosttyTerminal` (and `HuggingFace` the same way) to `matchPackageNames`, and makes `lint:swift-pins` require the xcodegen key alongside `owner/repo` so the next split cannot land unlabeled.

## Why

**Repro (already happened):**

1. Renovate bumps the xcodegen Ghostty pin.
2. The PR title/branch is `ghosttyterminal`, labels do not include `swift-pin`.
3. `Package.swift` / `Package.resolved` stay on the old exact version.
4. `npm run lint:swift-pins` fails; the `ci` aggregator fails with it.

Expected: one grouped `swift-pin` PR that moves both manifests, with `renovate-swift-pin-reconcile.yml` able to raise a leftover stale side.

## Approach / Implementation notes

- `parseProjectYmlPins` now captures the YAML package key as `ymlName`.
- `requiredRenovateNames` includes that key when it differs from `owner/repo`.
- `checkRenovateSwiftPinSync` uses those required names (it previously only checked `owner/repo`, which is why #3008's missing `GhosttyTerminal` was invisible to lint).

## Cross-cutting impact

- **Floats exercised:** none. Config + lint gate only.
- **Other callers:** `reconcile.mjs` still keys pins by GitHub identity; `ymlName` is lint-only.
- Does not change #3008's pin bump.

## Test plan

- [x] `npx vitest run packages/dev-tools/swift-pin-reconcile/lib.test.mjs` — 34 passed
- [x] `npm run lint:swift-pins` — 3 dual-pinned packages in sync
- [x] `npm run verify` — all 8 checks passed
- [x] `npm run typecheck`
- [x] New unit test: fails when `GhosttyTerminal` is missing from `matchPackageNames` even if `Lakr233/libghostty-spm` is listed
- [x] N/A — no UI, no runtime behavior

## Documentation

- [x] `packages/dev-tools/swift-pin-reconcile/README.md`
- [x] `docs/dev-tools-details.md`

## Risk & rollback

- Blast radius: Renovate grouping for three dual-pinned SPM packages. Worst case a future bump is over-grouped; revert this PR.
- CI cannot prove Renovate's hosted app will name the next bump `GhosttyTerminal`; the lint gate is the backstop.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets