### PR TITLE
fix(webapp): keep settled sudo-request glyphs across a reload

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -558,8 +558,12 @@ in its default amber `pending` state. When the cone resolves the request, the
 orchestrator persists the decision onto the originating message's `lickState`
 and the card flips in place — a green check (`confirmed`) for `lick_confirm` or
 a red cross (`dismissed`, rendered muted) for `lick_dismiss` — so the resolved
-verdict survives reload. The design-time fixture (`?ui-fixture=1`) carries one
-sample per state (`pending` / `confirmed` / `dismissed`) for styling.
+verdict survives reload. Pi history does not carry `lickState`; the kernel
+projects `lickId`/`lickState` through `toBufferedChatMessages` and folds the
+UI-store value back on boot reseed so `persistScoopAwait` cannot clobber a
+settled glyph with the pending default (#3004). The design-time fixture
+(`?ui-fixture=1`) carries one sample per state (`pending` / `confirmed` /
+`dismissed`) for styling.
 
 #### Other actionable licks (beyond sudo)
 

--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -218,7 +218,12 @@ kernel writes one per round (`Bridge.recordCompactionRow`, keyed by the row id
 so a `discarded` round deletes it); `toChatMessages` folds them back by
 `timestamp` alone, because no entry survives a rewrite to anchor to. The
 rendering side is unchanged: the row is a `ChatMessage` carrying `compaction`,
-and `messageEls` keys on that field.
+and `messageEls` keys on that field. Other out-of-band `ChatMessage` fields
+that also do not live in Pi history must take the same reseed hop:
+`toBufferedChatMessages` projects them explicitly, and a rebuild from agent
+state must not overwrite a settled UI-store value — `lickId`/`lickState` on
+sudo-request cards (#3004) overlay from `browser-coding-agent` so a confirmed
+or dismissed glyph cannot revert to pending.
 
 **Error cards are ordinary assistant-role rows, not markers.** A cone-error
 card (`ChatMessage.error` → `<slicc-error-card>`) is something the conversation

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -1052,23 +1052,44 @@ export class Bridge implements KernelFacade {
   }
 
   /**
-   * Fold `lickId`/`lickState` from the UI store onto a Pi-history rebuild.
-   * `agentMessagesToChatMessages` never emits the settled glyph, so without
-   * this `persistScoopAwait` would overwrite a confirmed/dismissed card with
-   * a pending one (#3004). Failures here cost the glyph, not the transcript.
+   * Fold `lickId`/`lickState` onto a Pi-history rebuild. The UI store is the
+   * live snapshot; the orchestrator channel-message DB is the durable write
+   * `persistLickDecision` awaits. `applyMessageUpdate` persists the UI store
+   * fire-and-forget, so a reload that races that write still recovers the
+   * settled glyph from the channel DB. Failures here cost the glyph, not the
+   * transcript.
    */
   private async overlayPersistedLickDecisionsOn(
     scoop: RegisteredScoop,
     buf: BufferedChatMessage[]
   ): Promise<BufferedChatMessage[]> {
-    if (!this.sessionStore) return buf;
     if (!buf.some((m) => m.channel === 'sudo-request' || m.lickId || m.lickState)) return buf;
-    try {
-      const session = await this.sessionStore.load(chatSessionIdFor(scoop));
-      return overlayPersistedLickDecisions(buf, session?.messages);
-    } catch {
-      return buf;
+    const stored: PersistedLickDecision[] = [];
+    if (this.sessionStore) {
+      try {
+        const session = await this.sessionStore.load(chatSessionIdFor(scoop));
+        if (session?.messages) stored.push(...session.messages);
+      } catch {
+        // glyph only
+      }
     }
+    try {
+      const channel = await this.orchestrator?.getMessagesForScoop?.(scoop.jid);
+      if (channel) {
+        for (const m of channel) {
+          stored.push({
+            id: m.id,
+            content: m.content,
+            channel: m.channel,
+            lickId: m.lickId,
+            lickState: m.lickState,
+          });
+        }
+      }
+    } catch {
+      // glyph only
+    }
+    return overlayPersistedLickDecisions(buf, stored);
   }
 
   /**
@@ -2572,13 +2593,25 @@ function isSettledLickState(
 }
 
 /**
+ * A sudo-request (or other actionable lick) card, not ordinary prose that
+ * happens to mention a lick id.
+ */
+function isActionableLickRow(m: PersistedLickDecision): boolean {
+  return (
+    m.channel === 'sudo-request' || !!m.lickId || !!m.lickState || m.id.startsWith('sudo-request-')
+  );
+}
+
+/**
  * Recover an actionable lick id from a reconstructed row. Live cards stamp
  * `lickId`; a Pi-history rebuild may only have it in the sudo-request body
  * (`Lick ID:` today, `Request ID:` on older envelopes) or the canonical
- * `sudo-request-<id>` message id.
+ * `sudo-request-<id>` message id. Ordinary rows that quote those lines are
+ * not cards and must not match.
  */
 function lickIdOf(m: PersistedLickDecision): string | undefined {
   if (m.lickId) return m.lickId;
+  if (!isActionableLickRow(m)) return undefined;
   const fromBody = /^(?:Lick ID|Request ID): (\S+)/m.exec(m.content)?.[1];
   if (fromBody) return fromBody;
   return m.id.startsWith('sudo-request-') ? m.id.slice('sudo-request-'.length) : undefined;
@@ -2610,14 +2643,14 @@ function overlayPersistedLickDecisions(
   const byId = new Map<string, PersistedLickDecision>();
   const byContent = new Map<string, PersistedLickDecision>();
   for (const m of stored) {
+    if (!isActionableLickRow(m)) continue;
     const lickId = lickIdOf(m);
     if (lickId) rememberLickDecision(byLickId, lickId, m);
     rememberLickDecision(byId, m.id, m);
-    if (m.channel === 'sudo-request' || m.lickId || m.lickState) {
-      rememberLickDecision(byContent, m.content, m);
-    }
+    rememberLickDecision(byContent, m.content, m);
   }
   return rebuilt.map((row) => {
+    if (!isActionableLickRow(row)) return row;
     const rowLickId = lickIdOf(row);
     const prior =
       (rowLickId ? byLickId.get(rowLickId) : undefined) ??

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -864,9 +864,10 @@ export class Bridge implements KernelFacade {
     if (!this.orchestrator) return;
     const cone = rootsOf(this.orchestrator.getScoops())[0];
     if (!cone) return;
-    // Same projector as the leader rebuild so `error` / `compaction` cannot
-    // silently drop here when they are added there. Streaming is the one
-    // field a live leader snapshot may still carry, so it is restored after.
+    // Same projector as the leader rebuild so `error` / `compaction` /
+    // `lickId`/`lickState` cannot silently drop here when they are added
+    // there. Streaming is the one field a live leader snapshot may still
+    // carry, so it is restored after.
     const buf = toBufferedChatMessages(messages).map((row, i) => ({
       ...row,
       isStreaming: messages[i]?.isStreaming,
@@ -994,10 +995,13 @@ export class Bridge implements KernelFacade {
     // Without this a rebuild from live agent state (every boot seed) would be
     // the transcript MINUS its seams, and persist that over the UI store.
     const { interleaveMarkers } = await import('../work-unit/conversation/derive.js');
-    return this.withPersistedErrorCards(
+    return this.overlayPersistedLickDecisionsOn(
       scoop,
-      toBufferedChatMessages(
-        interleaveMarkers(chatMessages, await this.loadConversationMarkers(scoop))
+      await this.withPersistedErrorCards(
+        scoop,
+        toBufferedChatMessages(
+          interleaveMarkers(chatMessages, await this.loadConversationMarkers(scoop))
+        )
       )
     );
   }
@@ -1041,7 +1045,30 @@ export class Bridge implements KernelFacade {
     const { toChatMessages } = await import('../work-unit/conversation/derive.js');
     const chatMessages = await toChatMessages(record, { source: sourceLabelFor(scoop) });
     if (chatMessages.length === 0) return null;
-    return this.withPersistedErrorCards(scoop, toBufferedChatMessages(chatMessages));
+    return this.overlayPersistedLickDecisionsOn(
+      scoop,
+      await this.withPersistedErrorCards(scoop, toBufferedChatMessages(chatMessages))
+    );
+  }
+
+  /**
+   * Fold `lickId`/`lickState` from the UI store onto a Pi-history rebuild.
+   * `agentMessagesToChatMessages` never emits the settled glyph, so without
+   * this `persistScoopAwait` would overwrite a confirmed/dismissed card with
+   * a pending one (#3004). Failures here cost the glyph, not the transcript.
+   */
+  private async overlayPersistedLickDecisionsOn(
+    scoop: RegisteredScoop,
+    buf: BufferedChatMessage[]
+  ): Promise<BufferedChatMessage[]> {
+    if (!this.sessionStore) return buf;
+    if (!buf.some((m) => m.channel === 'sudo-request' || m.lickId || m.lickState)) return buf;
+    try {
+      const session = await this.sessionStore.load(chatSessionIdFor(scoop));
+      return overlayPersistedLickDecisions(buf, session?.messages);
+    } catch {
+      return buf;
+    }
   }
 
   /**
@@ -2451,6 +2478,10 @@ function formatTranscript(messages: ReadonlyArray<{ role: string; content: strin
  * hand the panel identically-shaped rows — the field list is explicit on
  * purpose, so a new `ChatMessage` field is a compile-time decision here
  * rather than silently riding into the buffer.
+ *
+ * `lickId`/`lickState` (#3004) and `error` (#3003) are out-of-band (not in
+ * Pi history). Dropping them here lets `persistScoopAwait` clobber a settled
+ * sudo-request glyph or a cone-error card.
  */
 function toBufferedChatMessages(chatMessages: readonly ChatMessage[]): BufferedChatMessage[] {
   return chatMessages.map((m) => ({
@@ -2461,6 +2492,8 @@ function toBufferedChatMessages(chatMessages: readonly ChatMessage[]): BufferedC
     timestamp: m.timestamp,
     source: m.source,
     channel: m.channel,
+    lickId: m.lickId,
+    lickState: m.lickState,
     toolCalls: m.toolCalls?.map((tc) => ({
       id: tc.id,
       name: tc.name,
@@ -2521,4 +2554,81 @@ function bufferedTime(message: { timestamp: number }): number {
     if (!Number.isNaN(parsed)) return parsed;
   }
   return Number.NEGATIVE_INFINITY;
+}
+
+/** Subset of a UI-store row the reseed overlay copies lick decisions from. */
+interface PersistedLickDecision {
+  id: string;
+  content: string;
+  channel?: string;
+  lickId?: string;
+  lickState?: BufferedChatMessage['lickState'];
+}
+
+function isSettledLickState(
+  state: BufferedChatMessage['lickState']
+): state is 'confirmed' | 'dismissed' {
+  return state === 'confirmed' || state === 'dismissed';
+}
+
+/**
+ * Recover an actionable lick id from a reconstructed row. Live cards stamp
+ * `lickId`; a Pi-history rebuild may only have it in the sudo-request body
+ * (`Lick ID:` today, `Request ID:` on older envelopes) or the canonical
+ * `sudo-request-<id>` message id.
+ */
+function lickIdOf(m: PersistedLickDecision): string | undefined {
+  if (m.lickId) return m.lickId;
+  const fromBody = /^(?:Lick ID|Request ID): (\S+)/m.exec(m.content)?.[1];
+  if (fromBody) return fromBody;
+  return m.id.startsWith('sudo-request-') ? m.id.slice('sudo-request-'.length) : undefined;
+}
+
+function rememberLickDecision(
+  map: Map<string, PersistedLickDecision>,
+  key: string,
+  msg: PersistedLickDecision
+): void {
+  const existing = map.get(key);
+  if (!existing || (isSettledLickState(msg.lickState) && !isSettledLickState(existing.lickState))) {
+    map.set(key, msg);
+  }
+}
+
+/**
+ * Copy persisted `lickId`/`lickState` onto a Pi-history rebuild so
+ * `persistScoopAwait` cannot replace a settled sudo-request glyph with the
+ * pending default. Store values win; a settled state is never replaced by
+ * pending/absent.
+ */
+function overlayPersistedLickDecisions(
+  rebuilt: BufferedChatMessage[],
+  stored: readonly PersistedLickDecision[] | undefined
+): BufferedChatMessage[] {
+  if (!stored || stored.length === 0) return rebuilt;
+  const byLickId = new Map<string, PersistedLickDecision>();
+  const byId = new Map<string, PersistedLickDecision>();
+  const byContent = new Map<string, PersistedLickDecision>();
+  for (const m of stored) {
+    const lickId = lickIdOf(m);
+    if (lickId) rememberLickDecision(byLickId, lickId, m);
+    rememberLickDecision(byId, m.id, m);
+    if (m.channel === 'sudo-request' || m.lickId || m.lickState) {
+      rememberLickDecision(byContent, m.content, m);
+    }
+  }
+  return rebuilt.map((row) => {
+    const rowLickId = lickIdOf(row);
+    const prior =
+      (rowLickId ? byLickId.get(rowLickId) : undefined) ??
+      byId.get(row.id) ??
+      byContent.get(row.content);
+    if (!prior || (!prior.lickId && !prior.lickState)) return row;
+    const lickId = prior.lickId ?? rowLickId ?? lickIdOf(prior);
+    const lickState = isSettledLickState(prior.lickState)
+      ? prior.lickState
+      : (row.lickState ?? prior.lickState);
+    if (lickId === row.lickId && lickState === row.lickState && prior.id === row.id) return row;
+    return { ...row, id: prior.id, lickId, lickState };
+  });
 }

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -1270,6 +1270,10 @@ export interface ScoopMessagesReplacedMsg {
      * from the replay instead of losing the live `error` event.
      */
     error?: boolean;
+    /** Actionable-lick id so a remounted panel / follower can flip the card. */
+    lickId?: string;
+    /** Settled sudo-request glyph: pending / confirmed / dismissed (#3004). */
+    lickState?: 'pending' | 'confirmed' | 'dismissed';
   }>;
   /**
    * Ids of the messages still pending in the orchestrator's queue for this

--- a/packages/webapp/src/scoops/agent-message-to-chat.ts
+++ b/packages/webapp/src/scoops/agent-message-to-chat.ts
@@ -133,8 +133,9 @@ function translateUserMessage(m: UserMessage, idSeed: () => string): ChatMessage
     if (env.body.length === 0 && env.sender == null) continue;
     const lickChannel =
       (env.sender ? lickChannelFromSenderName(env.sender) : null) ?? lickChannelFromBody(env.body);
+    const lickId = lickChannel ? lickIdFromBody(env.body) : undefined;
     const msg: ChatMessage = {
-      id: idSeed(),
+      id: lickChannel === 'sudo-request' && lickId ? `sudo-request-${lickId}` : idSeed(),
       role: 'user',
       content: env.body,
       timestamp: m.timestamp,
@@ -142,6 +143,7 @@ function translateUserMessage(m: UserMessage, idSeed: () => string): ChatMessage
     if (lickChannel) {
       msg.source = 'lick';
       msg.channel = lickChannel;
+      if (lickId) msg.lickId = lickId;
     }
     out.push(msg);
   }
@@ -472,4 +474,15 @@ export function lickChannelFromBody(body: string): LickChannel | null {
   if (/^\[scoop_wait [^\]]+\]/.test(body)) return 'scoop-wait';
   if (body.startsWith('[Session Reload]')) return 'session-reload';
   return null;
+}
+
+/**
+ * Recover an actionable lick id from a reconstructed lick body. Live cards
+ * stamp `lickId` on the ChannelMessage; Pi history only has the body, which
+ * carries `Lick ID:` (current sudo-request / upgrade / navigate envelopes)
+ * or the older `Request ID:` sudo-request line. Does not set `lickState` —
+ * the decision is not in Pi history (#3004).
+ */
+export function lickIdFromBody(body: string): string | undefined {
+  return /^(?:Lick ID|Request ID): (\S+)/m.exec(body)?.[1];
 }

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -42,6 +42,7 @@ const { mockSessionStore, mockHandleAction } = vi.hoisted(() => ({
   mockSessionStore: vi.fn(function (this: any) {
     this.init = vi.fn().mockResolvedValue(undefined);
     this.saveMessages = vi.fn().mockResolvedValue(undefined);
+    this.load = vi.fn().mockResolvedValue(undefined);
     this.delete = vi.fn().mockResolvedValue(undefined);
   }),
   mockHandleAction: vi.fn().mockResolvedValue(undefined),
@@ -1495,6 +1496,30 @@ describe('Bridge follower mode', () => {
     expect(replaced).toBeDefined();
     expect(replaced.payload.scoopJid).toBe('cone_1');
     expect(replaced.payload.messages).toHaveLength(2);
+  });
+
+  it('applyFollowerSnapshot carries lickId/lickState onto the cone buffer', () => {
+    bridge.applyFollowerSnapshot([
+      {
+        id: 'sudo-request-lick-1',
+        role: 'user',
+        content: '[@test-scoop sudo-request]\nLick ID: lick-1\nKind: command\nDetail: git push',
+        timestamp: 100,
+        channel: 'sudo-request',
+        lickId: 'lick-1',
+        lickState: 'confirmed',
+      },
+    ] as any);
+
+    const after = (bridge as any).getBuffer('cone_1');
+    expect(after[0]).toMatchObject({ lickId: 'lick-1', lickState: 'confirmed' });
+    const replaced = sentMessages.find(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as any;
+    expect(replaced.payload.messages[0]).toMatchObject({
+      lickId: 'lick-1',
+      lickState: 'confirmed',
+    });
   });
 
   it('applyFollowerSnapshot is a noop when no orchestrator or no cone', () => {
@@ -3372,5 +3397,82 @@ describe('Bridge seedBuffersFromAgentState', () => {
   it('is a no-op when the orchestrator is not bound', async () => {
     const fresh = new Bridge();
     await expect(fresh.seedBuffersFromAgentState()).resolves.toBeUndefined();
+  });
+
+  const sudoBody = '[@test-scoop sudo-request]\nLick ID: lick-1\nKind: command\nDetail: git push';
+  const sudoHistory = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: `[9/10/2026, 12:00:00 PM] test-scoop: ${sudoBody}` }],
+      timestamp: 10,
+    },
+    {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'noted' }],
+      timestamp: 11,
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      stopReason: 'stop',
+    },
+  ];
+
+  it.each(['confirmed', 'dismissed'] as const)(
+    'reseed keeps a %s sudo-request glyph instead of reverting to pending (#3004)',
+    async (lickState) => {
+      const context = makeContext(sudoHistory);
+      await bridge.bind({
+        getScoops: vi.fn(() => [coneScoop]),
+        getScoopContext: vi.fn(() => context),
+      } as any);
+      const store = (bridge as any).sessionStore;
+      store.load.mockResolvedValue({
+        id: 'session-cone',
+        messages: [
+          {
+            id: 'sudo-request-lick-1',
+            role: 'user',
+            content: sudoBody,
+            timestamp: 10,
+            source: 'lick',
+            channel: 'sudo-request',
+            lickId: 'lick-1',
+            lickState,
+          },
+        ],
+      });
+
+      await bridge.seedBuffersFromAgentState();
+
+      const buf = (bridge as any).getBuffer('cone_1');
+      const card = buf.find((m: { lickId?: string }) => m.lickId === 'lick-1');
+      expect(card).toMatchObject({
+        id: 'sudo-request-lick-1',
+        channel: 'sudo-request',
+        lickId: 'lick-1',
+        lickState,
+      });
+      expect(card.lickState).not.toBe('pending');
+      const persisted = store.saveMessages.mock.calls[0][1];
+      expect(persisted.find((m: { lickId?: string }) => m.lickId === 'lick-1')).toMatchObject({
+        lickId: 'lick-1',
+        lickState,
+      });
+    }
+  );
+
+  it('reseed does not invent a settled glyph when the store has none', async () => {
+    const context = makeContext(sudoHistory);
+    await bridge.bind({
+      getScoops: vi.fn(() => [coneScoop]),
+      getScoopContext: vi.fn(() => context),
+    } as any);
+
+    await bridge.seedBuffersFromAgentState();
+
+    const buf = (bridge as any).getBuffer('cone_1');
+    const card = buf.find((m: { channel?: string }) => m.channel === 'sudo-request');
+    expect(card).toMatchObject({ lickId: 'lick-1', channel: 'sudo-request' });
+    expect(card.lickState).toBeUndefined();
   });
 });

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -3475,4 +3475,106 @@ describe('Bridge seedBuffersFromAgentState', () => {
     expect(card).toMatchObject({ lickId: 'lick-1', channel: 'sudo-request' });
     expect(card.lickState).toBeUndefined();
   });
+
+  it('reseed recovers a settled glyph from the channel-message DB when the UI store is stale', async () => {
+    const context = makeContext(sudoHistory);
+    await bridge.bind({
+      getScoops: vi.fn(() => [coneScoop]),
+      getScoopContext: vi.fn(() => context),
+      getMessagesForScoop: vi.fn(async () => [
+        {
+          id: 'sudo-request-lick-1',
+          chatJid: 'cone_1',
+          senderId: 'test-scoop',
+          senderName: 'test-scoop',
+          content: sudoBody,
+          timestamp: '2026-09-10T00:00:00.000Z',
+          fromAssistant: false,
+          channel: 'sudo-request',
+          lickId: 'lick-1',
+          lickState: 'confirmed',
+        },
+      ]),
+    } as any);
+    const store = (bridge as any).sessionStore;
+    store.load.mockResolvedValue({
+      id: 'session-cone',
+      messages: [
+        {
+          id: 'sudo-request-lick-1',
+          role: 'user',
+          content: sudoBody,
+          timestamp: 10,
+          source: 'lick',
+          channel: 'sudo-request',
+          lickId: 'lick-1',
+          lickState: 'pending',
+        },
+      ],
+    });
+
+    await bridge.seedBuffersFromAgentState();
+
+    const card = (bridge as any)
+      .getBuffer('cone_1')
+      .find((m: { lickId?: string }) => m.lickId === 'lick-1');
+    expect(card.lickState).toBe('confirmed');
+    const persisted = store.saveMessages.mock.calls[0][1];
+    expect(persisted.find((m: { lickId?: string }) => m.lickId === 'lick-1')?.lickState).toBe(
+      'confirmed'
+    );
+  });
+
+  it('reseed does not stamp a settled lick onto a later row that quotes the lick id', async () => {
+    const echoHistory = [
+      ...sudoHistory,
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: '[9/10/2026, 12:01:00 PM] User: approved Lick ID: lick-1 just now',
+          },
+        ],
+        timestamp: 12,
+      },
+    ];
+    const context = makeContext(echoHistory);
+    await bridge.bind({
+      getScoops: vi.fn(() => [coneScoop]),
+      getScoopContext: vi.fn(() => context),
+    } as any);
+    const store = (bridge as any).sessionStore;
+    store.load.mockResolvedValue({
+      id: 'session-cone',
+      messages: [
+        {
+          id: 'sudo-request-lick-1',
+          role: 'user',
+          content: sudoBody,
+          timestamp: 10,
+          source: 'lick',
+          channel: 'sudo-request',
+          lickId: 'lick-1',
+          lickState: 'confirmed',
+        },
+      ],
+    });
+
+    await bridge.seedBuffersFromAgentState();
+
+    const buf = (bridge as any).getBuffer('cone_1');
+    const cards = buf.filter((m: { lickId?: string }) => m.lickId === 'lick-1');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      id: 'sudo-request-lick-1',
+      channel: 'sudo-request',
+      lickState: 'confirmed',
+    });
+    const echo = buf.find((m: { content: string }) => m.content.includes('approved Lick ID'));
+    expect(echo).toBeDefined();
+    expect(echo.id).not.toBe('sudo-request-lick-1');
+    expect(echo.lickState).toBeUndefined();
+    expect(echo.lickId).toBeUndefined();
+  });
 });

--- a/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
+++ b/packages/webapp/tests/scoops/agent-message-to-chat.test.ts
@@ -118,6 +118,26 @@ describe('lickChannelFromBody', () => {
     expect(out).toHaveLength(1);
     expect(out[0].source).toBe('lick');
     expect(out[0].channel).toBe('sudo-request');
+    expect(out[0].lickId).toBe('sudo-mqf7gh5c-cr56age9');
+    expect(out[0].id).toBe('sudo-request-sudo-mqf7gh5c-cr56age9');
+    expect(out[0].lickState).toBeUndefined();
+  });
+
+  it('replayed sudo-request bodies recover lickId from the Lick ID line', () => {
+    const out = agentMessagesToChatMessages(
+      [
+        userMsg(
+          '[9/10/2026, 12:00:00 PM] test-scoop: [@test-scoop sudo-request]\nLick ID: lick-1\nKind: command\nDetail: git push'
+        ),
+      ],
+      { idSeed: seedId }
+    );
+    expect(out[0]).toMatchObject({
+      channel: 'sudo-request',
+      lickId: 'lick-1',
+      id: 'sudo-request-lick-1',
+    });
+    expect(out[0].lickState).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #3004.

## Summary

A settled `sudo-request` lick card flipped to a green check or red cross, then a full leader-tab reload put it back to the amber pending form. The boot reseed now keeps the confirmed/dismissed glyph that `persistLickDecision` already wrote.

## Why

Reported as a sibling of #2992: an out-of-band `ChatMessage` field that does not live in Pi history is dropped at the reseed hop.

**Repro**

1. A scoop files a `sudo-request`; the cone approves or denies it. The card shows ✓ / ✗.
2. Reload the leader tab.

Expected: the glyph stays confirmed/dismissed.
Actual: the card re-renders as pending amber, because `seedBuffersFromAgentState` rebuilt from Pi history (no `lickState`) and `persistScoopAwait` overwrote the UI store.

Distinct from #3003 (`error` field). This PR does not add or remove `error` on the projection list.

## Approach / Implementation notes

- `toBufferedChatMessages` now projects `lickId`/`lickState` (same explicit field list that gained `compaction` in #2992).
- Boot/remount rebuilds overlay the store-held decision onto the Pi-history rows so a settled value is never replaced by pending/absent.
- `agentMessagesToChatMessages` recovers `lickId` from the sudo-request body (`Lick ID:` / legacy `Request ID:`) so rebuilt cards stay addressable. It does not invent `lickState`.
- Follower snapshots and `scoop-messages-replaced` carry the same two fields so a remounted panel and a tray follower inherit the glyph.

## Cross-cutting impact

- **Floats exercised**: standalone/CLI and extension share `Bridge` + `OffscreenClient`; both get the overlay. Followers inherit via the replace envelope.
- **Other callers**: `buildBufferFromAgentMessages` and `buildBufferFromCanonicalRecord` both overlay; overlay is skipped when the rebuilt transcript has no lick card, so the canonical-record path still does not consult the UI store as a transcript source.
- **Persisted state**: no schema change. `browser-coding-agent` rows already held `lickState`; reseed no longer strips it.
- **Bundle size**: worker first-load +1.3 kB vs merge-base (allowance 5 kB).

## Test plan

- [x] `npm run verify` — 8/8 checks
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 21146 passed, 0 failed
- [x] `npm run test:coverage:webapp` — floors met
- [x] `npm run build` (includes chrome-extension)
- [x] `npm run bundle-size` — first-load OK, both apps under budget
- [x] **New behavior covered by unit tests**
  - `tests/kernel/bridge.test.ts` — reseed keeps confirmed and dismissed glyphs; does not invent a settled glyph when the store has none; follower snapshot carries `lickId`/`lickState`
  - `tests/scoops/agent-message-to-chat.test.ts` — reconstructed sudo-request bodies recover `lickId` from `Request ID:` and `Lick ID:` without setting `lickState`

## Documentation

- [x] `docs/approvals.md` — reseed overlay so the glyph survives reload
- [x] `docs/work-unit.md` — out-of-band fields must survive `toBufferedChatMessages` + boot reseed
- [x] N/A `README.md` — no user-facing behavior change beyond the bug being gone

## Risk & rollback

- Blast radius: sudo-request (and other actionable lick) glyphs on every float that reseeds. Worst case is a still-pending card, which is today's bug.
- No feature flag. Revert is clean: leftover `lickId`/`lickState` on a buffered row is ignored by the previous reader.
- What CI cannot catch: the glyph on a **real tray follower** after the leader reloads.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel change
- [x] Cross-float contract checked: replay shape (`ScoopMessagesReplacedMsg`), the kernel buffer, and follower snapshot projection

## Not in scope

- #3003 persist-of-error-rows (`ChatMessage.error`)
- #3008 / #2989 / dispatcher