### PR TITLE
fix(scoops): stop doubling curator scratch paths under extra cones

### DIFF
--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -681,10 +681,20 @@ function buildSpawnOptions(
  * its literal text; under an extra cone that path is another agent's folder and
  * every draft write there would escalate. The prompt — not the FS policy —
  * is rewritten to name this run's own scratch.
+ *
+ * Idempotent with `substitutePlaceholders`: per-cone scratch dirs start with
+ * the primary spelling (`…/agent-memory-curator-cone-…`), so a naive
+ * `replaceAll` would re-prefix already-expanded `{{SCRATCH_DIR}}` mentions.
+ * Protect the fully-substituted path first, then rewrite only the legacy
+ * primary spelling.
  */
 function rebaseScratchMentions(prompt: string, scratchDir: string): string {
   if (scratchDir === PRIMARY_CURATOR_SCRATCH) return prompt;
-  return prompt.replaceAll(PRIMARY_CURATOR_SCRATCH, scratchDir);
+  const sentinel = '\0SCRATCH\0';
+  return prompt
+    .replaceAll(scratchDir, sentinel)
+    .replaceAll(PRIMARY_CURATOR_SCRATCH, scratchDir)
+    .replaceAll(sentinel, scratchDir);
 }
 
 function substitutePlaceholders(template: string, values: Record<string, string>): string {

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -653,9 +653,44 @@ Curate {{MEMORY_PATH}}.`;
       // `{{SCRATCH_DIR}}` and spells the primary's out is rewritten rather
       // than sending every draft write into another agent's folder.
       const prompt = spawn.mock.calls[0][0].prompt;
-      expect(curatorScratchDir('cone-beta')).toBe('/scoops/agent-memory-curator-cone-beta');
-      expect(prompt).toContain('/scoops/agent-memory-curator-cone-beta');
+      const scratch = curatorScratchDir('cone-beta');
+      expect(scratch).toBe('/scoops/agent-memory-curator-cone-beta');
+      expect(prompt).toContain(scratch);
       expect(prompt).not.toContain('/scoops/agent-memory-curator/');
+      // Per-cone scratch dirs start with the primary spelling
+      // (`…/agent-memory-curator-…`); rebase must not re-prefix them.
+      expect(prompt).not.toContain(`${scratch}-cone-beta`);
+    });
+
+    it('does not double-substitute {{SCRATCH_DIR}} under an extra cone', async () => {
+      // Realistic shipped MEMORY.md: placeholders expand first, then the
+      // legacy rebase shim runs. The per-cone scratch
+      // `/scoops/agent-memory-curator-cone-slicc-engineering` starts with
+      // the primary prefix `/scoops/agent-memory-curator`, so a naive
+      // replaceAll doubles the cone suffix and the curator writes outside
+      // its sandbox (sudo escalation).
+      const cone = { folder: 'cone-slicc-engineering', jid: 'cone_slicc_engineering' };
+      const scratch = curatorScratchDir(cone.folder);
+      const doubled = `${scratch}-cone-slicc-engineering`;
+      expect(scratch).toBe('/scoops/agent-memory-curator-cone-slicc-engineering');
+      expect(doubled).toBe(
+        '/scoops/agent-memory-curator-cone-slicc-engineering-cone-slicc-engineering'
+      );
+
+      const memoryMd = `---\ntimeoutSeconds: 60\n---\nDraft in \`{{SCRATCH_DIR}}/draft.md\`, then write {{MEMORY_PATH}}.`;
+      const spawn = successSpawn();
+
+      await runAgenticMemoryPass({
+        spawn,
+        vfs: fakeVfs(memoryMd),
+        sessionArchivePath: ARCHIVE_PATH,
+        sessionCount: 1,
+        cone,
+      });
+
+      const prompt = spawn.mock.calls[0][0].prompt;
+      expect(prompt).toBe(`Draft in \`${scratch}/draft.md\`, then write ${DRAFT_PATH}.`);
+      expect(prompt).not.toContain(doubled);
     });
 
     it('rewrites a legacy MEMORY.md that spells the primary scratch folder out', async () => {


### PR DESCRIPTION
## Summary
- `substitutePlaceholders` expands `{{SCRATCH_DIR}}` to a per-cone path that already starts with the primary scratch prefix (`/scoops/agent-memory-curator-…`). The legacy `rebaseScratchMentions` shim then `replaceAll`’d that prefix again, producing doubled paths like `/scoops/agent-memory-curator-cone-slicc-engineering-cone-slicc-engineering`.
- Make the rebase idempotent: protect the already-substituted scratch dir before rewriting genuine legacy primary spellings.
- Add a regression test for the `{{SCRATCH_DIR}}` double-sub case (realistic cone folder) and keep coverage for legacy MEMORY.md that spells the primary path out.

## Test plan
- [x] Failing repro first: `does not double-substitute {{SCRATCH_DIR}} under an extra cone` received the doubled path before the fix
- [x] `npm test -- packages/webapp/tests/scoops/agentic-memory.test.ts` (37 passed), including legacy rewrite + own-scratch assertions
- [x] Full verify pass: `npm run verify`, touched-exemptions, typecheck, test (21134), test:coverage, both builds, bundle-size (first-load +0.0 kB)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)