### PR TITLE
fix(webapp): fail closed when write_file does not land

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -658,6 +658,13 @@ enforced by `patches/@zenfs+dom+*.patch`:
   mechanism behind the long-standing "phantom deletions" in `/workspace`
   (files a `git` checkout reports as deleted that will not go away).
 
+**`write_file` must not trust `writeFile` resolving alone.** The agent tool
+(`packages/webapp/src/tools/file-tools.ts`) stats the path and checks byte size
+after every write/edit before returning `File written:` / `File edited:`. A live
+instance observed `File written:` followed by `wc` reporting ENOENT on the same
+path — a success string that lies about durability breaks every memory design
+that depends on the file. Fail closed with `Write did not land: …` instead.
+
 **Concurrent reads are only as safe as the inode numbers.** ZenFS keys its
 vnode cache by `ino`, and every vnode owns a sparse data cache. Two paths whose
 inodes share an ino while both are open therefore share one vnode — and the

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -659,11 +659,16 @@ enforced by `patches/@zenfs+dom+*.patch`:
   (files a `git` checkout reports as deleted that will not go away).
 
 **`write_file` must not trust `writeFile` resolving alone.** The agent tool
-(`packages/webapp/src/tools/file-tools.ts`) stats the path and checks byte size
-after every write/edit before returning `File written:` / `File edited:`. A live
-instance observed `File written:` followed by `wc` reporting ENOENT on the same
-path — a success string that lies about durability breaks every memory design
-that depends on the file. Fail closed with `Write did not land: …` instead.
+(`packages/webapp/src/tools/file-tools.ts`) reads the path back and compares
+content after every write/edit before returning `File written:` / `File edited:`.
+Indexed `stat`/`size` is insufficient: ZenFS can answer from the in-memory index
+while OPFS has no file (`docs/pitfalls.md` above), and some backends report sizes
+that are not logical content length (AEM compressed listings; `/dev/null` is
+always size 0). A live instance observed `File written:` followed by `wc`
+reporting ENOENT on the same path — a success string that lies about durability
+breaks every memory design that depends on the file. Fail closed with
+`Write did not land: …` instead. Full readback is capped at 256 KiB (larger
+writes sample length + head/tail); sink devices skip readback by design.
 
 **Concurrent reads are only as safe as the inode numbers.** ZenFS keys its
 vnode cache by `ino`, and every vnode owns a sparse data cache. Two paths whose

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -261,12 +261,15 @@ Read file contents from the virtual filesystem (VirtualFS for cone, RestrictedFS
 **File**: `packages/webapp/src/tools/file-tools.ts`
 
 Write or create a file in the virtual filesystem. Creates parent directories automatically.
+After `writeFile` resolves, the tool **stats the path and checks the byte size** before
+returning success — a resolve alone is not treated as durable (avoids the live failure
+where `File written:` was followed by `wc` reporting ENOENT on the same path).
 
-| Property   | Value                               |
-| ---------- | ----------------------------------- |
-| **Name**   | `write_file`                        |
-| **Input**  | `{ path: string, content: string }` |
-| **Output** | `{ content: "File written" }`       |
+| Property   | Value                                                         |
+| ---------- | ------------------------------------------------------------- |
+| **Name**   | `write_file`                                                  |
+| **Input**  | `{ path: string, content: string }`                           |
+| **Output** | `{ content: "File written: <path>" }` or durability/`isError` |
 
 **Schema**:
 
@@ -280,6 +283,13 @@ Write or create a file in the virtual filesystem. Creates parent directories aut
   "required": ["path", "content"]
 }
 ```
+
+**Behavior**:
+
+- Success string is returned only when `stat` shows a file whose size matches the
+  UTF-8 byte length of `content`
+- Missing path, wrong entry kind, or size mismatch → `isError: true` with
+  `Write did not land: …` (never a bare `File written:` lie)
 
 ---
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -261,9 +261,12 @@ Read file contents from the virtual filesystem (VirtualFS for cone, RestrictedFS
 **File**: `packages/webapp/src/tools/file-tools.ts`
 
 Write or create a file in the virtual filesystem. Creates parent directories automatically.
-After `writeFile` resolves, the tool **stats the path and checks the byte size** before
+After `writeFile` resolves, the tool **reads the path back and compares content** before
 returning success — a resolve alone is not treated as durable (avoids the live failure
-where `File written:` was followed by `wc` reporting ENOENT on the same path).
+where `File written:` was followed by `wc` reporting ENOENT on the same path). Indexed
+`stat`/`size` is not used: ZenFS can answer metadata from an in-memory index while OPFS
+has no file, and some mounts report sizes that are not logical content length (AEM
+compressed listings; `/dev/null` always stats as 0).
 
 | Property   | Value                                                         |
 | ---------- | ------------------------------------------------------------- |
@@ -286,10 +289,11 @@ where `File written:` was followed by `wc` reporting ENOENT on the same path).
 
 **Behavior**:
 
-- Success string is returned only when `stat` shows a file whose size matches the
-  UTF-8 byte length of `content`
-- Missing path, wrong entry kind, or size mismatch → `isError: true` with
-  `Write did not land: …` (never a bare `File written:` lie)
+- Success string is returned only when a post-write `readTextFile` matches `content`
+  (full compare up to 256 KiB; larger payloads compare length + 4 KiB head/tail)
+- No-op sink devices (`/dev/null`) skip readback — the payload is discarded by design
+- Unreadable path or content mismatch → `isError: true` with `Write did not land: …`
+  (never a bare `File written:` lie)
 
 ---
 

--- a/packages/webapp/src/tools/file-tools.ts
+++ b/packages/webapp/src/tools/file-tools.ts
@@ -15,9 +15,23 @@ import {
 } from '@earendil-works/pi-coding-agent/dist/core/tools/truncate.js';
 import { createLogger } from '../base/logger.js';
 import type { VirtualFS } from '../fs/index.js';
+import { normalizePath } from '../fs/path-utils.js';
+import { isNoOpWriteDevicePath } from '../fs/virtual-device-paths.js';
 import type { ToolDefinition, ToolResult } from './types.js';
 
 const log = createLogger('tool:fs');
+
+/**
+ * Full content readback for durability checks at or below this UTF-16 length.
+ * Larger writes compare length + a head/tail sample instead of a second full
+ * copy — agent payloads are usually small; multi-MB writes should not double
+ * peak memory. Middle-of-file corruption on huge writes can slip past the
+ * sample (documented tradeoff).
+ */
+const VERIFY_FULL_READBACK_MAX_CHARS = 256 * 1024;
+
+/** Head/tail sample size for oversized durability checks. */
+const VERIFY_SAMPLE_CHARS = 4096;
 
 /**
  * Arguments for `read_file` — its `inputSchema` is the contract. Values arrive
@@ -57,30 +71,48 @@ export function createFileTools(fs: VirtualFS): ToolDefinition[] {
  * Confirm a write actually landed before telling the agent it succeeded.
  *
  * `writeFile` resolving is not enough: ZenFS/OPFS can update an in-memory index
- * (or a mount backend can ack) while a subsequent reader still sees ENOENT or a
- * truncated size — the live failure mode where `write_file` returned
- * `File written:` and an immediate `wc` on the same path reported "No such file
- * or directory". Fail closed with an error the agent can act on.
+ * (or a mount backend can ack) while a subsequent reader still sees ENOENT —
+ * the live failure mode where `write_file` returned `File written:` and an
+ * immediate `wc` on the same path reported "No such file or directory".
+ * Indexed `stat`/`size` cannot catch that split-brain (and is wrong for
+ * targets whose reported size is not logical content length — AEM compressed
+ * listings, `/dev/null`). Read the path back and compare readable content.
  *
- * @returns `null` when the path is a file of the expected byte length; otherwise
- * an error message suitable for `ToolResult.content`.
+ * No-op sink devices (`/dev/null`) discard the payload by design: once
+ * `writeFile` resolves, there is nothing durable to read — skip readback.
+ *
+ * @returns `null` when readable content matches (or the path is a sink);
+ * otherwise an error message suitable for `ToolResult.content`.
  */
 async function verifyWriteLanded(
   fs: VirtualFS,
   path: string,
   content: string
 ): Promise<string | null> {
-  const expectedBytes = new TextEncoder().encode(content).byteLength;
+  if (isNoOpWriteDevicePath(normalizePath(path))) {
+    return null;
+  }
   try {
-    const st = await fs.stat(path);
-    if (st.type !== 'file') {
-      return `Write did not land: ${path} is a ${st.type}, not a file`;
+    const readBack = await fs.readTextFile(path);
+    if (content.length <= VERIFY_FULL_READBACK_MAX_CHARS) {
+      if (readBack !== content) {
+        return (
+          `Write did not land: ${path} content mismatch ` +
+          `(expected ${content.length} chars, got ${readBack.length})`
+        );
+      }
+      return null;
     }
-    if (st.size !== expectedBytes) {
+    // Oversized: length + head/tail samples (see VERIFY_FULL_READBACK_MAX_CHARS).
+    if (readBack.length !== content.length) {
       return (
-        `Write did not land: ${path} size mismatch ` +
-        `(expected ${expectedBytes} bytes, got ${st.size})`
+        `Write did not land: ${path} content mismatch ` +
+        `(expected ${content.length} chars, got ${readBack.length})`
       );
+    }
+    const n = VERIFY_SAMPLE_CHARS;
+    if (readBack.slice(0, n) !== content.slice(0, n) || readBack.slice(-n) !== content.slice(-n)) {
+      return `Write did not land: ${path} content mismatch (head/tail sample)`;
     }
     return null;
   } catch (err) {

--- a/packages/webapp/src/tools/file-tools.ts
+++ b/packages/webapp/src/tools/file-tools.ts
@@ -54,6 +54,42 @@ export function createFileTools(fs: VirtualFS): ToolDefinition[] {
 }
 
 /**
+ * Confirm a write actually landed before telling the agent it succeeded.
+ *
+ * `writeFile` resolving is not enough: ZenFS/OPFS can update an in-memory index
+ * (or a mount backend can ack) while a subsequent reader still sees ENOENT or a
+ * truncated size — the live failure mode where `write_file` returned
+ * `File written:` and an immediate `wc` on the same path reported "No such file
+ * or directory". Fail closed with an error the agent can act on.
+ *
+ * @returns `null` when the path is a file of the expected byte length; otherwise
+ * an error message suitable for `ToolResult.content`.
+ */
+async function verifyWriteLanded(
+  fs: VirtualFS,
+  path: string,
+  content: string
+): Promise<string | null> {
+  const expectedBytes = new TextEncoder().encode(content).byteLength;
+  try {
+    const st = await fs.stat(path);
+    if (st.type !== 'file') {
+      return `Write did not land: ${path} is a ${st.type}, not a file`;
+    }
+    if (st.size !== expectedBytes) {
+      return (
+        `Write did not land: ${path} size mismatch ` +
+        `(expected ${expectedBytes} bytes, got ${st.size})`
+      );
+    }
+    return null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `Write did not land: ${path} is not readable (${message})`;
+  }
+}
+
+/**
  * Bound the read_file result to pi-coding-agent's own output-bounding contract
  * (`truncateHead` + `formatSize`) instead of returning whole files unbounded.
  * An unbounded read can dominate the whole context window and wedge compaction —
@@ -194,6 +230,11 @@ function createWriteFileTool(fs: VirtualFS): ToolDefinition {
 
       try {
         await fs.writeFile(path, content);
+        const durabilityError = await verifyWriteLanded(fs, path, content);
+        if (durabilityError) {
+          log.error('Write durability check failed', { path, error: durabilityError });
+          return { content: durabilityError, isError: true };
+        }
         return { content: `File written: ${path}` };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -252,6 +293,11 @@ function createEditFileTool(fs: VirtualFS): ToolDefinition {
 
         const newContent = content.replace(oldString, newString);
         await fs.writeFile(path, newContent);
+        const durabilityError = await verifyWriteLanded(fs, path, newContent);
+        if (durabilityError) {
+          log.error('Edit durability check failed', { path, error: durabilityError });
+          return { content: durabilityError, isError: true };
+        }
         return { content: `File edited: ${path}` };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/packages/webapp/tests/tools/file-tools.test.ts
+++ b/packages/webapp/tests/tools/file-tools.test.ts
@@ -7,7 +7,8 @@ import {
 } from '@earendil-works/pi-coding-agent/dist/core/tools/truncate.js';
 import 'fake-indexeddb/auto';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { VirtualFS } from '../../src/fs/index.js';
+import { RestrictedFS, VirtualFS } from '../../src/fs/index.js';
+import { DEV_NULL } from '../../src/fs/virtual-device-paths.js';
 import { createFileTools } from '../../src/tools/file-tools.js';
 import type { ToolDefinition } from '../../src/tools/types.js';
 
@@ -62,7 +63,25 @@ describe('File Tools', () => {
       expect(result.content).not.toContain('File written:');
     });
 
-    it('returns isError when writeFile resolves but size does not match', async () => {
+    it('returns isError when indexed stat looks fine but readback fails (OPFS split-brain)', async () => {
+      // ZenFS can answer stat from the in-memory index while OPFS has no file —
+      // the exact failure verifyWriteLanded must not trust metadata for.
+      const realWrite = fs.writeFile.bind(fs);
+      fs.writeFile = async (path: string, content: string | Uint8Array) => {
+        await realWrite(path, content);
+      };
+      fs.stat = async () => ({ type: 'file', size: 12, mtime: 0, ctime: 0 });
+      fs.readTextFile = async () => {
+        throw new Error("ENOENT: no such file or directory, open '/ghost.txt'");
+      };
+      const result = await writeFile.execute({ path: '/ghost.txt', content: 'never landed' });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/Write did not land/);
+      expect(result.content).toMatch(/not readable|ENOENT/);
+      expect(result.content).not.toContain('File written:');
+    });
+
+    it('returns isError when writeFile resolves but content does not match', async () => {
       const realWrite = fs.writeFile.bind(fs);
       fs.writeFile = async (path: string) => {
         // Land a truncated file — writeFile "succeeded" but content did not.
@@ -70,8 +89,24 @@ describe('File Tools', () => {
       };
       const result = await writeFile.execute({ path: '/trunc.txt', content: 'expected-full' });
       expect(result.isError).toBe(true);
-      expect(result.content).toMatch(/size mismatch/);
+      expect(result.content).toMatch(/content mismatch/);
       expect(result.content).not.toContain('File written:');
+    });
+
+    it('succeeds when stat size diverges from content length but readback matches', async () => {
+      // AEM Source Bus reports compressed listing size; /dev/null stats as 0.
+      // Durability must not require universal stat-size equality.
+      const realWrite = fs.writeFile.bind(fs);
+      const realRead = fs.readTextFile.bind(fs);
+      fs.writeFile = async (path: string, content: string | Uint8Array) => {
+        await realWrite(path, content);
+      };
+      fs.stat = async () => ({ type: 'file', size: 999999, mtime: 0, ctime: 0 });
+      fs.readTextFile = async (path: string) => realRead(path);
+      const result = await writeFile.execute({ path: '/aem-like.txt', content: 'payload' });
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toContain('File written:');
+      await expect(realRead('/aem-like.txt')).resolves.toBe('payload');
     });
 
     it('propagates writeFile failures without a success string', async () => {
@@ -82,6 +117,19 @@ describe('File Tools', () => {
       expect(result.isError).toBe(true);
       expect(result.content).toMatch(/EACCES|permission denied/);
       expect(result.content).not.toContain('File written:');
+    });
+
+    it('accepts nonempty writes to /dev/null without a false durability error', async () => {
+      const rfs = new RestrictedFS(fs, ['/workspace']);
+      const [nullWrite] = createFileTools(rfs as unknown as VirtualFS).filter(
+        (t) => t.name === 'write_file'
+      );
+      const result = await nullWrite.execute({
+        path: DEV_NULL,
+        content: 'discarded-but-accepted',
+      });
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toBe(`File written: ${DEV_NULL}`);
     });
   });
 

--- a/packages/webapp/tests/tools/file-tools.test.ts
+++ b/packages/webapp/tests/tools/file-tools.test.ts
@@ -40,11 +40,48 @@ describe('File Tools', () => {
       const result = await writeFile.execute({ path: '/hello.txt', content: 'Hello!' });
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('/hello.txt');
+      // Durability: the success string must mean a subsequent reader can see it.
+      await expect(fs.readTextFile('/hello.txt')).resolves.toBe('Hello!');
     });
 
     it('creates parent directories', async () => {
       const result = await writeFile.execute({ path: '/a/b/c.txt', content: 'deep' });
       expect(result.isError).toBeFalsy();
+      await expect(fs.readTextFile('/a/b/c.txt')).resolves.toBe('deep');
+    });
+
+    it('returns isError when writeFile resolves but the path is not readable', async () => {
+      // Repro of the live durability lie: write_file said "File written:" while
+      // an immediate follow-up on the same path saw ENOENT. Force that window
+      // by making writeFile a no-op success.
+      fs.writeFile = async () => {};
+      const result = await writeFile.execute({ path: '/phantom.txt', content: 'never landed' });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/Write did not land/);
+      expect(result.content).toContain('/phantom.txt');
+      expect(result.content).not.toContain('File written:');
+    });
+
+    it('returns isError when writeFile resolves but size does not match', async () => {
+      const realWrite = fs.writeFile.bind(fs);
+      fs.writeFile = async (path: string) => {
+        // Land a truncated file — writeFile "succeeded" but content did not.
+        await realWrite(path, 'x');
+      };
+      const result = await writeFile.execute({ path: '/trunc.txt', content: 'expected-full' });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/size mismatch/);
+      expect(result.content).not.toContain('File written:');
+    });
+
+    it('propagates writeFile failures without a success string', async () => {
+      fs.writeFile = async () => {
+        throw new Error('EACCES: permission denied, write /locked.txt');
+      };
+      const result = await writeFile.execute({ path: '/locked.txt', content: 'nope' });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/EACCES|permission denied/);
+      expect(result.content).not.toContain('File written:');
     });
   });
 
@@ -255,6 +292,25 @@ describe('File Tools', () => {
       });
       expect(result.isError).toBe(true);
       expect(result.content).toContain('2 times');
+    });
+
+    it('returns isError when the edit write resolves but the file vanishes', async () => {
+      await fs.writeFile('/edit-gone.txt', 'before');
+      const realWrite = fs.writeFile.bind(fs);
+      const realRm = fs.rm.bind(fs);
+      fs.writeFile = async (path: string, content: string | Uint8Array) => {
+        await realWrite(path, content);
+        await realRm(path);
+      };
+      const result = await editFile.execute({
+        path: '/edit-gone.txt',
+        old_string: 'before',
+        new_string: 'after',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/Write did not land/);
+      expect(result.content).toMatch(/not readable|ENOENT|no such file/i);
+      expect(result.content).not.toContain('File edited:');
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Root cause:** `write_file` / `edit_file` returned `File written:` / `File edited:` unconditionally after `fs.writeFile` resolved (`packages/webapp/src/tools/file-tools.ts`), with no check that the path was readable afterward. A live instance (memory-management report §2.7 / P0b) observed success followed by `wc` reporting ENOENT on the same path — a durability lie that undermines every memory/persistence design above the tool.
- **Fix:** After every write/edit, `verifyWriteLanded` stats the path and requires a file whose size matches the UTF-8 byte length of the written content. Missing path, wrong kind, or size mismatch → `isError: true` with `Write did not land: …` (never a bare success string).
- **Tests:** Vitest error-path coverage for no-op write (ENOENT), truncated write (size mismatch), thrown write errors, and edit-then-vanish; happy paths also assert a subsequent reader sees the content.

## Test plan
- [x] `npx vitest run packages/webapp/tests/tools/file-tools.test.ts`
- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension` + `npm run bundle-size`
- [ ] Smoke in a live cone: `write_file` a path then `bash: wc` on it; force a vanishing write (if reproable) and confirm `Write did not land` instead of `File written:`


Made with [Cursor](https://cursor.com)