### PR TITLE
refactor(webapp): use uint8ToBase64 in five shell command encoders

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts
+++ b/packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts
@@ -18,6 +18,7 @@
  * unchanged.
  */
 
+import { uint8ToBase64 } from '@slicc/shared-ts';
 import { isExtensionRealm } from '../../base/runtime-env.js';
 
 /** Camera / mic capture request forwarded to the popup. */
@@ -162,13 +163,10 @@ function newRequestId(): string {
 }
 
 function base64UrlEncode(s: string): string {
-  const bytes = new TextEncoder().encode(s);
-  let bin = '';
-  const chunk = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
-  }
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return uint8ToBase64(new TextEncoder().encode(s))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
 }
 
 function base64Decode(b64: string): Uint8Array {

--- a/packages/webapp/src/shell/supplemental-commands/open-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/open-command.ts
@@ -1,3 +1,4 @@
+import { uint8ToBase64 } from '@slicc/shared-ts';
 import type { Command, CommandContext, ExecResult } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { getPanelRpcClient, type PanelRpcClient } from '../../kernel/panel-rpc.js';
@@ -47,15 +48,6 @@ function openHelp(): { stdout: string; stderr: string; exitCode: number } {
     stderr: '',
     exitCode: 0,
   };
-}
-
-function toBase64(bytes: Uint8Array): string {
-  let binary = '';
-  const chunk = 8192;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-  }
-  return btoa(binary);
 }
 
 function parseSizeSpec(spec: string): { maxW: number; maxH: number } | null {
@@ -399,7 +391,7 @@ async function handleViewTarget(
     );
   }
 
-  const base64 = toBase64(resized.bytes);
+  const base64 = uint8ToBase64(resized.bytes);
   const outKb = Math.round(resized.bytes.byteLength / 1024);
   return okOutcome(
     `${path} (${resized.nativeWidth}x${resized.nativeHeight} → ` +

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts
@@ -7,6 +7,7 @@
  * Commands: route, route-list, unroute
  */
 
+import { uint8ToBase64 } from '@slicc/shared-ts';
 import { createLogger } from '../../../../base/logger.js';
 import { bindTabCapture, type TabCaptureBinding } from '../session-rebind.js';
 import { requireTab } from '../state.js';
@@ -25,13 +26,6 @@ const FETCH_PATTERNS = [{ urlPattern: '*', requestStage: 'Request' }];
 // Named via the handler context rather than imported from `cdp/` so this
 // module stays inside the shell layer (see layer-stack import direction).
 type BrowserAPI = PlaywrightHandlerCtx['browser'];
-
-function utf8ToBase64(str: string): string {
-  const bytes = new TextEncoder().encode(str);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
-  return btoa(binary);
-}
 
 /** Convert a glob-style URL pattern to a RegExp. */
 export function patternToRegex(pattern: string): RegExp {
@@ -86,7 +80,7 @@ async function handleRequestPaused(
         requestId,
         responseCode: match.status,
         responseHeaders,
-        body: match.body ? utf8ToBase64(match.body) : undefined,
+        body: match.body ? uint8ToBase64(new TextEncoder().encode(match.body)) : undefined,
       },
       sessionId
     )

--- a/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/screencapture-command.ts
@@ -1,3 +1,4 @@
+import { uint8ToBase64 } from '@slicc/shared-ts';
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { getPanelRpcClient, hasLocalDom } from '../../kernel/panel-rpc.js';
@@ -118,7 +119,7 @@ async function writeFileOutput(
 
   const sizeKB = Math.round(bytes.length / 1024);
   if (view) {
-    const base64 = toBase64(bytes);
+    const base64 = uint8ToBase64(bytes);
     return {
       stdout: `${fullPath} (${sizeKB} KB)\n<img:data:${mimeType};base64,${base64}>`,
       stderr: '',
@@ -154,15 +155,6 @@ Examples:
     stderr: '',
     exitCode: 0,
   };
-}
-
-function toBase64(bytes: Uint8Array): string {
-  let binary = '';
-  const chunk = 8192;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-  }
-  return btoa(binary);
 }
 
 function getMimeTypeForExtension(filename: string): string {

--- a/packages/webapp/src/shell/supplemental-commands/websocat-encoding.ts
+++ b/packages/webapp/src/shell/supplemental-commands/websocat-encoding.ts
@@ -1,3 +1,7 @@
+import { uint8ToBase64 } from '@slicc/shared-ts';
+
+export { uint8ToBase64 as bytesToBase64 };
+
 /** JSON-RPC 2.0 method call emitted from a stdin line (`--jsonrpc`). */
 interface JsonRpcMethodCall {
   id: number;
@@ -33,17 +37,11 @@ export function buildJsonRpc(line: string, id: number, omit: boolean): string {
   return JSON.stringify(payload);
 }
 
-export function bytesToBase64(bytes: Uint8Array): string {
-  let bin = '';
-  for (let i = 0; i < bytes.length; i += 1) bin += String.fromCharCode(bytes[i]);
-  return btoa(bin);
-}
-
 export function bytesToTextSafe(bytes: Uint8Array): string {
   try {
     return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
   } catch {
-    return bytesToBase64(bytes);
+    return uint8ToBase64(bytes);
   }
 }
 


### PR DESCRIPTION
Closes #2995

## Summary

Five shell commands under `packages/webapp/src/shell/supplemental-commands/` each hand-rolled a `Uint8Array` → base64 loop instead of calling `uint8ToBase64` from `@slicc/shared-ts`. Those copies had already drifted on chunk size (8192 vs `0x8000` vs unchunked) and none took the Node `Buffer` fast-path. This PR deletes the local loops and routes every encode through the shared codec the neighboring files already import.

## Why

`packages/shared-ts/src/base64.ts` exists specifically to replace the 13+ drifted copies inventoried in #1087. Prior #1749 covered `image-processor.ts` only. These five shell files were the leftover complicatification: identical `toBase64` helpers in `open` and `screencapture`, an unchunked `bytesToBase64` in websocat, an encode-then-loop `utf8ToBase64` in playwright routing, and a `0x8000`-chunked `base64UrlEncode` in extension media capture.

## Approach / Implementation notes

- `open-command.ts` and `screencapture-command.ts` — drop-in `uint8ToBase64(bytes)`.
- `websocat-encoding.ts` — `export { uint8ToBase64 as bytesToBase64 }` so `websocat-session.ts` keeps its existing import.
- `playwright/handlers/routing.ts` — `uint8ToBase64(new TextEncoder().encode(str))` at the single `Fetch.fulfillRequest` call site.
- `extension-media-capture.ts` — `uint8ToBase64` plus the existing URL-safe `.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')` chain.
- No sixth encoder. Decode in `extension-media-capture.ts` is untouched (out of scope).

## Cross-cutting impact

- **Floats exercised**: CLI (Node `Buffer` fast-path now used), Chrome extension / Electron / worker (chunked `btoa` path, 32 KiB). Same helper already used by `ssh`, `rsync`, playwright upload/mouse.
- **Shell contexts**: `open --view`, `screencapture -v`, `websocat --base64`, `playwright-cli route --body`, and the extension capture popup URL. Behavior is observationally identical for valid input; large payloads no longer risk an unchunked `fromCharCode` stack overflow in websocat/routing.
- **Other callers**: `bytesToBase64` re-export keeps `websocat-session.ts` and `bytesToTextSafe` compiling without a rename.
- **Bundle size**: first-load worker graph −0.5 kB vs merge-base; page graph unchanged.

## Test plan

- [x] `npm run verify` — all 8 lint-gate checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [x] `npx vitest run` on `open-command`, `screencapture-command`, `websocat-command`, `playwright/handlers/routing` — 102/102 passed
- [x] `npm run test` — 21151 passed, 1 flake in `cdp-worker-proxy.test.ts` (`Cannot connect: state is connected`); isolated re-run of that file 23/23 passed. Unrelated to this change.
- [x] `npm run test:coverage:webapp` — floors held (statements 83.85%, lines 85.81%)
- [x] `npm run build -w @slicc/webapp`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK (−0.5 kB worker vs merge-base)
- [x] No private `toBase64` unit test to retarget; existing command tests remain the contract
- [x] N/A — no UI change, no screencast

**Pre-existing failures**: one flake in `packages/webapp/tests/kernel/cdp-worker-proxy.test.ts` under full-suite load; green in isolation. Unrelated kernel reconnect test.

## Documentation

- [x] No documentation changes needed — internal codec consolidation, no user-facing command or skill change

## Risk & rollback

- Blast radius is the five encode call sites; decode and URL-safe wrapping are unchanged.
- Roll back: revert this PR.
- CI cannot catch a real `getDisplayMedia` / capture-popup round-trip; the URL-safe replace chain is identical to before.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (none)
- [x] Dual-mode: shared helper already used in CLI and extension neighbors