### PR TITLE
fix(webapp): space stacked sprinkle-action-cards in dips

### DIFF
--- a/packages/vfs-root/workspace/skills/dips/SKILL.md
+++ b/packages/vfs-root/workspace/skills/dips/SKILL.md
@@ -52,7 +52,7 @@ When the user clicks a button, you receive the lick as a message. Respond conver
 - **Tables** → `.sprinkle-table` with `.sprinkle-badge` for severity.
 - **Badges** → `.sprinkle-badge` variants (`--positive`, `--negative`, `--notice`, `--informative`).
 
-Multiple cards in one message: each is a separate `.sprinkle-action-card`. The iframe padding handles spacing. Don't wrap multiple cards in a single container.
+Multiple cards in one message: each is a separate `.sprinkle-action-card`. The host sheet zeros card margin and adds `margin-top: 12px` between adjacent cards — don't add your own card margins (a class like `.my-card { margin-top: 12px }` loses on specificity). Don't wrap multiple cards in a single container.
 
 ## Pre-styled form elements
 

--- a/packages/webapp/src/ui/dip.ts
+++ b/packages/webapp/src/ui/dip.ts
@@ -497,6 +497,8 @@ body{padding:12px 0;font-family:var(--s2-font-family, sans-serif);font-size:13px
 .sprinkle-inline .sprinkle-btn:not([class*="sprinkle-btn--"]){background:var(--s2-bg-elevated)}
 .sprinkle-inline .sprinkle-card{box-shadow:none;margin:0}
 .sprinkle-inline .sprinkle-action-card{margin:0;width:100%}
+/* Adjacent stacked cards: host owns the gap so dip-author margin cannot lose on specificity. */
+.sprinkle-inline .sprinkle-action-card+.sprinkle-action-card{margin-top:12px}
 .sprinkle-inline .sprinkle-action-card .sprinkle-table{width:100%}
 .sprinkle-inline .sprinkle-grid{width:100%}
 input[type="range"]{width:100%;height:4px;-webkit-appearance:none;appearance:none;background:var(--s2-gray-300);border-radius:2px;outline:none;cursor:default}

--- a/packages/webapp/tests/ui/dip.test.ts
+++ b/packages/webapp/tests/ui/dip.test.ts
@@ -658,3 +658,118 @@ describe('cherry iframe repaint workaround', () => {
     }
   });
 });
+
+describe('dip host action-card spacing', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function hostSheetFromSrcdoc(srcdoc: string): string {
+    const sheets = [...srcdoc.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((m) => m[1] ?? '');
+    const host = sheets.find((s) => s.includes('.sprinkle-inline .sprinkle-action-card'));
+    expect(host).toBeDefined();
+    return host ?? '';
+  }
+
+  function stackedCardFixture(hostCss: string, extraCss: string, html: string) {
+    const style = document.createElement('style');
+    style.textContent = `${hostCss}\n${extraCss}`;
+    document.head.appendChild(style);
+    const wrap = document.createElement('div');
+    wrap.style.width = '320px';
+    wrap.innerHTML = html;
+    document.body.appendChild(wrap);
+    return {
+      cards: [...wrap.querySelectorAll<HTMLElement>('.sprinkle-action-card')],
+      cleanup() {
+        style.remove();
+        wrap.remove();
+      },
+    };
+  }
+
+  it('injects a sibling gap in the host sheet while keeping the single-card reset', () => {
+    const inst = mountDip(container, '<div class="sprinkle-action-card">one</div>', vi.fn());
+    const host = hostSheetFromSrcdoc(container.querySelector('iframe')!.srcdoc);
+    expect(host).toMatch(/\.sprinkle-inline \.sprinkle-action-card\{margin:0;width:100%\}/);
+    expect(host).toMatch(
+      /\.sprinkle-inline \.sprinkle-action-card\s*\+\s*\.sprinkle-action-card\{margin-top:12px\}/
+    );
+    inst.dispose();
+  });
+
+  it('keeps a single card full-width with no extra top margin on the first card', () => {
+    const inst = mountDip(container, '<div class="sprinkle-action-card">one</div>', vi.fn());
+    const host = hostSheetFromSrcdoc(container.querySelector('iframe')!.srcdoc);
+    const { cards, cleanup } = stackedCardFixture(
+      host,
+      '',
+      '<div class="sprinkle-inline"><div class="sprinkle-action-card">one</div></div>'
+    );
+    try {
+      expect(cards).toHaveLength(1);
+      expect(getComputedStyle(cards[0]!).marginTop).toBe('0px');
+      expect(getComputedStyle(cards[0]!).width).toBe('100%');
+    } finally {
+      cleanup();
+      inst.dispose();
+    }
+  });
+
+  it('shows a non-zero gap between stacked action cards', () => {
+    const inst = mountDip(
+      container,
+      '<div class="sprinkle-action-card">a</div><div class="sprinkle-action-card">b</div><div class="sprinkle-action-card">c</div>',
+      vi.fn()
+    );
+    const host = hostSheetFromSrcdoc(container.querySelector('iframe')!.srcdoc);
+    const { cards, cleanup } = stackedCardFixture(
+      host,
+      '',
+      `<div class="sprinkle-inline">
+        <div class="sprinkle-action-card">a</div>
+        <div class="sprinkle-action-card">b</div>
+        <div class="sprinkle-action-card">c</div>
+      </div>`
+    );
+    try {
+      expect(cards).toHaveLength(3);
+      expect(getComputedStyle(cards[0]!).marginTop).toBe('0px');
+      expect(getComputedStyle(cards[1]!).marginTop).toBe('12px');
+      expect(getComputedStyle(cards[2]!).marginTop).toBe('12px');
+      for (const card of cards) {
+        expect(getComputedStyle(card).width).toBe('100%');
+      }
+    } finally {
+      cleanup();
+      inst.dispose();
+    }
+  });
+
+  it('host sibling gap outranks an authored card class margin-top', () => {
+    const inst = mountDip(container, '<div class="sprinkle-action-card">one</div>', vi.fn());
+    const host = hostSheetFromSrcdoc(container.querySelector('iframe')!.srcdoc);
+    const { cards, cleanup } = stackedCardFixture(
+      host,
+      '.my-card{margin-top:12px}',
+      `<div class="sprinkle-inline">
+        <div class="sprinkle-action-card my-card">a</div>
+        <div class="sprinkle-action-card my-card">b</div>
+      </div>`
+    );
+    try {
+      expect(getComputedStyle(cards[0]!).marginTop).toBe('0px');
+      expect(getComputedStyle(cards[1]!).marginTop).toBe('12px');
+    } finally {
+      cleanup();
+      inst.dispose();
+    }
+  });
+});


### PR DESCRIPTION
Closes #3031

## Summary

Stacked `.sprinkle-action-card`s inside a dip rendered with no gap: the host sheet zeroed `margin` at a specificity that beat any class a dip author added. Adjacent cards now get a 12px top gap from the host sheet; a single card stays full-width with no extra top margin.

## Why

**Repro**
1. Render a dip whose body is two sibling `.sprinkle-action-card`s (gelatiere welcome stream is the live example; any stacked-card dip reproduces it).
2. Observe the cards.

Expected: a visible gap between cards.
Actual: they touch edge to edge. `.sprinkle-inline .sprinkle-action-card { margin: 0 }` outranks `.my-card { margin-top: 12px }`.

The dips skill previously claimed iframe padding handled spacing. Body padding is around the dip as a whole, not between sibling cards.

Does not steal gelatiere PR #3005 — that workaround can drop after this host fix lands. Does not touch #3035.

## Approach / Implementation notes

- Host sheet (`DIP_HOST_STYLES` in `packages/webapp/src/ui/dip.ts`) keeps `.sprinkle-inline .sprinkle-action-card { margin: 0; width: 100% }` for the single-card case.
- Adds `.sprinkle-inline .sprinkle-action-card + .sprinkle-action-card { margin-top: 12px }` (higher specificity than the reset and than an authored class).
- `sprinkle-components.css` does not zero action-card margin, so no dual copy.
- Updates `packages/vfs-root/workspace/skills/dips/SKILL.md` so authors do not fight host specificity.

## Cross-cutting impact

- **Floats exercised**: CLI / Chrome extension / Electron / hosted — same `dip.ts` host sheet is injected into every dip iframe. No follower-specific path.
- **Shell contexts**: none.
- **Other callers**: `DIP_HOST_STYLES` is injected by `buildDipSrcdoc` for both trusted and untrusted dips, final and draft.
- **Persisted state**: none.
- **Security**: CSS-only; no sandbox / innerHTML change.

## Test plan

- [x] Host CSS contains the sibling gap; single-card reset (`margin: 0; width: 100%`) is unchanged
- [x] Stacked-card fixture: first card `margin-top: 0px`, later cards `12px`, all `width: 100%`
- [x] Authored `.my-card { margin-top: 12px }` still loses on the first card; sibling gap still applies
- [x] `npm run verify` (lint gate)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 21242 passed, 53 skipped
- [x] `npm run test:coverage`
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load +0.0 kB vs merge-base

**Pre-existing failures**: none on this change.

## Documentation

- [x] `packages/vfs-root/workspace/skills/dips/SKILL.md` (agent-facing spacing contract)
- [ ] README / CLAUDE.md / docs/ — N/A (internal host CSS; skill is the author-facing contract)

## Risk & rollback

- Blast radius: all dips that stack sibling `.sprinkle-action-card`s. Single-card dips unchanged.
- No feature flag. Revert this PR to roll back.
- jsdom computed-style fixture covers the gap; a live SLICC session with a multi-card dip was not driven in a browser for this PR.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets
- [x] Dual-mode: same host sheet in CLI and extension
- [x] Linear history; rebased onto `origin/main`