### PR TITLE
test(webapp): harden session-freezer filename collision flake

### DIFF
--- a/packages/webapp/tests/transcript/frozen-archive-writer.test.ts
+++ b/packages/webapp/tests/transcript/frozen-archive-writer.test.ts
@@ -3,7 +3,7 @@
  * compaction snapshot, so its document must round-trip through the reader
  * and its index primitives must be safe to call from either realm.
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { FsError } from '../../src/fs/types.js';
 import type { ChatMessage } from '../../src/scoops/chat-types.js';
 import {
@@ -22,6 +22,7 @@ import {
   readSessionsIndexForWrite,
   rewriteTranscriptPointers,
   serializeIndexWrite,
+  shortId,
   slugify,
   stripEphemeral,
   upsertSessionsIndexEntry,
@@ -257,5 +258,26 @@ describe('index primitives', () => {
     await expect(first).rejects.toThrow('boom');
     expect(await second).toBe('ok');
     expect(order).toEqual(['first', 'second']);
+  });
+});
+
+describe('shortId', () => {
+  it('stays unique across two clocks even when Math.random is frozen', () => {
+    // Production ids pair Date.now() with 4 random chars. Same-millisecond
+    // callers can collide on the random suffix (Node 25 CI on #3055 collapsed
+    // two pending-*.md rows). Distinct clocks must never collide, even with
+    // a deterministic RNG — the contract the freezer concurrency tests rely on.
+    const rand = vi.spyOn(Math, 'random').mockReturnValue(0.123456789);
+    const now = vi.spyOn(Date, 'now');
+    try {
+      now.mockReturnValue(Date.UTC(2026, 4, 13, 19, 0, 10));
+      const a = shortId();
+      now.mockReturnValue(Date.UTC(2026, 4, 13, 19, 0, 20));
+      const b = shortId();
+      expect(a).not.toBe(b);
+    } finally {
+      rand.mockRestore();
+      now.mockRestore();
+    }
   });
 });

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -3124,6 +3124,13 @@ describe('markSnapshotUnavailable — serialized inside indexWriteChain', () => 
     // Both markSnapshotUnavailable and freezeConeSession write to the same
     // index file via indexWriteChain. Running them concurrently must still
     // produce exactly two entries (one per session) — not a clobbered index.
+    //
+    // Quick-mode filenames are `pending-${shortId()}.md`, and shortId() is
+    // base-36 Date.now() plus 4 random chars. Two freezes in the same
+    // millisecond can collide on the random suffix (Node 25 CI on #3055);
+    // upsert is keyed on filename, so a collision collapses the index to
+    // one row. Pin distinct clocks so this test asserts the mutex, not
+    // shortId uniqueness — same guard as "serializes concurrent enrichments".
     const vfs1 = makeFakeVfs();
     const store1 = makeFakeStore({
       id: 'session-1',
@@ -3138,12 +3145,23 @@ describe('markSnapshotUnavailable — serialized inside indexWriteChain', () => 
       updatedAt: 3,
     });
 
+    const freezeQuickAt = async (store: SessionStore, utcSecond: number) => {
+      const dateSpy = vi
+        .spyOn(Date, 'now')
+        .mockReturnValue(Date.UTC(2026, 4, 13, 19, 0, utcSecond));
+      try {
+        return await freezeConeSession({
+          sessionStore: store,
+          vfs: vfs1 as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+          mode: 'quick',
+        });
+      } finally {
+        dateSpy.mockRestore();
+      }
+    };
+
     // Freeze first session to get a filename to mark.
-    const frozen1 = await freezeConeSession({
-      sessionStore: store1,
-      vfs: vfs1 as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
-      mode: 'quick',
-    });
+    const frozen1 = await freezeQuickAt(store1, 10);
     expect(frozen1).not.toBeNull();
 
     // Race: mark session-1 and freeze session-2 concurrently.
@@ -3152,13 +3170,11 @@ describe('markSnapshotUnavailable — serialized inside indexWriteChain', () => 
       vfs1 as unknown as Parameters<typeof markSnapshotUnavailable>[0],
       frozen1!.filename
     );
-    const freezePromise = freezeConeSession({
-      sessionStore: store2,
-      vfs: vfs1 as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
-      mode: 'quick',
-    });
+    const freezePromise = freezeQuickAt(store2, 20);
 
-    await Promise.all([markPromise, freezePromise]);
+    const [, frozen2] = await Promise.all([markPromise, freezePromise]);
+    expect(frozen2).not.toBeNull();
+    expect(frozen2!.filename).not.toBe(frozen1!.filename);
 
     const index = await readSessionsIndex(
       vfs1 as unknown as Parameters<typeof readSessionsIndex>[0]


### PR DESCRIPTION
Follow-up to #3055.

## Summary

Node 25 CI on #3055 failed in `concurrent mark + freeze produce no duplicate entries` because two quick-mode freezes in the same millisecond can share a `pending-<shortId()>.md` filename. `upsertSessionsIndexEntry` is keyed on filename, so the collision collapses the index to one row (`expected length 2, got 1`).

This PR pins distinct `Date.now` values on each freeze — the same guard the sibling `serializes concurrent enrichments` test already uses — so the test asserts the index mutex, not `shortId` uniqueness.

## Why

From [the #3055 comment](https://github.com/ai-ecoverse/slicc/pull/3055#issuecomment-5633920472): `shortId()` is base-36 `Date.now()` plus 4 random chars. Same-millisecond freezes only differ on the random suffix; a deterministic shard can collide. Reproduced there by freezing the clock and `Math.random`.

The lucide bump itself was unrelated and is already in the merge queue, so this is a test-only follow-up.

## Approach / Implementation notes

- Pin `Date.now` per freeze in the concurrent mark+freeze test (utcSecond 10 vs 20), restore the spy in `finally`.
- Assert the two pending filenames differ before checking index length.
- Add a `shortId` unit test that distinct clocks never collide even with frozen `Math.random`.

No production `shortId` change — the helper is still unique-enough for live traffic; the flake is a same-tick test collision.

## Cross-cutting impact

- **Floats exercised**: none (test-only)
- **Other callers**: `shortId()` still used by quick-mode freezer and live snapshot filenames; production behavior unchanged

## Test plan

- [x] `npx biome check --write` on the two test files
- [x] `npm run verify`
- [x] `npm run typecheck`
- [x] `npx vitest run --project webapp packages/webapp/tests/ui/session-freezer.test.ts packages/webapp/tests/transcript/frozen-archive-writer.test.ts` — 96 passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] N/A for UI / screenshots / coverage floors (test-only)

## Documentation

- [x] No documentation changes needed

## Risk & rollback

Test-only. Revert this PR if the spies leak across tests (they restore in `finally`).

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff