### PR TITLE
docs(shell-reference): complete builtin-shadow-map table with pdftoppm + ffprobe

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -529,18 +529,20 @@ normal behavior.
 `packages/webapp/src/shell/supplemental-commands/builtin-shadow-map.ts` is authoritative. It
 currently maps exactly these npm package names:
 
-| npm package names                                       | SLICC built-in   |
-| ------------------------------------------------------- | ---------------- |
-| `@biomejs/biome`, `biome`                               | `biome`          |
-| `esbuild`                                               | `esbuild`        |
-| `playwright`, `@playwright/test`, `playwright-core`     | `playwright-cli` |
-| `puppeteer`, `puppeteer-core`                           | `puppeteer`      |
-| `typescript`                                            | `tsc`            |
-| `imagemagick`, `imagemagick-cli`, `imagemagick-convert` | `convert`        |
-| `magick-cli`, `@imagemagick/magick-wasm`                | `magick`         |
-| `ffmpeg`, `@ffmpeg/ffmpeg`                              | `ffmpeg`         |
-| `sqlite3`                                               | `sqlite3`        |
-| `v86`                                                   | `v86`            |
+| npm package names                                                                     | SLICC built-in   |
+| ------------------------------------------------------------------------------------- | ---------------- |
+| `@biomejs/biome`, `biome`                                                             | `biome`          |
+| `esbuild`                                                                             | `esbuild`        |
+| `playwright`, `@playwright/test`, `playwright-core`                                   | `playwright-cli` |
+| `puppeteer`, `puppeteer-core`                                                         | `puppeteer`      |
+| `typescript`                                                                          | `tsc`            |
+| `pdf-poppler`, `pdf-to-img`, `pdf2pic`, `pdf-img-convert`, `poppler`, `poppler-utils` | `pdftoppm`       |
+| `imagemagick`, `imagemagick-cli`, `imagemagick-convert`                               | `convert`        |
+| `magick-cli`, `@imagemagick/magick-wasm`                                              | `magick`         |
+| `ffmpeg`, `@ffmpeg/ffmpeg`                                                            | `ffmpeg`         |
+| `ffprobe`, `@ffprobe-installer/ffprobe`                                               | `ffprobe`        |
+| `sqlite3`                                                                             | `sqlite3`        |
+| `v86`                                                                                 | `v86`            |
 
 ### `npm run` / `ipk run` script running
 

--- a/packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { INSTALL_PACKAGES } from '../../../src/shell/supplemental-commands/biome-command.js';
 import {
@@ -61,5 +64,41 @@ describe('formatBuiltinShadowHint', () => {
     expect(hint).toMatch(/^ipx:/);
     expect(hint).toContain(`try: ${shadow.example}`);
     expect(hint).not.toContain('first run:');
+  });
+});
+
+describe('docs/shell-reference.md builtin-shadow-map table', () => {
+  // The doc names builtin-shadow-map.ts as authoritative and claims to list
+  // "exactly" these package names. Guard against drift so the two never diverge.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const doc = readFileSync(
+    join(here, '..', '..', '..', '..', '..', 'docs', 'shell-reference.md'),
+    'utf8'
+  );
+
+  // Collect every backtick-wrapped npm package name from the shadow-map table
+  // (left column) — the rows between the "npm package names" header and the
+  // first blank line that follows it.
+  const tableStart = doc.indexOf('| npm package names');
+  const tableSection = doc.slice(tableStart, doc.indexOf('\n\n', tableStart));
+  const documentedPackages = new Set<string>();
+  for (const row of tableSection.split('\n')) {
+    if (!row.startsWith('|') || row.includes('---') || row.includes('npm package names')) {
+      continue;
+    }
+    const [leftCell] = row.slice(1).split('|');
+    for (const match of leftCell.matchAll(/`([^`]+)`/g)) {
+      documentedPackages.add(match[1]);
+    }
+  }
+
+  it('locates the shadow-map table in the doc', () => {
+    expect(tableStart).toBeGreaterThan(-1);
+    expect(documentedPackages.size).toBeGreaterThan(0);
+  });
+
+  it('documents exactly the package names the code maps', () => {
+    const mapped = Object.keys(BUILTIN_SHADOW_MAP).sort();
+    expect([...documentedPackages].sort()).toEqual(mapped);
   });
 });


### PR DESCRIPTION
Closes #3054

## What

`docs/shell-reference.md` names `builtin-shadow-map.ts` as authoritative and
claims to map **exactly** the listed npm package names, but the table omitted
two whole built-ins and eight package keys:

- `pdftoppm` — mapped from `pdf-poppler`, `pdf-to-img`, `pdf2pic`,
  `pdf-img-convert`, `poppler`, `poppler-utils`
- `ffprobe` — mapped from `ffprobe`, `@ffprobe-installer/ffprobe`

A reader consulting the reference to decide whether `npx poppler` or
`npx ffprobe` redirects to a SLICC built-in would wrongly conclude they don't,
because the table declared the enumeration complete.

## Changed

- Added the missing `pdftoppm` and `ffprobe` rows to the table in
  `docs/shell-reference.md` (in source-map order). Prettier realigned the
  table column widths on commit.
- Added a drift-guard test in
  `packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts`
  that parses the doc table's left column and asserts it equals
  `Object.keys(BUILTIN_SHADOW_MAP)` exactly, so the doc and the code can never
  silently diverge again.

## Verified

- `npx biome check --write` on the touched files — clean
- `npm run typecheck` — pass
- `npx vitest run builtin-shadow-map.test.ts` — 8/8 pass
- `npm run verify` (lint + boy-scout debt + prettier + autofix-drift) — all 8 checks pass
- `npm run lint:docs` — no dead references, size budgets ok
